### PR TITLE
feat(cli): add positional direction/amount shorthand for scroll

### DIFF
--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -2574,6 +2574,18 @@ if (tool === "click" && firstArg) {
   }
 }
 
+if (tool === "scroll" && firstArg) {
+  if (firstArg === "top" || firstArg === "bottom") {
+    tool = `scroll.${firstArg}`;
+    firstArg = undefined;
+  } else if (["up", "down", "left", "right"].includes(firstArg)) {
+    toolArgs.scroll_direction = firstArg;
+    const px = positional[2] ? parseInt(positional[2], 10) : 300;
+    toolArgs.scroll_amount = Math.max(1, Math.round(px / 100));
+    firstArg = undefined;
+  }
+}
+
 if (firstArg !== undefined) {
   const primaryKey = PRIMARY_ARG_MAP[tool];
   if (primaryKey && toolArgs[primaryKey] === undefined) {


### PR DESCRIPTION
Closes #52

## Summary
- `surf scroll down 800` now works — maps positional args to `scroll_direction` and `scroll_amount`
- `surf scroll top` and `surf scroll bottom` reroute to `scroll.top` / `scroll.bottom`
- Default scroll amount is 300px when no pixel value specified
- Supports all directions: up, down, left, right

## Test plan
- [ ] `surf scroll down 800` scrolls down ~800px
- [ ] `surf scroll up 400` scrolls up ~400px
- [ ] `surf scroll top` scrolls to top
- [ ] `surf scroll bottom` scrolls to bottom
- [ ] `surf scroll down` (no amount) uses default 300px

🤖 Generated with [Claude Code](https://claude.com/claude-code)