### PR TITLE
fix: scroll command issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **scroll command** - Fixed three issues with scroll commands:
+  - `scroll down` now works (was silently ignoring positional direction argument)
+  - CDP mouseWheel scrolling now works reliably (added mouseMoved before mouseWheel)
+  - `scroll.info` now correctly reports window scroll position when no selector provided
+- **scroll --amount** - Fixed `--amount` flag not being passed through to scroll handler
+- **scroll docs** - Fixed incorrect SKILL.md examples (`scroll.to --y`, `scroll.by --y` never existed)
+
 ## [2.5.0] - 2026-01-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ surf click 100 200                  # Click by coordinates
 surf type "hello" --submit          # Type and press Enter
 surf type "email@example.com" --ref e12  # Type into specific element
 surf key Escape                     # Press key
+surf scroll down                    # Scroll down
+surf scroll down --amount 5         # Scroll down more
 surf scroll.bottom                  # Scroll to bottom
 ```
 

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -530,9 +530,9 @@ const TOOLS = {
     commands: {
       "scroll": { 
         desc: "Scroll in direction", 
-        args: [], 
-        opts: { direction: "up|down|left|right", amount: "Scroll amount (1-10)" },
-        examples: [{ cmd: "scroll --direction down --amount 3", desc: "Scroll down" }]
+        args: ["direction"], 
+        opts: { amount: "Scroll amount (1-10)" },
+        examples: [{ cmd: "scroll down --amount 3", desc: "Scroll down" }]
       },
       "scroll.top": { desc: "Scroll to top of page", args: [], opts: { selector: "Target specific container" } },
       "scroll.bottom": { desc: "Scroll to bottom of page", args: [], opts: { selector: "Target specific container" } },
@@ -2525,6 +2525,7 @@ const PRIMARY_ARG_MAP = {
   "frame.js": "code",
   "element.styles": "selector",
   "select": "selector",
+  scroll: "direction",
 };
 
 const toolArgs = { ...options };

--- a/native/host-helpers.cjs
+++ b/native/host-helpers.cjs
@@ -416,7 +416,7 @@ function formatToolContent(result, log = () => {}) {
  */
 function mapComputerAction(args, tabId) {
   const a = args || {};
-  const { action, text, scroll_direction, scroll_amount, 
+  const { action, text, direction, amount,
           start_coordinate, ref, duration, modifiers } = a;
   const coordinate = a.coordinate || (a.x !== undefined && a.y !== undefined ? [a.x, a.y] : undefined);
   const baseMsg = { tabId };
@@ -474,14 +474,14 @@ function mapComputerAction(args, tabId) {
       return { type: "FIND_AND_TYPE", text, submit: a.submit ?? false, submitKey: a.submitKey || "Enter", ...baseMsg };
     
     case "scroll": {
-      const amount = (scroll_amount || 3) * 100;
+      const scrollAmount = (amount || 3) * 100;
       const deltas = {
-        up: { deltaX: 0, deltaY: -amount },
-        down: { deltaX: 0, deltaY: amount },
-        left: { deltaX: -amount, deltaY: 0 },
-        right: { deltaX: amount, deltaY: 0 },
+        up: { deltaX: 0, deltaY: -scrollAmount },
+        down: { deltaX: 0, deltaY: scrollAmount },
+        left: { deltaX: -scrollAmount, deltaY: 0 },
+        right: { deltaX: scrollAmount, deltaY: 0 },
       };
-      const { deltaX, deltaY } = deltas[scroll_direction] || { deltaX: 0, deltaY: 0 };
+      const { deltaX, deltaY } = deltas[direction] || { deltaX: 0, deltaY: 0 };
       return { type: "EXECUTE_SCROLL", deltaX, deltaY, x: coordinate?.[0], y: coordinate?.[1], ...baseMsg };
     }
     

--- a/native/host.cjs
+++ b/native/host.cjs
@@ -1078,7 +1078,7 @@ function mapBatchActionToArgs(action) {
     case "wait":
       return { duration: (action.ms || 1000) / 1000 };
     case "scroll":
-      return { scroll_direction: action.direction };
+      return { direction: action.direction, amount: action.amount };
     case "screenshot":
       return { savePath: action.output };
     case "navigate":

--- a/skills/surf/SKILL.md
+++ b/skills/surf/SKILL.md
@@ -163,10 +163,12 @@ surf page.state                # Modals, loading state, scroll info
 ## Scrolling
 
 ```bash
-surf scroll.bottom
-surf scroll.top  
-surf scroll.to --y 500         # Scroll to Y position
-surf scroll.by --y 200         # Scroll by amount
+surf scroll down               # Scroll down (default amount)
+surf scroll up                 # Scroll up
+surf scroll down --amount 5    # Scroll down more (1-10)
+surf scroll.bottom             # Scroll to bottom of page
+surf scroll.top                # Scroll to top of page
+surf scroll.to --ref e5        # Scroll element into view
 surf scroll.info               # Get scroll position
 ```
 

--- a/src/cdp/controller.ts
+++ b/src/cdp/controller.ts
@@ -1321,6 +1321,9 @@ export class CDPController {
   }
 
   async scroll(tabId: number, x: number, y: number, deltaX: number, deltaY: number): Promise<void> {
+    // Move mouse to position first (required for wheel events to target correctly)
+    await this.dispatchMouseEvent(tabId, "mouseMoved", x, y, { button: "none", buttons: 0 });
+    await new Promise(resolve => setTimeout(resolve, 50));
     await this.dispatchMouseEvent(tabId, "mouseWheel", x, y, { deltaX, deltaY });
   }
 

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -732,20 +732,22 @@ export async function handleMessage(
       const deltaX = message.deltaX || 0;
       const deltaY = message.deltaY || 0;
       
+      // Try CDP scroll first (now with mouseMoved positioning)
       try {
         const viewport = await cdp.getViewportSize(tabId);
         const x = message.x ?? viewport.width / 2;
         const y = message.y ?? viewport.height / 2;
         await cdp.scroll(tabId, x, y, deltaX, deltaY);
       } catch {
+        // Fallback to JS for restricted pages
         try {
-          const scrollFallback = (dx: number, dy: number) => {
+          const scrollFn = (dx: number, dy: number) => {
             window.scrollBy(dx, dy);
             return { scrollX: window.scrollX, scrollY: window.scrollY };
           };
           await chrome.scripting.executeScript({
             target: { tabId },
-            func: scrollFallback,
+            func: scrollFn,
             args: [deltaX, deltaY],
           });
         } catch {
@@ -950,15 +952,25 @@ export async function handleMessage(
       const selector = message.selector;
       
       const scrollInfoScript = (sel: string | null) => {
-        const findScrollable = (): Element => {
-          const candidates = [...document.querySelectorAll("*")].filter(el => 
-            el.scrollHeight > el.clientHeight && el.clientHeight > 200
-          ).sort((a,b) => b.scrollHeight - a.scrollHeight);
-          return candidates[0] || document.documentElement;
-        };
+        // When no selector provided, measure window scroll (consistent with scroll command)
+        if (!sel) {
+          const scrollTop = window.scrollY || document.documentElement.scrollTop || 0;
+          const scrollHeight = document.documentElement.scrollHeight;
+          const clientHeight = window.innerHeight;
+          const maxScroll = scrollHeight - clientHeight;
+          return {
+            scrollTop,
+            scrollHeight,
+            clientHeight,
+            atBottom: scrollTop + clientHeight >= scrollHeight - 10,
+            atTop: scrollTop < 10,
+            scrollPercentage: maxScroll > 0 ? Math.round((scrollTop / maxScroll) * 100) : 100
+          };
+        }
         
-        const container = sel ? document.querySelector(sel) || findScrollable() : findScrollable();
-        if (!container) return { error: "No scrollable container found" };
+        // For specific selector, find the element
+        const container = document.querySelector(sel);
+        if (!container) return { error: `Element not found: ${sel}` };
         
         const maxScroll = container.scrollHeight - container.clientHeight;
         return { 


### PR DESCRIPTION
With these changes I'm able to scroll and get scroll information consistently.

## Summary
- Fix CDP mouseWheel not scrolling by adding mouseMoved before wheel event
- Fix scroll.info measuring wrong element by using window.scrollY directly
- Fix scroll ignoring positional direction arg (now accepts `scroll down`)
- Fix --amount flag not being passed through to scroll handler
- Fix incorrect SKILL.md examples (`scroll.to --y`, `scroll.by --y` never existed)

## Changes
- `src/cdp/controller.ts` - Add mouseMoved before mouseWheel event
- `src/service-worker/index.ts` - Use window.scrollY directly when no selector
- `native/cli.cjs` - Add `scroll: "direction"` to PRIMARY_ARG_MAP
- `native/host-helpers.cjs`, `native/host.cjs` - Change scroll_direction/scroll_amount to direction/amount
- `CHANGELOG.md`, `README.md`, `skills/surf/SKILL.md` - Update docs