### PR TITLE
fix: page.text now returns clean text without JS/CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **page.text** - Now returns clean text content without JavaScript and CSS. Changed from `textContent` to `innerText` which properly excludes script/style tag content.
+
 ## [2.5.0] - 2026-01-23
 
 ### Added

--- a/src/content/accessibility-tree.ts
+++ b/src/content/accessibility-tree.ts
@@ -1274,7 +1274,7 @@ function getPageText(): { text: string; title: string; url: string; error?: stri
     const main = document.querySelector("main");
     const content = article || main || document.body;
 
-    const text = content.textContent
+    const text = (content as HTMLElement).innerText
       ?.replace(/\s+/g, " ")
       .trim()
       .substring(0, 50000) || "";


### PR DESCRIPTION
## Summary

- Changes `textContent` to `innerText` in `getPageText()` function
- `innerText` excludes content from `<script>` and `<style>` tags, while `textContent` returns everything including JS/CSS code

## Files Changed

- `src/content/accessibility-tree.ts` - one line change at line 1277
- `CHANGELOG.md` - added fix note