### PR TITLE
feat: add env var overrides for package manager installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ surf install <extension-id> --browser all      # All supported browsers
 
 Supported: `chrome`, `chromium`, `brave`, `edge`, `arc`
 
+**Package Manager Installs (Nix, Homebrew, etc.)**
+If surf is installed via a package manager that stores binaries in non-standard locations, set these environment variables before running `surf install`:
+```bash
+export SURF_NODE_PATH=/path/to/node
+export SURF_HOST_PATH=/path/to/native/host.cjs
+export SURF_EXTENSION_PATH=/path/to/extension/dist
+```
+See [Environment Variables](#environment-variables) for details.
+
 ### Uninstall
 
 ```bash
@@ -509,6 +518,26 @@ surf workflow.validate ./my-workflow.json
 --no-screenshot    # Skip auto-screenshot after actions
 --full             # Full resolution screenshots (skip resize)
 --network-path <path>  # Custom path for network logs (default: /tmp/surf, or SURF_NETWORK_PATH env)
+```
+
+## Environment Variables
+
+```bash
+SURF_NETWORK_PATH         # Path for network capture logs (default: /tmp/surf)
+SURF_NODE_PATH            # Path to node binary (for native host wrapper)
+SURF_HOST_PATH            # Path to native/host.cjs (for native host wrapper)
+SURF_EXTENSION_PATH       # Path to extension dist/ directory
+```
+
+**Use cases:**
+- `SURF_NODE_PATH` / `SURF_HOST_PATH`: Package manager installs (e.g., Nix) that store binaries in non-standard locations
+- `SURF_EXTENSION_PATH`: Package managers that create stable symlinks instead of changing paths on reinstall
+
+**Example (Nix):**
+```bash
+export SURF_NODE_PATH=~/.local/share/surf-cli/node
+export SURF_HOST_PATH=~/.local/share/surf-cli/native/host.cjs
+export SURF_EXTENSION_PATH=~/.local/share/surf-cli/extension
 ```
 
 ## Socket API

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -1752,8 +1752,7 @@ if (args[0] === "server") {
 }
 
 if (args[0] === "extension-path" || args[0] === "path") {
-  const path = require("path");
-  const distPath = path.resolve(__dirname, "../dist");
+  const distPath = process.env.SURF_EXTENSION_PATH || path.resolve(__dirname, "../dist");
   console.log(distPath);
   process.exit(0);
 }

--- a/scripts/install-native-host.cjs
+++ b/scripts/install-native-host.cjs
@@ -58,6 +58,9 @@ const NODE_PATHS = {
 };
 
 function findNode() {
+  if (process.env.SURF_NODE_PATH && fs.existsSync(process.env.SURF_NODE_PATH)) {
+    return process.env.SURF_NODE_PATH;
+  }
   const platform = process.platform;
   const paths = NODE_PATHS[platform] || [];
   for (const p of paths) {
@@ -95,6 +98,9 @@ function getWrapperDir() {
 }
 
 function getHostPath() {
+  if (process.env.SURF_HOST_PATH && fs.existsSync(process.env.SURF_HOST_PATH)) {
+    return process.env.SURF_HOST_PATH;
+  }
   const npmRoot = findNpmGlobalRoot();
   if (npmRoot) {
     const globalPath = path.join(npmRoot, "surf-cli/native/host.cjs");


### PR DESCRIPTION
Hello! This introduces optional environment variables to control where to install/find binaries. This follows https://github.com/nicobailon/surf-cli/pull/32 to make the surf-cli more nix friendly.

Let me know if you need/want other changes and if i should add a changelog entry!

Session: https://buildwithpi.ai/session/#d10018b8b6995f8da783f969d94960ec

<details><summary>Commit desc</summary>
<p>



Add SURF_NODE_PATH, SURF_HOST_PATH, and SURF_EXTENSION_PATH
environment variables to support package manager installations
(e.g., Nix) that store binaries in non-standard locations
or use stable symlinks that survive reinstalls.

</p>
</details> 
