### PR TITLE
chore: include skills directory in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "native/",
     "scripts/",
     "dist/",
+    "skills/",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
Adds the `skills/` directory to the `files` array in package.json so that the skills are included when the package is published to npm.

Currently, the skills directory exists in the repository but is not included in the published npm package. This change ensures users who install surf-cli via npm will have access to the skills documentation.

**Changes:**
- Added `skills/` to the `files` array in package.json

**Testing:**
Can be verified with `npm pack --dry-run` to confirm skills/ is included in the package.