### PR TITLE
fix(js): auto-return expression values in surf js

### DIFF
--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -1773,7 +1773,14 @@ export async function handleMessage(
         await cdp.evaluateScript(tabId, piHelpersCode);
         
         const escaped = message.code.replace(/`/g, "\\`").replace(/\$/g, "\\$");
-        const expression = `(async () => { 'use strict'; ${escaped} })()`;
+
+        // Auto-prepend return for single expressions so values are returned
+        const trimmedCode = message.code.trim();
+        const statementKeywords = /^(if|for|while|do|switch|try|const|let|var|function|class|throw|return)\b/;
+        const isExpression = !trimmedCode.includes(';') && !statementKeywords.test(trimmedCode);
+        const wrappedCode = isExpression ? `return ${escaped}` : escaped;
+
+        const expression = `(async () => { 'use strict'; ${wrappedCode} })()`;
         
         const result = await cdp.evaluateScript(tabId, expression);
         


### PR DESCRIPTION
Closes #51

## Summary
- Detects single-expression code (no semicolons, no statement keywords) and auto-prepends `return` so `surf js "1 + 1"` returns `2` instead of `"undefined"`
- Multi-statement code and side-effect calls continue to work as-is
- Heuristic: if code has no `;` and doesn't start with a statement keyword (`if`, `for`, `while`, `const`, `let`, `var`, `function`, `class`, `throw`, `return`, etc.), it's treated as an expression

## Test plan
- [ ] `surf js "1 + 1"` returns `2`
- [ ] `surf js "document.title"` returns page title
- [ ] `surf js "document.querySelectorAll('button').length"` returns count
- [ ] `surf js "const x = 1; x + 2"` still works (multi-statement)
- [ ] `surf js "console.log('hi')"` still works (side-effect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)