### PR TITLE
feat(aistudio): add AI Studio provider (network-first GenerateContent parsing + DOM fallback)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Surf takes a different approach:
 
 **Smart Defaults** - Screenshots auto-resize to 1200px (saves tokens). Actions auto-capture screenshots (saves round-trips). Errors on restricted pages warn instead of fail.
 
-**AI Without API Keys** - Query ChatGPT, Gemini, Perplexity, and Grok using your existing browser logins. No API keys needed.
+**AI Without API Keys** - Query ChatGPT, Gemini, Perplexity, Grok, and AI Studio using your existing browser logins. No API keys needed.
 
 **Network Capture** - Automatically logs all network requests while active. Filter, search, and replay API calls without manually setting up request interception.
 
@@ -138,7 +138,7 @@ surf locate.role button --name "Submit" --action click  # Find and click
 surf locate.role textbox --action fill --value "hello"  # Find and fill
 surf locate.role link --all                       # List all links
 
-# By text content  
+# By text content
 surf locate.text "Sign In" --action click         # Click element with text
 surf locate.text "Accept" --exact                 # Exact match only
 
@@ -300,6 +300,11 @@ surf gemini "a robot surfing" --generate-image /tmp/robot.png # Generate image
 surf gemini "add sunglasses" --edit-image photo.jpg --output out.jpg
 surf gemini "summarize" --youtube "https://youtube.com/..."   # YouTube analysis
 surf gemini "hello" --model gemini-2.5-flash                  # Model selection
+
+# Gemini via AI Studio (mind the rate limits)
+surf aistudio "hi gemini"                                    # Defaults to gemini-3-pro-preview
+surf aistudio "redteam the arguments here" --with-page       # Include page context
+surf aistudio "quick answer" --model gemini-3-flash-preview  # Use a different model
 
 # Perplexity
 surf perplexity "what is quantum computing"

--- a/native/aistudio-client.cjs
+++ b/native/aistudio-client.cjs
@@ -1,0 +1,1466 @@
+/**
+ * AI Studio Web Client for surf-cli
+ *
+ * CDP-based client for aistudio.google.com using browser automation.
+ * Provides access to Gemini models with AI Studio's system prompt
+ * and configuration (temperature 1.0, high thinking effort).
+ *
+ * DOM reference (as of Feb 2026):
+ *   - Prompt input: textbox[placeholder*="Start typing"] or role="textbox"
+ *   - Submit: button[type="submit"] (disabled until text entered)
+ *   - Submit shortcut: Cmd+Enter (macOS) / Ctrl+Enter
+ *   - Model selector: button containing model name, opens dropdown
+ *   - System instructions: expandable section
+ */
+
+const AISTUDIO_URL = "https://aistudio.google.com/prompts/new_chat";
+const GENERATE_CONTENT_URL_FRAGMENT =
+  "google.internal.alkali.applications.makersuite.v1.MakerSuiteService/GenerateContent";
+
+// NOTE: For AI Studio, the URL-based model selector is only reliable when we pass
+// the *exact* model id the UI expects (e.g. "gemini-3-pro-preview").
+// We intentionally do NOT try to map friendly aliases like "gemini-3-pro" -> "...-preview"
+// because those aliases have been unreliable in the browser UI
+const DEFAULT_MODEL = "gemini-3-pro-preview";
+
+function normalizeModelString(model) {
+  return String(model || "").trim().toLowerCase();
+}
+
+function buildAiStudioUrl(model) {
+  const normalized = normalizeModelString(model);
+  if (!normalized) return AISTUDIO_URL;
+
+  // Only use the URL param when the caller passes a literal AI Studio model id.
+  // If the model id is wrong/unknown, AI Studio will fall back to the last-selected
+  // model in the UI, which is acceptable.
+  const looksLikeUrlModelId =
+    /^[a-z0-9-]+$/.test(normalized) && (normalized.includes("preview") || normalized.includes("latest"));
+
+  if (!looksLikeUrlModelId) return AISTUDIO_URL;
+
+  return `${AISTUDIO_URL}?model=${encodeURIComponent(normalized)}`;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function getNestedValue(value, pathParts, fallback) {
+  let current = value;
+  for (const part of pathParts) {
+    if (current == null) return fallback;
+    if (typeof part === 'number') {
+      if (!Array.isArray(current)) return fallback;
+      current = current[part];
+    } else {
+      if (typeof current !== 'object') return fallback;
+      current = current[part];
+    }
+  }
+  return current ?? fallback;
+}
+
+function buildClickDispatcher() {
+  return `function dispatchClickSequence(target) {
+    if (!target || !(target instanceof EventTarget)) return false;
+    const types = ['pointerdown', 'mousedown', 'pointerup', 'mouseup', 'click'];
+    for (const type of types) {
+      const common = { bubbles: true, cancelable: true, view: window };
+      let event;
+      if (type.startsWith('pointer') && 'PointerEvent' in window) {
+        event = new PointerEvent(type, { ...common, pointerId: 1, pointerType: 'mouse' });
+      } else {
+        event = new MouseEvent(type, common);
+      }
+      target.dispatchEvent(event);
+    }
+    return true;
+  }`;
+}
+
+function cleanAiStudioResponse(rawText, userPrompt = '') {
+  if (!rawText) return '';
+
+  // Lines that match exactly (full trimmed line, case-insensitive) are stripped
+  // These are AI Studio UI chrome artifacts that can leak into DOM text extraction
+  const bannedExact = new Set([
+    'user',
+    'model',
+    'info',
+    'warning',
+    'close',
+    'edit',
+    'more_vert',
+    'thumb_up',
+    'thumb_down',
+    'good response',
+    'bad response',
+    'rerun this turn',
+    'open options',
+    'running...',
+
+    // Code block UI chrome from AI Studio (can leak from rendered mode)
+    'code',
+    'download',
+    'content_copy',
+    'expand_less',
+    'expand_more',
+  ]);
+
+  const promptTrimmed = String(userPrompt || '').trim();
+
+  let lines = String(rawText).split(/\r?\n/);
+
+  // If the raw extraction includes both roles, keep only the last model segment
+  // Raw Mode commonly renders as:
+  //   User
+  //   <prompt>
+  //   Model
+  //   <response>
+  // plus occasional UI banners
+  const lastModelIdx = (() => {
+    for (let i = lines.length - 1; i >= 0; i--) {
+      if (String(lines[i] || '').trim().toLowerCase() === 'model') return i;
+    }
+    return -1;
+  })();
+
+  if (lastModelIdx !== -1 && lastModelIdx + 1 < lines.length) {
+    lines = lines.slice(lastModelIdx + 1);
+  }
+
+  let inCodeFence = false;
+  let previousWasBlank = false;
+
+  const cleanedLines = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    const lower = trimmed.toLowerCase();
+
+    const isFenceLine = trimmed.startsWith('```');
+
+    // Fence lines: preserve exactly (minus trailing whitespace)
+    if (isFenceLine) {
+      inCodeFence = !inCodeFence;
+      cleanedLines.push(line.replace(/[\t ]+$/g, ''));
+      previousWasBlank = false;
+      continue;
+    }
+
+    // Inside code fences: preserve indentation and blank lines
+    if (inCodeFence) {
+      cleanedLines.push(line.replace(/[\t ]+$/g, ''));
+      previousWasBlank = false;
+      continue;
+    }
+
+    // Outside code: drop UI-only lines and prompt echo
+    if (trimmed.length === 0) {
+      if (!previousWasBlank) {
+        cleanedLines.push('');
+        previousWasBlank = true;
+      }
+      continue;
+    }
+
+    if (bannedExact.has(lower)) continue;
+    if (promptTrimmed && trimmed === promptTrimmed) continue;
+
+    // Common AI Studio footer/disclaimer
+    if (lower.includes('google ai models may make mistakes')) continue;
+    if (lower.includes('double-check outputs')) continue;
+    if (lower.startsWith('response ready')) continue;
+
+    // Drive enable prompt (AI Studio UI banner)
+    if (lower.includes('turn drive on for future conversations')) continue;
+    if (lower.includes('your work is currently not being saved')) continue;
+    if (lower.includes('enable google drive')) continue;
+
+    // Remove inline UI icon tokens, but only outside code
+    const withoutIcons = trimmed
+      .replace(/\bthumb_up\b/g, '')
+      .replace(/\bthumb_down\b/g, '')
+      .replace(/\bmore_vert\b/g, '')
+      .trim();
+
+    if (withoutIcons.length === 0) continue;
+
+    cleanedLines.push(withoutIcons);
+    previousWasBlank = false;
+  }
+
+  // Trim leading/trailing blank lines
+  while (cleanedLines.length > 0 && cleanedLines[0].trim().length === 0) cleanedLines.shift();
+  while (cleanedLines.length > 0 && cleanedLines[cleanedLines.length - 1].trim().length === 0) cleanedLines.pop();
+
+  return cleanedLines.join('\n');
+}
+
+function hasRequiredCookies(cookies) {
+  if (!cookies || !Array.isArray(cookies)) return false;
+  const sid = cookies.find(c => c.name === "__Secure-1PSID" && c.value);
+  return Boolean(sid);
+}
+
+async function evaluate(cdp, expression) {
+  const result = await cdp(expression);
+  if (result.exceptionDetails) {
+    const desc = result.exceptionDetails.exception?.description ||
+                 result.exceptionDetails.text ||
+                 "Evaluation failed";
+    throw new Error(desc);
+  }
+  if (result.error) {
+    throw new Error(result.error);
+  }
+  return result.result?.value;
+}
+
+// ============================================================================
+// Page State Functions
+// ============================================================================
+
+function extractModelKeywords(modelId) {
+  const normalized = normalizeModelString(modelId);
+  if (!normalized) return [];
+
+  const ignored = new Set(["gemini", "preview", "latest"]);
+
+  const tokens = normalized
+    .split("-")
+    .map(t => t.trim())
+    .filter(Boolean)
+    .filter(t => !ignored.has(t))
+    .filter(t => !/^\d+(?:\.\d+)?$/.test(t));
+
+  // Keep short-but-meaningful tokens like "pro"
+  const keywords = tokens.filter(t => t.length >= 3);
+
+  return Array.from(new Set(keywords));
+}
+
+async function readCurrentModelInfo(cdp) {
+  return evaluate(cdp, `(() => {
+    const normalize = (text) => (text || '').replace(/\s+/g, ' ').trim();
+
+    const selector = document.querySelector('button.model-selector-card, .model-selector-card');
+    if (!selector) {
+      return { found: false, label: '', modelId: '' };
+    }
+
+    const raw = normalize(selector.textContent || '');
+    const lower = raw.toLowerCase();
+    const compact = lower.replace(/\s+/g, '');
+    const modelIdMatch = compact.match(/gemini-[a-z0-9-]*(?:preview|latest)/) ||
+      lower.match(/gemini-[a-z0-9-]*(?:preview|latest)/);
+
+    return {
+      found: true,
+      label: lower,
+      modelId: modelIdMatch ? modelIdMatch[0] : '',
+    };
+  })()`);
+}
+
+async function waitForModelToApply(cdp, requestedModel, log, timeoutMs = 15000) {
+  const normalizedRequested = normalizeModelString(requestedModel);
+  const keywords = extractModelKeywords(normalizedRequested);
+  if (!normalizedRequested) return true;
+
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const info = await readCurrentModelInfo(cdp).catch(() => ({ found: false, label: '', modelId: '' }));
+
+    const modelIdMatches = info.modelId && info.modelId === normalizedRequested;
+    const keywordMatches = info.label && keywords.length > 0 && keywords.every(k => info.label.includes(k));
+
+    if (modelIdMatches || keywordMatches) {
+      log(
+        `Model appears applied: requested=${normalizedRequested}` +
+        `${info.modelId ? `, detected=${info.modelId}` : ''}` +
+        `${info.label ? `, label=${info.label.slice(0, 120)}` : ''}`
+      );
+      return true;
+    }
+
+    await delay(250);
+  }
+
+  log(`Model did not appear to apply within ${timeoutMs}ms (requested=${normalizedRequested})`);
+  return false;
+}
+
+async function waitForPageLoad(cdp, timeoutMs = 30000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const ready = await evaluate(cdp, "document.readyState");
+    if (ready === "complete" || ready === "interactive") {
+      // Extra wait for AI Studio's SPA to hydrate
+      await delay(2500);
+      return;
+    }
+    await delay(100);
+  }
+  throw new Error("Page did not load in time");
+}
+
+async function waitForStudioReady(cdp, timeoutMs = 30000) {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const state = await evaluate(cdp, `(() => {
+      const url = location.href;
+      const isLoginPage = url.includes('accounts.google.com') || url.includes('/signin');
+      const isStudioPage = url.includes('aistudio.google.com');
+
+      const isVisible = (el) => Boolean(el && (el.offsetParent !== null || el.getClientRects().length > 0));
+
+      const candidates = Array.from(document.querySelectorAll('[role="textbox"], textarea'))
+        .filter((el) => isVisible(el));
+
+      const byPlaceholder = (el) => {
+        const placeholder = (el.getAttribute && el.getAttribute('placeholder') ? el.getAttribute('placeholder') : '') || '';
+        const p = placeholder.toLowerCase();
+        return p.includes('prompt') || p.includes('start typing') || p.includes('enter');
+      };
+
+      // Prefer the canonical prompt input, but fall back to any visible textbox/textarea.
+      // (Placeholders can change; role="textbox" tends to be stable in AI Studio.)
+      const promptInput = candidates.find(byPlaceholder) || (candidates.length ? candidates[candidates.length - 1] : null);
+
+      return {
+        ready: isStudioPage && !!promptInput,
+        hasInput: !!promptInput,
+        isStudioPage,
+        isLoginPage,
+        url
+      };
+    })()`);
+
+    if (state && state.ready) {
+      return state;
+    }
+
+    if (state && state.isLoginPage) {
+      throw new Error("Redirected to login page - sign into Google in Chrome first");
+    }
+
+    await delay(300);
+  }
+
+  throw new Error("AI Studio chat input not found - page may not have loaded correctly");
+}
+
+// ============================================================================
+// Display Options
+// ============================================================================
+
+async function enableUnformattedMarkdownView(cdp, log = () => {}, timeoutMs = 8000) {
+  // AI Studio currently exposes this as “Raw Mode” under the “View more actions” menu.
+  // When enabled, the conversation view shows the raw markdown source (including ``` fences)
+
+  // Fast path: if the page already visibly advertises the inverse toggle, Raw Mode is on
+  // (This avoids opening the menu on every request)
+  try {
+    const alreadyEnabled = await evaluate(cdp, `(() => {
+      const t = (document.body && document.body.innerText ? document.body.innerText : '').toLowerCase();
+      return t.includes('show conversation with markdown formatting') || t.includes('raw mode');
+    })()`);
+
+    if (alreadyEnabled) {
+      log('Markdown toggle: already enabled (detected on page)');
+      return { success: true, alreadyEnabled: true, detected: true };
+    }
+  } catch (e) {
+    // Ignore detection failures and fall back to menu interaction
+  }
+
+  const openMenu = await evaluate(cdp, `(() => {
+    ${buildClickDispatcher()}
+    const buttons = Array.from(document.querySelectorAll('button'));
+    const menuBtn = buttons.find(b => {
+      const label = (b.getAttribute('aria-label') || '').toLowerCase();
+      const text = (b.textContent || '').toLowerCase();
+      return label.includes('view more actions') || text.includes('view more actions');
+    });
+    if (!menuBtn) return { success: false, error: 'View more actions button not found' };
+    dispatchClickSequence(menuBtn);
+    return { success: true };
+  })()`);
+
+  if (!openMenu || !openMenu.success) {
+    log(`Markdown toggle: ${openMenu?.error || 'menu not available'}`);
+    return { success: false, reason: openMenu?.error || 'menu not available' };
+  }
+
+  const deadline = Date.now() + timeoutMs;
+  let result = null;
+
+  while (Date.now() < deadline) {
+    // Keep this evaluate small and robust; the Raw Mode menu item is in the light DOM
+    // as a button[role=menuitem] inside [role=menu]
+    result = await evaluate(cdp, `(() => {
+      ${buildClickDispatcher()}
+
+      const menu = document.querySelector('[role="menu"]');
+      if (!menu) return { ready: false };
+
+      const items = Array.from(menu.querySelectorAll('button,[role="menuitem"]'));
+      const normalize = (s) => (s || '').toLowerCase().replace(/\s+/g, ' ').trim();
+
+      const target = items.find(el => {
+        const t = normalize(el.textContent || '');
+        return t.includes('raw mode') || t.includes('raw output') || t.includes('viewing raw output');
+      });
+
+      if (!target) {
+        return {
+          ready: true,
+          found: false,
+          candidates: items.slice(0, 6).map(el => normalize(el.textContent || '').slice(0, 80)),
+        };
+      }
+
+      const label = normalize(target.textContent || '');
+      const ariaChecked = target.getAttribute('aria-checked');
+      const ariaPressed = target.getAttribute('aria-pressed');
+      const isEnabled = ariaChecked === 'true' || ariaPressed === 'true' || label.includes('check');
+
+      if (!isEnabled) {
+        dispatchClickSequence(target);
+      }
+
+      return {
+        ready: true,
+        found: true,
+        label: label,
+        isEnabled: isEnabled,
+        clicked: !isEnabled,
+      };
+    })()`);
+
+    if (result && result.ready) {
+      break;
+    }
+
+    await delay(150);
+  }
+
+  // Close menu (Escape)
+  await evaluate(cdp, `(() => {
+    const esc = new KeyboardEvent('keydown', { key: 'Escape', code: 'Escape', bubbles: true });
+    document.dispatchEvent(esc);
+  })()`).catch(() => {});
+
+  if (!result || !result.ready) {
+    log('Markdown toggle: menu did not appear');
+    return { success: false, reason: 'menu did not appear' };
+  }
+
+  if (!result.found) {
+    log(`Markdown toggle: Raw Mode item not found (candidates: ${(result.candidates || []).join(' | ')})`);
+    return { success: false, reason: 'raw mode item not found' };
+  }
+
+  if (result.isEnabled) {
+    log('Markdown toggle: already enabled (Raw Mode)');
+    return { success: true, alreadyEnabled: true };
+  }
+
+  if (result.clicked) {
+    log('Markdown toggle: enabled (Raw Mode)');
+    await delay(200);
+    return { success: true, enabled: true };
+  }
+
+  log('Markdown toggle: not enabled (unexpected)');
+  return { success: false, reason: 'unexpected raw mode toggle state' };
+}
+
+// ============================================================================
+// Model Selection
+// ============================================================================
+
+async function closeModelSelectorIfOpen(cdp, log = () => {}) {
+  const closed = await evaluate(cdp, `(() => {
+    const dialog = document.querySelector('[role="dialog"]');
+    if (!dialog) return false;
+
+    const hasModelOptions = dialog.querySelector('button.content-button, [role="option"], mat-option, mat-list-item');
+    if (!hasModelOptions) return false;
+
+    const esc = new KeyboardEvent('keydown', { key: 'Escape', code: 'Escape', bubbles: true });
+    document.dispatchEvent(esc);
+    return true;
+  })()`).catch(() => false);
+
+  if (closed) {
+    log('Closed model selector dialog before continuing');
+    await delay(150);
+  }
+
+  return Boolean(closed);
+}
+
+async function selectModel(cdp, desiredModel, log, timeoutMs = 10000) {
+  const normalizedTargetModel = normalizeModelString(desiredModel);
+  if (!normalizedTargetModel) return desiredModel;
+
+  const openSelector = await evaluate(cdp, `(() => {
+    ${buildClickDispatcher()}
+
+    const normalize = (text) => (text || '').replace(/\s+/g, ' ').trim();
+    const isVisible = (el) => Boolean(el && (el.offsetParent !== null || el.getClientRects().length > 0));
+
+    const direct = document.querySelector('button.model-selector-card, .model-selector-card');
+    if (isVisible(direct)) {
+      dispatchClickSequence(direct);
+      return { success: true, method: 'model-selector-card', currentModel: normalize(direct.textContent || '').slice(0, 120) };
+    }
+
+    const fallbackButtons = Array.from(document.querySelectorAll('button')).filter((b) => {
+      if (!isVisible(b)) return false;
+      const cls = (b.className || '').toString().toLowerCase();
+      const aria = (b.getAttribute('aria-label') || '').toLowerCase();
+      const text = normalize(b.textContent || '').toLowerCase();
+
+      if (cls.includes('model-selector-card')) return true;
+      if (aria.includes('model') && text.includes('gemini')) return true;
+      return false;
+    });
+
+    if (fallbackButtons.length > 0) {
+      const target = fallbackButtons[0];
+      dispatchClickSequence(target);
+      return { success: true, method: 'fallback-model-button', currentModel: normalize(target.textContent || '').slice(0, 120) };
+    }
+
+    return { success: false, error: 'Model selector button not found' };
+  })()`);
+
+  if (!openSelector || !openSelector.success) {
+    log(`Model selector not found: ${openSelector?.error || 'unknown'}`);
+    return desiredModel;
+  }
+
+  log(`Opened model selector via ${openSelector.method}: ${openSelector.currentModel || '(unknown)'}`);
+
+  const deadline = Date.now() + timeoutMs;
+  const targetToken = normalizedTargetModel.replace(/[^a-z0-9]/g, '');
+
+  while (Date.now() < deadline) {
+    const result = await evaluate(cdp, `(() => {
+      ${buildClickDispatcher()}
+
+      const target = ${JSON.stringify(normalizedTargetModel)};
+      const targetToken = ${JSON.stringify(targetToken)};
+      const normalize = (text) => (text || '').replace(/\s+/g, ' ').trim();
+      const isVisible = (el) => Boolean(el && (el.offsetParent !== null || el.getClientRects().length > 0));
+      const normalizeToken = (text) => (text || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+
+      const candidates = Array.from(document.querySelectorAll(
+        'button.content-button, [role="dialog"] button, [role="option"], mat-option, mat-list-item, [role="menuitem"]'
+      ))
+        .filter(isVisible)
+        .map((el) => {
+          const raw = normalize(el.textContent || '');
+          const lower = raw.toLowerCase();
+          return {
+            el,
+            raw,
+            lower,
+            token: normalizeToken(raw),
+          };
+        })
+        .filter((item) => {
+          return item.lower.includes('gemini') || item.lower.includes('nano banana') || item.lower.includes('-preview');
+        });
+
+      if (candidates.length === 0) {
+        return { found: false, waiting: true };
+      }
+
+      const exact = candidates.find((item) => item.lower.includes(target));
+      if (exact) {
+        dispatchClickSequence(exact.el);
+        return { found: true, success: true, model: exact.raw.slice(0, 160), match: 'exact' };
+      }
+
+      const fuzzy = candidates.find((item) => item.token.includes(targetToken));
+      if (fuzzy) {
+        dispatchClickSequence(fuzzy.el);
+        return { found: true, success: true, model: fuzzy.raw.slice(0, 160), match: 'fuzzy' };
+      }
+
+      return {
+        found: true,
+        success: false,
+        models: candidates.slice(0, 8).map((item) => item.raw.slice(0, 80)),
+      };
+    })()`);
+
+    if (result && result.found) {
+      if (result.success) {
+        log(`Selected model (${result.match}): ${result.model}`);
+        await delay(300);
+        return result.model;
+      }
+
+      log(`Model "${desiredModel}" not found in selector options: ${JSON.stringify(result.models || [])}`);
+      break;
+    }
+
+    await delay(200);
+  }
+
+  await evaluate(cdp, `(() => {
+    const esc = new KeyboardEvent('keydown', { key: 'Escape', code: 'Escape', bubbles: true });
+    document.dispatchEvent(esc);
+  })()`).catch(() => {});
+
+  return desiredModel;
+}
+
+// ============================================================================
+// Input and Submission
+// ============================================================================
+
+async function typePrompt(cdp, inputCdp, prompt) {
+  // Focus the prompt input - AI Studio uses a textbox with specific placeholder
+  const focused = await evaluate(cdp, `(() => {
+    ${buildClickDispatcher()}
+
+    const isVisible = (el) => Boolean(el && (el.offsetParent !== null || el.getClientRects().length > 0));
+
+    const candidates = Array.from(document.querySelectorAll('[role="textbox"], textarea'))
+      .filter((el) => isVisible(el));
+
+    const byPlaceholder = (el) => {
+      const placeholder = (el.getAttribute && el.getAttribute('placeholder') ? el.getAttribute('placeholder') : '') || '';
+      const p = placeholder.toLowerCase();
+      return p.includes('prompt') || p.includes('start typing') || p.includes('enter');
+    };
+
+    const promptInput = candidates.find(byPlaceholder) || (candidates.length ? candidates[candidates.length - 1] : null);
+
+    if (promptInput) {
+      dispatchClickSequence(promptInput);
+      promptInput.focus?.();
+      return { success: true, method: byPlaceholder(promptInput) ? 'placeholder-match' : 'visible-textbox-fallback' };
+    }
+
+    return { success: false, error: 'Prompt input not found' };
+  })()`);
+
+  if (!focused || !focused.success) {
+    throw new Error(`Could not focus prompt input: ${focused?.error || 'unknown'}`);
+  }
+
+  await delay(300);
+
+  // Type using CDP Input API
+  await inputCdp("Input.insertText", { text: prompt });
+  await delay(300);
+}
+
+async function submitPrompt(cdp, inputCdp) {
+  // Wait briefly for the submit button to become enabled after typing
+  await delay(200);
+
+  // Try clicking the submit button first
+  const clicked = await evaluate(cdp, `(() => {
+    ${buildClickDispatcher()}
+    // AI Studio's submit button is button[type="submit"]
+    const submitBtn = document.querySelector('button[type="submit"]:not([disabled])');
+    if (submitBtn) {
+      dispatchClickSequence(submitBtn);
+      return { success: true, method: 'submit-button' };
+    }
+    return { success: false };
+  })()`);
+
+  if (clicked && clicked.success) {
+    await delay(500);
+    return;
+  }
+
+  // Fallback: Cmd+Enter (macOS) / Ctrl+Enter
+  const modifiers = process.platform === "darwin" ? 4 : 2; // 4 = Meta (Cmd), 2 = Ctrl
+  await inputCdp("Input.dispatchKeyEvent", {
+    type: "keyDown",
+    key: "Enter",
+    code: "Enter",
+    windowsVirtualKeyCode: 13,
+    nativeVirtualKeyCode: 13,
+    modifiers,
+    text: "\r",
+  });
+  await inputCdp("Input.dispatchKeyEvent", {
+    type: "keyUp",
+    key: "Enter",
+    code: "Enter",
+    windowsVirtualKeyCode: 13,
+    nativeVirtualKeyCode: 13,
+    modifiers,
+  });
+
+  await delay(500);
+}
+
+// ============================================================================
+// Response Handling
+// ============================================================================
+
+function normalizeAiStudioRpcJson(rawText) {
+  let text = String(rawText || '').trim();
+  if (!text) return text;
+
+  // Strip Google's common XSSI prefix
+  //   )]}'\n<json>
+  if (text.startsWith(")]}'")) {
+    const newlineIndex = text.indexOf('\n');
+    text = (newlineIndex === -1 ? '' : text.slice(newlineIndex + 1)).trim();
+    if (!text) return text;
+  }
+
+  // Some RPC errors are returned in JS-ish array form with a leading elision:
+  //   [,[7,"The caller does not have permission"]]
+  // Normalize this into valid JSON before parsing
+  if (text.startsWith('[,')) {
+    return `[null${text.slice(1)}`;
+  }
+
+  return text;
+}
+
+function parseAiStudioRpcError(rawText) {
+  const normalized = normalizeAiStudioRpcJson(rawText);
+  if (!normalized) return null;
+
+  try {
+    const parsed = JSON.parse(normalized);
+    const code = getNestedValue(parsed, [1, 0], null);
+    const message = getNestedValue(parsed, [1, 1], null);
+
+    if (typeof message === 'string' && message.trim()) {
+      return {
+        code: typeof code === 'number' ? code : undefined,
+        message: message.trim(),
+      };
+    }
+  } catch {
+    // ignore parse failures
+  }
+
+  return null;
+}
+
+function isThinkingModelChunk(chunk) {
+  if (!Array.isArray(chunk)) return false;
+
+  // Observed structure for thinking chunks:
+  // [null, "<thinking>", ..., 1]
+  if (chunk.length >= 16 && chunk[15] === 1) return true;
+
+  const last = chunk[chunk.length - 1];
+  return chunk.length > 2 && last === 1;
+}
+
+function collectModelTextSegments(node, out) {
+  if (!Array.isArray(node)) return;
+
+  // Stream chunk patterns seen in GenerateContent response payload:
+  //   [ [[null, "<chunk>"]], "model" ]
+  //   [ [[[null, "<chunk>"]]], "model" ]
+  if (node.length >= 2 && node[1] === 'model') {
+    const payloadLevel2 = getNestedValue(node, [0, 0], null);
+    const payloadLevel3 = getNestedValue(node, [0, 0, 0], null);
+
+    const segment = typeof payloadLevel2?.[1] === 'string'
+      ? payloadLevel2[1]
+      : typeof payloadLevel3?.[1] === 'string'
+        ? payloadLevel3[1]
+        : null;
+
+    if (typeof segment === 'string' && segment.length > 0) {
+      out.push({
+        text: segment,
+        thinking: isThinkingModelChunk(payloadLevel2) || isThinkingModelChunk(payloadLevel3),
+      });
+
+      return;
+    }
+  }
+
+  for (const child of node) {
+    if (Array.isArray(child)) {
+      collectModelTextSegments(child, out);
+    }
+  }
+}
+
+function extractFinalResponseText(value) {
+  const text = String(value || '').trim();
+  if (!text) return '';
+
+  const lines = text.split(/\r?\n/);
+  const headingIndex = lines.findIndex((line, index) => index > 0 && /^#{1,6}\s+/.test(String(line || '').trim()));
+
+  if (headingIndex <= 0) {
+    return text;
+  }
+
+  const preambleText = lines.slice(0, headingIndex).join('\n').trim();
+  const finalText = lines.slice(headingIndex).join('\n').trim();
+
+  if (!preambleText || !finalText) {
+    return text;
+  }
+
+  const lower = preambleText.toLowerCase();
+  const looksLikeThinking =
+    lower.includes('considering') ||
+    lower.includes('focusing') ||
+    lower.includes('reasoning') ||
+    lower.includes("i'm") ||
+    lower.includes('i am');
+
+  return looksLikeThinking ? finalText : text;
+}
+
+function parseAiStudioGenerateContentText(rawText) {
+  const normalized = normalizeAiStudioRpcJson(rawText);
+  if (!normalized) return '';
+
+  let parsed;
+  try {
+    parsed = JSON.parse(normalized);
+  } catch (e) {
+    throw new Error(`Invalid GenerateContent JSON (${normalized.length} chars): ${e.message}`);
+  }
+
+  const segments = [];
+  collectModelTextSegments(parsed, segments);
+
+  const finalText = segments
+    .filter((segment) => !segment.thinking)
+    .map((segment) => segment.text)
+    .join('')
+    .trim();
+
+  if (finalText) {
+    return extractFinalResponseText(finalText);
+  }
+
+  const combinedText = segments
+    .map((segment) => segment.text)
+    .join('')
+    .trim();
+
+  return extractFinalResponseText(combinedText);
+}
+
+function extractGenerateEntries(entries) {
+  if (!Array.isArray(entries)) return [];
+
+  return entries
+    .filter((entry) => {
+      const url = String(entry?.url || '');
+      return entry && typeof entry === 'object' && url.includes(GENERATE_CONTENT_URL_FRAGMENT);
+    })
+    .sort((a, b) => (a.ts || 0) - (b.ts || 0));
+}
+
+function extractLastUserPromptFromGenerateRequestBody(rawBody) {
+  if (!rawBody || typeof rawBody !== 'string') return null;
+
+  try {
+    const parsed = JSON.parse(rawBody);
+    const turns = Array.isArray(parsed?.[1]) ? parsed[1] : [];
+
+    for (let i = turns.length - 1; i >= 0; i--) {
+      const turn = turns[i];
+      if (!Array.isArray(turn) || turn[1] !== 'user') continue;
+
+      const prompt = getNestedValue(turn, [0, 0, 1], null);
+      if (typeof prompt === 'string' && prompt.trim()) {
+        return prompt.trim();
+      }
+    }
+  } catch {
+    // ignore parse failures
+  }
+
+  return null;
+}
+
+function doesGenerateEntryMatchPrompt(entry, expectedPrompt) {
+  const expected = String(expectedPrompt || '').trim();
+  if (!expected) return true;
+
+  const requestBody = typeof entry?.requestBody === 'string' ? entry.requestBody : '';
+  if (!requestBody) return false;
+
+  const extractedPrompt = extractLastUserPromptFromGenerateRequestBody(requestBody);
+  if (extractedPrompt) {
+    return extractedPrompt === expected;
+  }
+
+  // Fallback heuristic if request body parsing fails
+  const probe = expected.slice(0, 120);
+  return probe.length > 0 && requestBody.includes(probe);
+}
+
+async function waitForGenerateResponseFromNetwork(params) {
+  const {
+    tabId,
+    readNetworkEntries,
+    timeoutMs = 300000,
+    baselineEntryIds = new Set(),
+    prompt = '',
+    log = () => {},
+  } = params;
+
+  const deadline = Date.now() + timeoutMs;
+  let lastSeenCount = -1;
+  const parseErrorCounts = new Map();
+
+  while (Date.now() < deadline) {
+    const network = await readNetworkEntries(tabId);
+
+    if (network?.error) {
+      throw new Error(String(network.error));
+    }
+
+    const allEntries = Array.isArray(network?.entries)
+      ? network.entries
+      : Array.isArray(network?.requests)
+        ? network.requests
+        : [];
+
+    const generateEntries = extractGenerateEntries(allEntries);
+
+    if (generateEntries.length !== lastSeenCount) {
+      lastSeenCount = generateEntries.length;
+      log(`GenerateContent network entries seen: ${generateEntries.length}`);
+    }
+
+    const freshEntries = generateEntries.filter((entry) => !baselineEntryIds.has(entry.id));
+
+    for (const entry of freshEntries) {
+      if (!doesGenerateEntryMatchPrompt(entry, prompt)) {
+        log(`Skipping GenerateContent entry ${entry?.id || 'unknown'} (prompt mismatch)`);
+        continue;
+      }
+
+      const status = Number(entry?.status || 0);
+      const body = typeof entry?.responseBody === 'string' ? entry.responseBody : '';
+
+      if (status >= 400) {
+        const rpcError = parseAiStudioRpcError(body);
+        const msg = rpcError?.message || `HTTP ${status}`;
+        throw new Error(`AI Studio GenerateContent failed (${status}): ${msg}`);
+      }
+
+      if (status !== 200 || !body) {
+        continue;
+      }
+
+      let parsedText = '';
+      try {
+        parsedText = parseAiStudioGenerateContentText(body);
+      } catch (e) {
+        const requestId = entry.id || 'unknown';
+        const parseErrorCount = (parseErrorCounts.get(requestId) || 0) + 1;
+        parseErrorCounts.set(requestId, parseErrorCount);
+
+        log(`GenerateContent parse error (${requestId} #${parseErrorCount}): ${e.message || e}`);
+
+        if (parseErrorCount >= 3) {
+          throw new Error(`GenerateContent body for ${requestId} is not parseable; falling back to DOM`);
+        }
+
+        continue;
+      }
+
+      if (parsedText && parsedText.length > 0) {
+        return {
+          text: parsedText,
+          requestId: entry.id,
+          status,
+        };
+      }
+    }
+
+    await delay(350);
+  }
+
+  throw new Error('Timed out waiting for AI Studio GenerateContent network response');
+}
+
+async function waitForResponse(cdp, timeoutMs = 300000, userPrompt = '', log = () => {}) {
+  const deadline = Date.now() + timeoutMs;
+
+  // Wait a moment for the request to start
+  await delay(1000);
+
+  // Phase 1: Poll for completion signals only (lightweight)
+  // Require the "done" condition for a few consecutive polls to avoid early exits
+  let doneStreak = 0;
+
+  while (Date.now() < deadline) {
+    const status = await evaluate(cdp, `(function() {
+      var buttons = Array.from(document.querySelectorAll('button'));
+
+      var bodyText = (document.body && document.body.innerText ? document.body.innerText : '').toLowerCase();
+
+      // Rate limit detection: match the *actual* AI Studio error strings (surgical)
+      // Observed strings (Feb 2026):
+      // - "You've reached your rate limit. Please try again later."
+      // - "Failed to generate content: user has exceeded quota. Please try again later."
+      var rateLimitMsg = null;
+      if (bodyText.indexOf("you've reached your rate limit") !== -1) {
+        rateLimitMsg = "You've reached your rate limit. Please try again later.";
+      } else if (bodyText.indexOf('failed to generate content: user has exceeded quota') !== -1) {
+        rateLimitMsg = "Failed to generate content: user has exceeded quota. Please try again later.";
+      }
+      var rateLimited = rateLimitMsg !== null;
+
+      // Completion signal: rating buttons appear once the model finished generating
+      var hasRatingBtns = buttons.some(function(b) {
+        return (b.getAttribute('aria-label') || b.textContent || '').toLowerCase().indexOf('good response') !== -1;
+      });
+
+      // Stop button present during generation
+      var hasStopBtn = buttons.some(function(b) {
+        var label = (b.getAttribute('aria-label') || '').toLowerCase();
+        var text = (b.textContent || '').toLowerCase();
+        return text.indexOf('stop') !== -1 || label.indexOf('stop') !== -1 || text.indexOf('running') !== -1;
+      });
+
+      return {
+        done: hasRatingBtns && !hasStopBtn,
+        hasStopBtn: hasStopBtn,
+        rateLimited: rateLimited,
+        rateLimitMsg: rateLimitMsg
+      };
+    })()`);
+
+    if (status && status.rateLimited) {
+      const msg = status.rateLimitMsg || "You've reached your rate limit. Please try again later.";
+      throw new Error(
+        `AI Studio rate limited: ${msg} ` +
+        "(Tip: use `surf gemini` / another provider as a fallback.)"
+      );
+    }
+
+    if (status && status.done) {
+      doneStreak++;
+      if (doneStreak === 1) {
+        log("Completion signal detected (waiting for stability...)");
+      }
+      if (doneStreak >= 3) {
+        log("Completion signal stable");
+        break;
+      }
+    } else {
+      doneStreak = 0;
+    }
+
+    await delay(500);
+  }
+
+  if (Date.now() >= deadline) {
+    throw new Error("Response timeout - AI Studio did not complete in time");
+  }
+
+  // Phase 2: Extract the response text via DOM walk
+  // Even after the completion signal, AI Studio can still stream/finish rendering.
+  // Re-extract until the cleaned response stabilizes to avoid returning truncated output
+  await delay(800);
+
+  const extractScript = `(function() {
+    function stripUi(text) {
+      if (!text) return '';
+
+      var removeLabels = ['Edit', 'Rerun this turn', 'Open options', 'Good response', 'Bad response'];
+      var removeSet = {};
+      for (var i = 0; i < removeLabels.length; i++) {
+        removeSet[String(removeLabels[i]).toLowerCase()] = true;
+      }
+
+      var lines = String(text).split(/\r?\n/);
+      var kept = [];
+
+      for (var j = 0; j < lines.length; j++) {
+        var line = lines[j];
+        var trimmed = (line || '').trim();
+        if (!trimmed) {
+          kept.push('');
+          continue;
+        }
+
+        if (removeSet[trimmed.toLowerCase()]) continue;
+        kept.push(line);
+      }
+
+      return kept.join('\n').trim();
+    }
+
+    var buttons = Array.from(document.querySelectorAll('button'));
+    var goodBtn = buttons.find(function(b) {
+      return (b.getAttribute('aria-label') || b.textContent || '').toLowerCase().indexOf('good response') !== -1;
+    });
+
+    // Prefer extracting relative to the model turn container (good response button)
+    // so we don’t accidentally return the user prompt (especially with --with-page)
+    if (goodBtn) {
+      var container = goodBtn.parentElement;
+      while (container && container !== document.body) {
+        try {
+          var big = Array.from(container.querySelectorAll('[class*="very-large-text-container"]'));
+          if (big && big.length) {
+            var t = (big[big.length - 1].innerText || '').trim();
+            if (t && t.length > 10) {
+              return { text: stripUi(t), method: 'good-btn-large-container' };
+            }
+          }
+        } catch (e) {}
+
+        var text = (container.innerText || '').trim();
+        if (text.length > 50) {
+          var cleaned = stripUi(text);
+          if (cleaned.length > 20) {
+            return { text: cleaned, method: 'good-btn-walk' };
+          }
+        }
+        container = container.parentElement;
+      }
+    }
+
+    // Fallback: dedicated container (may include user prompt; used only if we can’t locate goodBtn)
+    var big2 = Array.from(document.querySelectorAll('[class*="very-large-text-container"]'));
+    if (big2 && big2.length) {
+      for (var j = big2.length - 1; j >= 0; j--) {
+        var tt = (big2[j].innerText || '').trim();
+        var ll = tt.toLowerCase();
+        if (tt.length > 50 && ll.indexOf('google ai studio uses cookies') === -1) {
+          return { text: stripUi(tt), method: 'very-large-text-container' };
+        }
+      }
+    }
+
+    var promptInput = document.querySelector('[role="textbox"][placeholder*="prompt" i], textarea[placeholder*="prompt" i]');
+    if (promptInput) {
+      var parent = promptInput.parentElement;
+      while (parent && parent !== document.body) {
+        var siblings = parent.parentElement ? Array.from(parent.parentElement.children) : [];
+        var myIdx = siblings.indexOf(parent);
+        for (var s = 0; s < myIdx; s++) {
+          var sibText = (siblings[s].innerText || '').trim();
+          if (sibText.length > 50) {
+            return { text: stripUi(sibText), method: 'sibling-walk' };
+          }
+        }
+        parent = parent.parentElement;
+      }
+    }
+
+    return { text: document.body.innerText || '', method: 'body-fallback' };
+  })()`;
+
+  let bestText = '';
+  let bestRaw = '';
+  let bestExtracted = null;
+  let lastText = null;
+  let stableCount = 0;
+
+  const extractDeadline = Math.min(deadline, Date.now() + 15000);
+
+  while (Date.now() < extractDeadline) {
+    const extracted = await evaluate(cdp, extractScript);
+    const responseTextRaw = extracted
+      ? String(extracted.text || '').trim()
+      : '';
+    const responseText = cleanAiStudioResponse(responseTextRaw, userPrompt);
+
+    if (responseText.length > bestText.length) {
+      bestText = responseText;
+      bestRaw = responseTextRaw;
+      bestExtracted = extracted;
+    }
+
+    if (lastText !== null && responseText === lastText && responseText.length > 5) {
+      stableCount++;
+      if (stableCount >= 2) {
+        log(
+          'Extraction stabilized: method=' + (extracted ? extracted.method : 'none') +
+          ', raw length=' + responseTextRaw.length +
+          ', cleaned length=' + responseText.length
+        );
+        return {
+          text: responseText,
+          thinkingTime: null,
+          url: extracted ? (extracted.url || '') : '',
+        };
+      }
+    } else {
+      stableCount = 0;
+      lastText = responseText;
+    }
+
+    await delay(700);
+  }
+
+  // If we couldn't stabilize, return the best (longest) extraction we saw
+  log(
+    'Extraction not stable before deadline; returning best length=' + bestText.length +
+    ', raw length=' + bestRaw.length +
+    ', method=' + (bestExtracted ? bestExtracted.method : 'none')
+  );
+
+  if (!bestText || bestText.length < 5) {
+    throw new Error('Could not extract response text from AI Studio');
+  }
+
+  return {
+    text: bestText,
+    thinkingTime: null,
+    url: bestExtracted ? (bestExtracted.url || '') : '',
+  };
+}
+
+// ============================================================================
+// Main Query Function
+// ============================================================================
+
+async function query(options) {
+  const {
+    prompt,
+    model = DEFAULT_MODEL,
+    timeout = 300000,
+    getCookies,
+    createTab,
+    closeTab,
+    cdpEvaluate,
+    cdpCommand,
+    readNetworkEntries,
+    log = () => {},
+  } = options;
+
+  const startTime = Date.now();
+  log("Starting AI Studio query");
+
+  const resolvedModel = normalizeModelString(model) || DEFAULT_MODEL;
+  log(`Requested model: ${resolvedModel}`);
+
+  // Check cookies for Google authentication
+  const { cookies } = await getCookies();
+  if (!hasRequiredCookies(cookies)) {
+    throw new Error("Google login required - sign into Google in Chrome first");
+  }
+  log(`Got ${cookies.length} cookies`);
+
+  // Create tab (try to select the model via URL param for reliability)
+  const tabInfo = await createTab(buildAiStudioUrl(resolvedModel));
+  const { tabId } = tabInfo || {};
+
+  if (!tabId) {
+    throw new Error(`Failed to create AI Studio tab: ${JSON.stringify(tabInfo)}`);
+  }
+  log(`Created tab ${tabId}`);
+
+  const cdp = (expr) => cdpEvaluate(tabId, expr);
+  const inputCdp = (method, params) => cdpCommand(tabId, method, params);
+
+  let baselineGenerateEntryIds = new Set();
+
+  try {
+    // Wait for page load
+    await waitForPageLoad(cdp);
+    log("Page loaded");
+
+    // Wait for AI Studio chat UI to be ready
+    await waitForStudioReady(cdp);
+    log("AI Studio ready");
+
+    // Prime network tracking and capture baseline request ids for GenerateContent
+    if (typeof readNetworkEntries === 'function') {
+      try {
+        const baselineNetwork = await readNetworkEntries(tabId);
+        const baselineEntries = Array.isArray(baselineNetwork?.entries)
+          ? baselineNetwork.entries
+          : Array.isArray(baselineNetwork?.requests)
+            ? baselineNetwork.requests
+            : [];
+
+        baselineGenerateEntryIds = new Set(
+          extractGenerateEntries(baselineEntries)
+            .map((entry) => entry.id)
+            .filter(Boolean)
+        );
+
+        log(`Network baseline ready (${baselineGenerateEntryIds.size} GenerateContent entries)`);
+      } catch (e) {
+        log(`Network baseline failed: ${e.message || e}`);
+      }
+    }
+
+    // Enable raw markdown view (best-effort)
+    try {
+      await enableUnformattedMarkdownView(cdp, log);
+    } catch (e) {
+      log(`Markdown toggle failed: ${e.message}`);
+    }
+
+    // Model selection: best-effort via URL param only
+    // If the model id is wrong/unknown, AI Studio will typically keep the last-selected model in the UI.
+    const createdUrl = buildAiStudioUrl(resolvedModel);
+    const usedUrlParam = createdUrl.includes('?model=');
+
+    let runtimeUrl = await evaluate(cdp, 'location.href');
+    let runtimeModelParam = await evaluate(cdp, `(() => {
+      try {
+        return new URLSearchParams(location.search).get('model') || '';
+      } catch {
+        return '';
+      }
+    })()`);
+
+    if (usedUrlParam && !runtimeModelParam) {
+      try {
+        log(`Runtime model param missing; retrying direct navigation: ${createdUrl}`);
+        await inputCdp('Page.navigate', { url: createdUrl });
+        await waitForPageLoad(cdp);
+        await waitForStudioReady(cdp);
+        runtimeUrl = await evaluate(cdp, 'location.href');
+        runtimeModelParam = await evaluate(cdp, `(() => {
+          try {
+            return new URLSearchParams(location.search).get('model') || '';
+          } catch {
+            return '';
+          }
+        })()`);
+      } catch (e) {
+        log(`Direct model URL navigation retry failed: ${e.message || e}`);
+      }
+    }
+
+    if (usedUrlParam) {
+      log(`Model via URL param: requested="${resolvedModel}", runtimeParam="${runtimeModelParam || '(none)'}"`);
+    } else {
+      log(`Model via UI (no URL param): requested="${resolvedModel}"`);
+    }
+
+    // Helpful debug: what the UI currently shows
+    const currentModelInfo = await readCurrentModelInfo(cdp).catch(() => ({ found: false, label: '', modelId: '' }));
+
+    log(`AI Studio URL: ${runtimeUrl}`);
+    if (currentModelInfo?.label) {
+      log(`AI Studio UI model label: ${currentModelInfo.label.slice(0, 120)}`);
+    }
+    if (currentModelInfo?.modelId) {
+      log(`AI Studio UI model id: ${currentModelInfo.modelId}`);
+    }
+
+    let modelApplied = false;
+
+    if (usedUrlParam && runtimeModelParam === resolvedModel) {
+      modelApplied = true;
+      log(`Model confirmed by URL param: ${runtimeModelParam}`);
+    }
+
+    if (!modelApplied && usedUrlParam) {
+      try {
+        modelApplied = await waitForModelToApply(cdp, resolvedModel, log);
+      } catch (e) {
+        log(`Model apply wait failed: ${e.message}`);
+      }
+    }
+
+    if (!modelApplied) {
+      try {
+        log(`Attempting UI model selection fallback: ${resolvedModel}`);
+        await selectModel(cdp, resolvedModel, log);
+        modelApplied = await waitForModelToApply(cdp, resolvedModel, log, 10000);
+      } catch (e) {
+        log(`UI model selection fallback failed: ${e.message}`);
+      }
+    }
+
+    await closeModelSelectorIfOpen(cdp, log);
+
+    // Type prompt
+    await typePrompt(cdp, inputCdp, prompt);
+    log("Prompt typed");
+
+    // Submit
+    await submitPrompt(cdp, inputCdp);
+    log("Submitted, waiting for response...");
+
+    // Wait for response
+    let response;
+
+    if (typeof readNetworkEntries === 'function') {
+      try {
+        const networkResult = await waitForGenerateResponseFromNetwork({
+          tabId,
+          readNetworkEntries,
+          timeoutMs: timeout,
+          baselineEntryIds: baselineGenerateEntryIds,
+          prompt,
+          log,
+        });
+
+        response = {
+          text: networkResult.text,
+          thinkingTime: null,
+          url: '',
+          partial: false,
+        };
+
+        log(
+          `Network response: ${response.text.length} chars` +
+          `${networkResult.requestId ? ` (request ${networkResult.requestId})` : ''}`
+        );
+      } catch (networkErr) {
+        log(`Network extraction failed, falling back to DOM: ${networkErr.message || networkErr}`);
+
+        const remainingTimeoutMs = Math.max(timeout - (Date.now() - startTime), 10000);
+        response = await waitForResponse(cdp, remainingTimeoutMs, prompt, log);
+      }
+    } else {
+      response = await waitForResponse(cdp, timeout, prompt, log);
+    }
+
+    const thinkingInfo = response.thinkingTime ? ` (thought for ${response.thinkingTime}s)` : '';
+    log(`Response: ${response.text.length} chars${thinkingInfo}${response.partial ? ' (partial)' : ''}`);
+
+    return {
+      response: response.text,
+      model: resolvedModel,
+      thinkingTime: response.thinkingTime,
+      url: response.url,
+      partial: response.partial || false,
+      tookMs: Date.now() - startTime,
+    };
+  } finally {
+    await closeTab(tabId).catch(() => {});
+  }
+}
+
+// ============================================================================
+// Exports
+// ============================================================================
+
+module.exports = {
+  query,
+  hasRequiredCookies,
+  buildAiStudioUrl,
+};

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -9,6 +9,7 @@ const networkFormatters = require("./formatters/network.cjs");
 const networkStore = require("./network-store.cjs");
 const { parseDoCommands } = require("./do-parser.cjs");
 const { executeDoSteps } = require("./do-executor.cjs");
+const { formatJsonOutput } = require("./json-output.cjs");
 
 const SOCKET_PATH = "/tmp/surf.sock";
 
@@ -412,6 +413,20 @@ const TOOLS = {
           { cmd: 'grok "quick question" --model fast', desc: "Faster model" },
           { cmd: 'grok --validate', desc: "Check UI and list available models" },
           { cmd: 'grok --validate --save-models', desc: "Save discovered models to settings" },
+        ]
+      },
+      "aistudio": {
+        desc: "Query via Google AI Studio (uses browser session)",
+        args: ["query"],
+        opts: {
+          "with-page": "Include current page context",
+          model: "Model (best-effort): pass an AI Studio model id like gemini-3-pro-preview, gemini-3-flash-preview, gemini-flash-lite-latest. If invalid, AI Studio uses the last-selected UI model",
+          timeout: "Timeout in seconds (default: 300)"
+        },
+        examples: [
+          { cmd: 'aistudio "explain quantum computing"', desc: "Basic query" },
+          { cmd: 'aistudio "redteam this" --with-page', desc: "With page context" },
+          { cmd: 'aistudio "quick answer" --model gemini-3-flash-preview', desc: "Model selection" },
         ]
       },
       "ai": { 
@@ -2485,6 +2500,7 @@ const PRIMARY_ARG_MAP = {
   chatgpt: "query",
   perplexity: "query",
   grok: "query",
+  aistudio: "query",
   navigate: "url",
   go: "url",
   js: "code",
@@ -2851,7 +2867,7 @@ const socket = net.createConnection(SOCKET_PATH, () => {
   socket.write(JSON.stringify(request) + "\n");
 });
 
-const AI_TOOLS = ["smoke", "chatgpt", "gemini", "perplexity", "grok", "ai"];
+const AI_TOOLS = ["smoke", "chatgpt", "gemini", "perplexity", "grok", "aistudio", "ai"];
 const requestTimeout = AI_TOOLS.includes(tool) ? 300000 : 30000;
 const timeout = setTimeout(() => {
   console.error(`Error: Request timed out (${requestTimeout / 1000}s)`);
@@ -2934,8 +2950,12 @@ async function handleResponse(response) {
     data = result || response.result;
   }
 
+  if (tool === 'aistudio' && typeof data === 'string') {
+    data = { response: data };
+  }
+
   if (wantJson) {
-    console.log(JSON.stringify(data, null, 2));
+    console.log(formatJsonOutput(data));
     socket.end();
     process.exit(0);
   }
@@ -3105,6 +3125,16 @@ async function handleResponse(response) {
       console.log(`\nImage saved: ${data.imagePath}`);
     }
     console.error(`\n[${data.model || 'unknown'} | ${((data.tookMs || 0) / 1000).toFixed(1)}s]`);
+  } else if (tool === "aistudio" && data?.response) {
+    console.log(data.response);
+
+    const meta = [];
+    if (data.model) meta.push(data.model);
+    if (data.thinkingTime) meta.push(`thought ${data.thinkingTime}s`);
+    if (Number.isFinite(data.tookMs)) meta.push(`${(data.tookMs / 1000).toFixed(1)}s`);
+    if (meta.length > 0) {
+      console.error(`\n[${meta.join(' | ')}]`);
+    }
   } else if (tool === "perplexity" && data?.response) {
     console.log(data.response);
     const meta = [];

--- a/native/host-helpers.cjs
+++ b/native/host-helpers.cjs
@@ -2,6 +2,10 @@ const fs = require("fs");
 const networkFormatters = require("./formatters/network.cjs");
 const networkStore = require("./network-store.cjs");
 
+function normalizeModelString(model) {
+  return String(model || "").trim().toLowerCase();
+}
+
 /**
  * Format tool result content for MCP response
  * @param {*} result - The result object from the extension
@@ -1070,6 +1074,18 @@ function mapToolToMessage(tool, args, tabId) {
         timeout: a.timeout ? parseInt(a.timeout, 10) * 1000 : 300000,
         ...baseMsg
       };
+    case "aistudio": {
+      if (!a.query) throw new Error("query required");
+
+      return {
+        type: "AISTUDIO_QUERY",
+        query: a.query,
+        model: a.model ? normalizeModelString(a.model) : "gemini-3-pro-preview",
+        withPage: a["with-page"],
+        timeout: a.timeout ? parseInt(a.timeout, 10) * 1000 : 300000,
+        ...baseMsg
+      };
+    }
     case "window.new":
       return { 
         type: "WINDOW_NEW", 

--- a/native/host.cjs
+++ b/native/host.cjs
@@ -10,6 +10,7 @@ const chatgptClient = require("./chatgpt-client.cjs");
 const geminiClient = require("./gemini-client.cjs");
 const perplexityClient = require("./perplexity-client.cjs");
 const grokClient = require("./grok-client.cjs");
+const aistudioClient = require("./aistudio-client.cjs");
 const { mapToolToMessage, mapComputerAction, formatToolContent } = require("./host-helpers.cjs");
 
 const SOCKET_PATH = "/tmp/surf.sock";
@@ -285,6 +286,116 @@ async function handleApiRequest(msg, sendResponse) {
 const log = (msg) => {
   fs.appendFileSync(LOG_FILE, `${new Date().toISOString()} ${msg}\n`);
 };
+
+function redactForLog(value, depth = 0) {
+  if (depth > 6) return "[Truncated]";
+
+  const OMIT_STRING_KEYS = new Set([
+    "base64",
+    "pagecontent",
+    "text",
+    "requestbody",
+    "responsebody",
+  ]);
+
+  const SUMMARIZE_ARRAY_KEYS = new Set(["entries", "requests"]);
+
+  const truncate = (input, max = 200) => {
+    const text = String(input || "");
+    return text.length > max
+      ? `${text.slice(0, max)}…<${text.length - max} more chars>`
+      : text;
+  };
+
+  if (Array.isArray(value)) {
+    return value.map((v) => redactForLog(v, depth + 1));
+  }
+
+  if (value && typeof value === "object") {
+    const out = {};
+
+    for (const [key, child] of Object.entries(value)) {
+      const lower = key.toLowerCase();
+
+      // Avoid logging credentials/secrets
+      if (
+        lower.includes("token") ||
+        lower.includes("authorization") ||
+        lower.includes("password") ||
+        lower.includes("secret") ||
+        lower === "auth"
+      ) {
+        out[key] = "<redacted>";
+        continue;
+      }
+
+      // Cookie payloads from extension contain session cookies; log only safe metadata
+      if (lower === "cookies" && Array.isArray(child)) {
+        out[key] = child.map((c) => {
+          if (!c || typeof c !== "object") return c;
+          return {
+            name: c.name,
+            domain: c.domain,
+            path: c.path,
+            secure: c.secure,
+            httpOnly: c.httpOnly,
+            sameSite: c.sameSite,
+            expirationDate: c.expirationDate,
+          };
+        });
+        continue;
+      }
+
+      // Individual cookie objects sometimes appear inline
+      if (
+        lower === "value" &&
+        typeof value.name === "string" &&
+        typeof value.domain === "string"
+      ) {
+        out[key] = "<redacted>";
+        continue;
+      }
+
+      // Omit or summarize high-volume/sensitive fields (prompts, model output, screenshots, full network dumps)
+      if (typeof child === "string") {
+        if (OMIT_STRING_KEYS.has(lower)) {
+          out[key] = `<omitted ${child.length} chars>`;
+          continue;
+        }
+
+        out[key] = truncate(child);
+        continue;
+      }
+
+      if (SUMMARIZE_ARRAY_KEYS.has(lower) && Array.isArray(child)) {
+        out[key] = {
+          count: child.length,
+          sample: child.slice(0, 3).map((entry) => ({
+            id: entry?.id,
+            method: entry?.method,
+            status: entry?.status,
+            url: entry?.url,
+          })),
+        };
+        continue;
+      }
+
+      out[key] = redactForLog(child, depth + 1);
+    }
+
+    return out;
+  }
+
+  return value;
+}
+
+function safeStringifyForLog(value) {
+  try {
+    return JSON.stringify(redactForLog(value));
+  } catch (e) {
+    return '"[unstringifiable]"';
+  }
+}
 
 log("Host starting...");
 
@@ -911,6 +1022,121 @@ function handleToolRequest(msg, socket) {
     return;
   }
   
+  if (extensionMsg.type === "AISTUDIO_QUERY") {
+    const { query, model, withPage, timeout } = extensionMsg;
+    
+    queueAiRequest(async () => {
+      const EXT_CALL_TIMEOUT_MS = 30000;
+
+      const callExtension = (toolName, msg, timeoutMs = EXT_CALL_TIMEOUT_MS) => new Promise((resolve, reject) => {
+        const id = ++requestCounter;
+
+        if (msg && msg.type === "AISTUDIO_NEW_TAB") {
+          log(`[aistudio] Opening tab: ${(msg.url || "https://aistudio.google.com/prompts/new_chat")}`);
+        }
+
+        const timeoutId = setTimeout(() => {
+          pendingToolRequests.delete(id);
+          reject(new Error(`Timeout waiting for extension: ${toolName}`));
+        }, timeoutMs);
+
+        pendingToolRequests.set(id, {
+          socket: null,
+          originalId: null,
+          tool: toolName,
+          onComplete: (r) => {
+            clearTimeout(timeoutId);
+            resolve(r);
+          }
+        });
+
+        writeMessage({ ...msg, id });
+      });
+
+      // 1. Get page context if requested
+      let pageContext = null;
+      if (withPage) {
+        const pageResult = await callExtension(
+          "get_page_text",
+          { type: "GET_PAGE_TEXT", tabId: extensionMsg.tabId },
+          45000
+        );
+
+        if (pageResult && !pageResult.error) {
+          pageContext = {
+            url: pageResult.url,
+            text: pageResult.text || pageResult.pageContent || ""
+          };
+        }
+      }
+
+      // 2. Build full prompt
+      let fullPrompt = query || "";
+      if (pageContext) {
+        const MAX_PAGE_CONTEXT_CHARS = 20000;
+        const pageText = String(pageContext.text || "");
+        const truncated = pageText.length > MAX_PAGE_CONTEXT_CHARS
+          ? pageText.slice(0, MAX_PAGE_CONTEXT_CHARS) + "\n\n[...truncated...]"
+          : pageText;
+
+        fullPrompt = `Page: ${pageContext.url}\n\n${truncated}\n\n---\n\n${fullPrompt}`;
+      }
+
+      // 3. Call AI Studio client
+      const result = await aistudioClient.query({
+        prompt: fullPrompt,
+        model: model || "gemini-3-pro-preview",
+        timeout: timeout || 300000,
+        getCookies: () => callExtension("get_cookies", { type: "GET_GOOGLE_COOKIES" }, 45000),
+        createTab: (url) => callExtension(
+          "create_tab",
+          { type: "AISTUDIO_NEW_TAB", url },
+          45000
+        ),
+        closeTab: (tabIdToClose) => callExtension(
+          "close_tab",
+          { type: "AISTUDIO_CLOSE_TAB", tabId: tabIdToClose },
+          45000
+        ),
+        cdpEvaluate: (tabId, expression) => callExtension(
+          "cdp_evaluate",
+          { type: "AISTUDIO_EVALUATE", tabId, expression }
+        ),
+        cdpCommand: (tabId, method, params) => callExtension(
+          "cdp_command",
+          { type: "AISTUDIO_CDP_COMMAND", tabId, method, params }
+        ),
+        readNetworkEntries: (tabIdToRead) => callExtension(
+          "read_network_entries",
+          {
+            type: "READ_NETWORK_REQUESTS",
+            tabId: tabIdToRead,
+            full: true,
+            limit: 100,
+            urlPattern: "MakerSuiteService/GenerateContent"
+          },
+          45000
+        ),
+        log: (msg) => log(`[aistudio] ${msg}`)
+      });
+
+      return result;
+    }).then((result) => {
+      const payload = {
+        response: result.response,
+        model: result.model,
+        thinkingTime: result.thinkingTime,
+        tookMs: result.tookMs
+      };
+
+      sendToolResponse(socket, originalId, { output: JSON.stringify(payload) }, null);
+    }).catch((err) => {
+      sendToolResponse(socket, originalId, null, err.message);
+    });
+    
+    return;
+  }
+  
   if (extensionMsg.type === "EXECUTE_KEY_REPEAT") {
     const { key, repeat, tabId: tid } = extensionMsg;
     let completed = 0;
@@ -1109,7 +1335,7 @@ function processInput() {
     
     try {
       const msg = JSON.parse(jsonStr);
-      log(`Received from extension: ${JSON.stringify(msg)}`);
+      log(`Received from extension: ${safeStringifyForLog(msg)}`);
       
       if (msg.type === "GET_AUTH") {
         log("Handling GET_AUTH from extension");

--- a/native/json-output.cjs
+++ b/native/json-output.cjs
@@ -1,0 +1,7 @@
+function formatJsonOutput(value) {
+  return JSON.stringify(value === undefined ? null : value, null, 2);
+}
+
+module.exports = {
+  formatJsonOutput,
+};

--- a/skills/surf/SKILL.md
+++ b/skills/surf/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: surf
-description: Control Chrome browser via CLI for testing, automation, and debugging. Use when the user needs browser automation, screenshots, form filling, page inspection, network/CPU emulation, DevTools streaming, or AI queries via ChatGPT/Gemini/Perplexity/Grok.
+description: Control Chrome browser via CLI for testing, automation, and debugging. Use when the user needs browser automation, screenshots, form filling, page inspection, network/CPU emulation, DevTools streaming, or AI queries via ChatGPT/Gemini/AI Studio/Perplexity/Grok.
 ---
 
 # Surf Browser Automation
@@ -61,6 +61,13 @@ surf gemini "hello" --model gemini-2.5-flash      # Models: gemini-3-pro (defaul
 surf gemini "wide banner" --generate-image /tmp/banner.png --aspect-ratio 16:9
 ```
 
+### Gemini via AI Studio (mind the rate limits)
+```bash
+surf aistudio "hi gemini"                                    # Defaults to using gemini-3-pro-preview
+surf aistudio "redteam the arguments here" --with-page       # Include page context
+surf aistudio "quick answer" --model gemini-3-flash-preview  # Use a different model
+```
+
 ### Perplexity
 ```bash
 surf perplexity "what is quantum computing"
@@ -72,7 +79,7 @@ surf perplexity "latest news" --model sonar       # Model selection (Pro)
 ### Grok (via x.com - requires X.com login in Chrome)
 ```bash
 surf grok "what are the latest AI trends on X"    # Search X posts
-surf grok "analyze @username recent activity"     # Profile analysis  
+surf grok "analyze @username recent activity"     # Profile analysis
 surf grok "summarize this page" --with-page       # Include page context
 surf grok "find viral AI posts" --deep-search     # DeepSearch mode
 surf grok "quick question" --model fast           # Models: auto, fast, expert, thinking (default)
@@ -230,7 +237,7 @@ surf element.styles ".card"            # Or by CSS selector
 
 ```bash
 surf scroll.bottom
-surf scroll.top  
+surf scroll.top
 surf scroll.to --y 500         # Scroll to Y position
 surf scroll.to --ref e5        # Scroll element into view
 surf scroll.by --y 200         # Scroll by amount
@@ -264,7 +271,7 @@ surf dialog.dismiss            # Dismiss (Cancel)
 surf emulate.network slow-3g   # Presets: slow-3g, fast-3g, 4g, offline
 surf emulate.network reset     # Disable throttling
 
-# CPU throttling  
+# CPU throttling
 surf emulate.cpu 4             # 4x slower
 surf emulate.cpu 1             # Reset
 
@@ -467,17 +474,17 @@ surf workflow.validate workflow.json
   "steps": [
     // Capture step output for later use
     { "tool": "js", "args": { "code": "return [1,2,3]" }, "as": "items" },
-    
+
     // Fixed iterations
     { "repeat": 5, "steps": [
       { "tool": "click", "args": { "ref": "e5" } }
     ]},
-    
+
     // Iterate over array
     { "each": "%{items}", "as": "item", "steps": [
       { "tool": "js", "args": { "code": "console.log('%{item}')" } }
     ]},
-    
+
     // Repeat until condition
     { "repeat": 20, "until": { "tool": "js", "args": { "code": "return done" } }, "steps": [...] }
   ]
@@ -515,7 +522,7 @@ surf wait.element ".missing" --auto-capture --timeout 2000
 ```bash
 --tab-id <id>         # Target specific tab
 --window-id <id>      # Target specific window
---json                # Raw JSON output  
+--json                # Raw JSON output
 --auto-capture        # Screenshot + console on error
 --timeout <ms>        # Override default timeout
 ```

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -1843,10 +1843,10 @@ export async function handleMessage(
           cdp.clearNetworkRequests(tabId);
         }
         
-        // Return entries sliced to limit
+        // Return most recent entries sliced to limit
         const limit = message.limit || 100;
         return { 
-          entries: entries.slice(0, limit),
+          entries: entries.slice(-limit),
           format: message.format,
           verbose: message.verbose
         };
@@ -2802,8 +2802,61 @@ export async function handleMessage(
       return result;
     }
 
+    case "AISTUDIO_NEW_TAB": {
+      const url = message.url || "https://aistudio.google.com/prompts/new_chat";
+      const tab = await chrome.tabs.create({
+        url,
+        active: true,
+      });
+      if (!tab.id) throw new Error("Failed to create tab");
+      const currentTab = await chrome.tabs.get(tab.id);
+      if (currentTab.status !== "complete") {
+        await new Promise<void>((resolve) => {
+          const listener = (tabId: number, info: chrome.tabs.TabChangeInfo) => {
+            if (tabId === tab.id && info.status === "complete") {
+              chrome.tabs.onUpdated.removeListener(listener);
+              resolve();
+            }
+          };
+          chrome.tabs.onUpdated.addListener(listener);
+          setTimeout(() => {
+            chrome.tabs.onUpdated.removeListener(listener);
+            resolve();
+          }, 30000);
+        });
+      }
+      await cdp.attach(tab.id);
+      // Wait for JS runtime to be ready after CDP attach
+      await waitForRuntimeReady(tab.id, 10000);
+      return { tabId: tab.id };
+    }
+
+    case "AISTUDIO_CLOSE_TAB": {
+      const studioTabId = message.tabId;
+      if (studioTabId) {
+        try {
+          await cdp.detach(studioTabId);
+        } catch {}
+        try {
+          await chrome.tabs.remove(studioTabId);
+        } catch {}
+      }
+      return { success: true };
+    }
+
+    case "AISTUDIO_CDP_COMMAND": {
+      const { method, params } = message;
+      const result = await cdp.sendCommand(message.tabId, method, params || {});
+      return result;
+    }
+
+    case "AISTUDIO_EVALUATE": {
+      const result = await cdp.evaluateScript(message.tabId, message.expression);
+      return result;
+    }
+
     case "GET_GOOGLE_COOKIES": {
-      // Gemini requires cookies from multiple Google domains
+      // Gemini and AI Studio require cookies from multiple Google domains
       const domains = [".google.com", ".gemini.google.com", "accounts.google.com", "www.google.com"];
       const allCookies: chrome.cookies.Cookie[] = [];
       
@@ -2815,7 +2868,7 @@ export async function handleMessage(
       }
       
       // Also try by URL for better coverage
-      const urls = ["https://gemini.google.com", "https://accounts.google.com", "https://www.google.com"];
+      const urls = ["https://gemini.google.com", "https://aistudio.google.com", "https://accounts.google.com", "https://www.google.com"];
       for (const url of urls) {
         try {
           const cookies = await chrome.cookies.getAll({ url });
@@ -2951,6 +3004,7 @@ const COMMANDS_WITHOUT_TAB = new Set([
   "GET_CHATGPT_COOKIES", "GET_GOOGLE_COOKIES", "GET_TWITTER_COOKIES",
   "PERPLEXITY_NEW_TAB", "PERPLEXITY_CLOSE_TAB", "PERPLEXITY_EVALUATE", "PERPLEXITY_CDP_COMMAND",
   "GROK_NEW_TAB", "GROK_CLOSE_TAB", "GROK_EVALUATE", "GROK_CDP_COMMAND",
+  "AISTUDIO_NEW_TAB", "AISTUDIO_CLOSE_TAB", "AISTUDIO_EVALUATE", "AISTUDIO_CDP_COMMAND",
   "WINDOW_NEW", "WINDOW_LIST", "WINDOW_FOCUS", "WINDOW_CLOSE", "WINDOW_RESIZE",
   "EMULATE_DEVICE_LIST"
 ]);

--- a/test/unit/cli-json-output.test.ts
+++ b/test/unit/cli-json-output.test.ts
@@ -1,0 +1,29 @@
+import { createRequire } from 'node:module';
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const { formatJsonOutput } = require('../../native/json-output.cjs');
+
+describe('formatJsonOutput', () => {
+    it('emits valid JSON for string output', () => {
+        const output = formatJsonOutput('OK');
+        expect(() => JSON.parse(output)).not.toThrow();
+        expect(JSON.parse(output)).toBe('OK');
+    });
+
+    it('emits valid JSON for undefined', () => {
+        const output = formatJsonOutput(undefined);
+        expect(JSON.parse(output)).toBeNull();
+    });
+
+    it('emits valid JSON for objects', () => {
+        const payload = { ok: true, n: 3 };
+        const output = formatJsonOutput(payload);
+        expect(JSON.parse(output)).toEqual(payload);
+    });
+
+    it('escapes quotes correctly', () => {
+        const output = formatJsonOutput('He said "hi"');
+        expect(JSON.parse(output)).toBe('He said "hi"');
+    });
+});

--- a/test/unit/host-helpers.test.ts
+++ b/test/unit/host-helpers.test.ts
@@ -64,6 +64,24 @@ describe("mapToolToMessage", () => {
     });
   });
 
+  describe("aistudio commands", () => {
+    it("maps aistudio to AISTUDIO_QUERY with default model", () => {
+      const msg = helpers.mapToolToMessage("aistudio", { query: "hi" });
+      expect(msg.type).toBe("AISTUDIO_QUERY");
+      expect(msg.model).toBe("gemini-3-pro-preview");
+    });
+
+    it("normalizes aistudio model to lowercase", () => {
+      const msg = helpers.mapToolToMessage("aistudio", { query: "hi", model: "GEMINI-3-FLASH-PREVIEW" });
+      expect(msg.model).toBe("gemini-3-flash-preview");
+    });
+
+    it("does not validate aistudio model ids (passes through)", () => {
+      const msg = helpers.mapToolToMessage("aistudio", { query: "hi", model: "gemini-flash-lite-latest" });
+      expect(msg.model).toBe("gemini-flash-lite-latest");
+    });
+  });
+
   describe("error cases", () => {
     it("returns null for unknown tool", () => {
       expect(helpers.mapToolToMessage("unknown.command", {})).toBeNull();


### PR DESCRIPTION
This adds an AI Studio (aistudio.google.com) provider so `surf aistudio "<prompt>"` can drive the Playground UI via the existing Chrome extension + native host bridge, returning the model’s final answer directly in the terminal.  The motivation for adding this (over the existing Gemini provider) is that, when accessed via AI Studio, the Gemini models are not as nerfed as they are from the consumer-facing Gemini experience.  For Gemini 3 Pro the difference can be very meaningful with certain prompts.  The downside is aggressive per-day rate limiting for the Gemini 3 Pro and Gemini 3 Flash models when accessed this way.

Response extraction is network-first by parsing the `MakerSuiteService/GenerateContent` RPC payload from captured network entries, with a DOM-based fallback (`waitForResponse`) to keep the provider working when network capture or RPC parsing fails.  The host log redaction is also hardened to avoid writing prompts/model outputs and large payloads to disk.

Summary of changes:
  - add `native/aistudio-client.cjs` CDP-driven client: open new chat, best-effort model selection, enable Raw Markdown view, type + submit prompts, network-first GenerateContent parsing (final-response only) with DOM fallback
  - extension/service-worker: support richer network entry export for AI Studio polling and return the most recent entries in the `READ_NETWORK_REQUESTS` full path (plus `urlPattern` filtering)
  - native host: route `AISTUDIO_QUERY`, optionally prepend page context (`--with-page`), filter network polling to GenerateContent via `urlPattern`, and harden `redactForLog` to omit/summarize high-volume sensitive fields (request/response bodies, page text, screenshots, network dumps)
  - CLI: register `surf aistudio` command/help, make `--json` always emit valid JSON via a shared formatter
  - docs: update `README.md` + `skills/surf/SKILL.md` with AI Studio examples, default model behavior, and rate-limit caution
  - tests: add minimal unit coverage for JSON output formatting (`test/unit/cli-json-output.test.ts`)