### PR TITLE
fix: use portable shebang in native messaging host wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **Native messaging host portability** - Generated Unix wrappers now use `#!/usr/bin/env bash` so Chrome can launch the host on NixOS, Guix, and other non-FHS Linux systems. (@ppetru)
+
 ## [2.6.0] - 2026-02-21
 
 ### Added

--- a/scripts/install-native-host.cjs
+++ b/scripts/install-native-host.cjs
@@ -129,7 +129,7 @@ function createWrapper(wrapperDir, nodePath, hostPath) {
   } else {
     const shPath = path.join(wrapperDir, "host-wrapper.sh");
     const hostDir = path.dirname(hostPath);
-    const content = `#!/bin/bash
+    const content = `#!/usr/bin/env bash
 cd "${hostDir}"
 exec "${nodePath}" "${hostPath}"
 `;


### PR DESCRIPTION
On NixOS (and other non-FHS Linux distributions like Guix), `/bin/bash` doesn't exist — all binaries live in the Nix store.

This causes Chrome's native messaging to fail with:

```

LaunchProcess: failed to execvp:
/home/user/.local/share/surf-cli/host-wrapper.sh

```

The fix changes the generated shebang from `#!/bin/bash` to `#!/usr/bin/env bash`, which is portable across all Unix-like systems.