### PR TITLE
feat: add Windows support for socket communication

### DIFF
--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -10,7 +10,9 @@ const networkStore = require("./network-store.cjs");
 const { parseDoCommands } = require("./do-parser.cjs");
 const { executeDoSteps } = require("./do-executor.cjs");
 
-const SOCKET_PATH = "/tmp/surf.sock";
+const SOCKET_PATH = process.platform === "win32"
+  ? "\\\\.\\pipe\\surf-sock"
+  : path.join(os.tmpdir(), "surf.sock");
 
 // ============================================================================
 // Workflow Resolution and Management

--- a/native/do-executor.cjs
+++ b/native/do-executor.cjs
@@ -11,8 +11,12 @@
  */
 
 const net = require("net");
+const os = require("os");
+const path = require("path");
 
-const SOCKET_PATH = "/tmp/surf.sock";
+const SOCKET_PATH = process.platform === "win32"
+  ? "\\\\.\\pipe\\surf-sock"
+  : path.join(os.tmpdir(), "surf.sock");
 
 // Maximum iterations for loops (safety cap)
 const MAX_LOOP_ITERATIONS = 100;

--- a/native/host.cjs
+++ b/native/host.cjs
@@ -12,7 +12,9 @@ const perplexityClient = require("./perplexity-client.cjs");
 const grokClient = require("./grok-client.cjs");
 const { mapToolToMessage, mapComputerAction, formatToolContent } = require("./host-helpers.cjs");
 
-const SOCKET_PATH = "/tmp/surf.sock";
+const SOCKET_PATH = process.platform === "win32"
+  ? "\\\\.\\pipe\\surf-sock"
+  : path.join(os.tmpdir(), "surf.sock");
 
 // Cross-platform image resize (macOS: sips, Linux: ImageMagick)
 function resizeImage(filePath, maxSize) {
@@ -73,7 +75,9 @@ async function processAiQueue() {
     setTimeout(processAiQueue, 2000);
   }
 }
-const LOG_FILE = "/tmp/surf-host.log";
+const LOG_FILE = process.platform === "win32"
+  ? path.join(os.tmpdir(), "surf-host.log")
+  : "/tmp/surf-host.log";
 const AUTH_FILE = path.join(os.homedir(), ".pi", "agent", "auth.json");
 
 const DEFAULT_RETRY_OPTIONS = {

--- a/native/mcp-server.cjs
+++ b/native/mcp-server.cjs
@@ -1,10 +1,14 @@
 #!/usr/bin/env node
 const net = require("net");
+const os = require("os");
+const path = require("path");
 const { McpServer } = require("@modelcontextprotocol/sdk/server/mcp.js");
 const { StdioServerTransport } = require("@modelcontextprotocol/sdk/server/stdio.js");
 const { z } = require("zod");
 
-const SOCKET_PATH = "/tmp/surf.sock";
+const SOCKET_PATH = process.platform === "win32"
+  ? "\\\\.\\pipe\\surf-sock"
+  : path.join(os.tmpdir(), "surf.sock");
 const REQUEST_TIMEOUT = 30000;
 
 const TOOL_SCHEMAS = {


### PR DESCRIPTION
## Summary

- Replace hardcoded `/tmp/surf.sock` Unix socket paths with platform-conditional logic
- Use Windows named pipes (`\.\pipe\surf-sock`) on `win32`, `os.tmpdir()` on Unix
- Fix `LOG_FILE` in `host.cjs` to use `os.tmpdir()` on Windows
- Add missing `os` and `path` imports to `do-executor.cjs` and `mcp-server.cjs`

Fixes #43
Related to #42 (same user-facing error, different root cause — Windows path vs macOS socket creation)

## Changes

4 files in `native/`:

| File | Change |
|------|--------|
| `cli.cjs` | `SOCKET_PATH` → platform conditional |
| `do-executor.cjs` | `SOCKET_PATH` → platform conditional + added `os`/`path` imports |
| `host.cjs` | `SOCKET_PATH` + `LOG_FILE` → platform conditional |
| `mcp-server.cjs` | `SOCKET_PATH` → platform conditional + added `os`/`path` imports |

## Test plan

- [x] Tested on Windows 11 Pro with Node.js v22 — `surf tab.list` connects and returns Chrome tabs
- [x] Backward-compatible: Unix paths unchanged (uses `os.tmpdir()` which returns `/tmp` on Linux/macOS)