### PR TITLE
feat(cli): support space-separated cookie subcommands

### DIFF
--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -2475,6 +2475,16 @@ if (REMOVED_COMMANDS[tool]) {
 
 tool = ALIASES[tool] || tool;
 
+// Join space-separated subcommands: "cookie list" -> "cookie.list"
+if (tool === "cookie" && firstArg && ["list", "get", "set", "clear", "delete"].includes(firstArg)) {
+  if (firstArg === "delete") {
+    tool = "cookie.clear";
+  } else {
+    tool = `cookie.${firstArg}`;
+  }
+  firstArg = undefined;
+}
+
 // Auto-save screenshots to temp file when no --output specified
 // This ensures agents always get a usable file path, not just an in-memory ID
 // Can be disabled with --no-save flag or autoSaveScreenshots: false in surf.json
@@ -2559,6 +2569,8 @@ const PRIMARY_ARG_MAP = {
   "frame.js": "code",
   "element.styles": "selector",
   "select": "selector",
+  "cookie.get": "name",
+  "cookie.clear": "name",
 };
 
 const toolArgs = { ...options };


### PR DESCRIPTION
Closes #54

## Summary
- `surf cookie list` now works (joins to `cookie.list`)
- `surf cookie get "name"` maps positional arg to `--name`
- `surf cookie delete "name"` routes to `cookie.clear`
- Adds `cookie.get` and `cookie.clear` to `PRIMARY_ARG_MAP` for positional arg support

## Test plan
- [ ] `surf cookie list` lists cookies
- [ ] `surf cookie get "session_id"` returns specific cookie
- [ ] `surf cookie set --name "x" --value "y"` sets a cookie
- [ ] `surf cookie delete "x"` removes the cookie
- [ ] `surf cookie clear --all` clears all cookies
- [ ] `surf cookie.list` still works (dot notation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)