### PR TITLE
fix(cli): recognize --full-page as alias for --fullpage

### DIFF
--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -2414,7 +2414,7 @@ if (args[0] === "workflow.validate") {
   }
 }
 
-const BOOLEAN_FLAGS = ["auto-capture", "json", "stream", "dry-run", "stop-on-error", "fail-fast", "clear", "submit", "all", "case-sensitive", "hard", "annotate", "fullpage", "reset", "no-screenshot", "full", "soft-fail", "has-body", "exclude-static", "v", "vv", "request", "by-tab", "har", "jsonl", "no-save", "no-auto-wait"];
+const BOOLEAN_FLAGS = ["auto-capture", "json", "stream", "dry-run", "stop-on-error", "fail-fast", "clear", "submit", "all", "case-sensitive", "hard", "annotate", "fullpage", "full-page", "reset", "no-screenshot", "full", "soft-fail", "has-body", "exclude-static", "v", "vv", "request", "by-tab", "har", "jsonl", "no-save", "no-auto-wait"];
 
 const AUTO_SCREENSHOT_TOOLS = ["click", "type", "key", "smart_type", "form.fill", "form_input", "drag", "hover", "scroll", "scroll.top", "scroll.bottom", "scroll.to", "dialog.accept", "dialog.dismiss", "js", "eval"];
 
@@ -2459,6 +2459,13 @@ const parseArgs = (rawArgs) => {
 };
 
 let { positional, options } = parseArgs(args);
+
+// Normalize hyphenated flag aliases
+if (options["full-page"]) {
+  options.fullpage = true;
+  delete options["full-page"];
+}
+
 let tool = positional[0];
 let firstArg = positional[1];
 


### PR DESCRIPTION
Closes #53

## Summary
- Adds `full-page` to `BOOLEAN_FLAGS` so `--full-page` is recognized as a boolean flag
- Normalizes `options["full-page"]` to `options.fullpage` after argument parsing
- Both `--fullpage` and `--full-page` now work for full-page screenshots

## Test plan
- [ ] `surf screenshot --full-page /tmp/test.png` captures full page
- [ ] `surf screenshot --fullpage /tmp/test.png` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)