### PR TITLE
feat(cli): add positional width/height shorthand for resize

### DIFF
--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -2574,6 +2574,14 @@ if (tool === "click" && firstArg) {
   }
 }
 
+if (tool === "resize" && firstArg) {
+  toolArgs.width = parseInt(firstArg, 10);
+  if (positional[2]) {
+    toolArgs.height = parseInt(positional[2], 10);
+  }
+  firstArg = undefined;
+}
+
 if (firstArg !== undefined) {
   const primaryKey = PRIMARY_ARG_MAP[tool];
   if (primaryKey && toolArgs[primaryKey] === undefined) {


### PR DESCRIPTION
Closes #56

## Summary
- `surf resize 375 812` now works as shorthand for `surf resize --width 375 --height 812`
- Single positional arg sets width only: `surf resize 375`

## Test plan
- [ ] `surf resize 375 812` sets viewport to 375x812
- [ ] `surf resize 1920` sets width to 1920, keeps current height
- [ ] `surf resize --width 375 --height 812` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)