### PR TITLE
feat: support SURF_SOCKET env var for parallel agent sessions

### DIFF
--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -17,6 +17,64 @@ let SOCKET_PATH = process.env.SURF_SOCKET || (IS_WIN ? "//./pipe/surf" : "/tmp/s
 if (IS_WIN) { try { fs.mkdirSync(SURF_TMP, { recursive: true }); } catch {} }
 
 // ============================================================================
+// Browser Lock — serialize concurrent agent access to the same socket
+// Inspired by github.com/m13v/browser-lock (atomic mkdir mutex)
+// ============================================================================
+
+const LOCK_EXPIRY_MS = 30000;    // 30s — stale lock expiry
+const LOCK_POLL_MS = 500;        // poll interval while waiting
+const LOCK_MAX_WAIT_MS = 60000;  // give up after 60s
+
+function getLockDir() {
+  const hash = require("crypto").createHash("md5").update(SOCKET_PATH).digest("hex").slice(0, 12);
+  return path.join(SURF_TMP, `surf-lock-${hash}.d`);
+}
+
+function tryAcquireLock(lockDir) {
+  try {
+    fs.mkdirSync(lockDir);
+    fs.writeFileSync(path.join(lockDir, "info"), JSON.stringify({ pid: process.pid, timestamp: Date.now() }));
+    return true;
+  } catch (e) {
+    if (e.code !== "EEXIST") throw e;
+    try {
+      const info = JSON.parse(fs.readFileSync(path.join(lockDir, "info"), "utf8"));
+      if (Date.now() - info.timestamp > LOCK_EXPIRY_MS) {
+        try { fs.unlinkSync(path.join(lockDir, "info")); } catch {}
+        try { fs.rmdirSync(lockDir); } catch {}
+        return tryAcquireLock(lockDir);
+      }
+    } catch {
+      try {
+        const stat = fs.statSync(lockDir);
+        if (Date.now() - stat.mtimeMs > LOCK_EXPIRY_MS) {
+          try { fs.unlinkSync(path.join(lockDir, "info")); } catch {}
+          try { fs.rmdirSync(lockDir); } catch {}
+          return tryAcquireLock(lockDir);
+        }
+      } catch {}
+    }
+    return false;
+  }
+}
+
+function acquireLock() {
+  const lockDir = getLockDir();
+  const deadline = Date.now() + LOCK_MAX_WAIT_MS;
+  while (Date.now() < deadline) {
+    if (tryAcquireLock(lockDir)) return true;
+    try { execSync(`sleep 0.5`, { stdio: "ignore" }); } catch {}
+  }
+  return false;
+}
+
+function releaseLock() {
+  const lockDir = getLockDir();
+  try { fs.unlinkSync(path.join(lockDir, "info")); } catch {}
+  try { fs.rmdirSync(lockDir); } catch {}
+}
+
+// ============================================================================
 // Workflow Resolution and Management
 // ============================================================================
 
@@ -1813,10 +1871,12 @@ TIPS
   - Use --tab-id <id> to target a specific tab
   - Use --window-id <id> to isolate from user's browsing
 
-PARALLEL SESSIONS (multiple agents)
-  SURF_SOCKET=/tmp/surf-qa.sock surf navigate "URL"   Run agent on separate socket
-  surf --socket /tmp/surf-qa.sock navigate "URL"       Same via flag
-  NOTE: Each socket needs its own host process. Start host with SURF_SOCKET set.`);
+MULTI-AGENT WORKFLOWS
+  Built-in lock: surf serializes concurrent requests automatically.
+  Agents wait (up to 60s) if another agent is mid-request.
+  surf navigate "URL" --no-lock            Bypass lock if needed
+  Use --window-id to isolate agents in separate browser windows.
+  SURF_SOCKET=/tmp/surf-qa.sock surf ...   Custom socket path (advanced)`);
   process.exit(0);
 }
 
@@ -2487,7 +2547,7 @@ if (args[0] === "workflow.validate") {
   }
 }
 
-const BOOLEAN_FLAGS = ["auto-capture", "json", "stream", "dry-run", "stop-on-error", "fail-fast", "clear", "submit", "all", "case-sensitive", "hard", "annotate", "fullpage", "full-page", "reset", "no-screenshot", "full", "soft-fail", "has-body", "exclude-static", "v", "vv", "request", "by-tab", "har", "jsonl", "no-save", "no-auto-wait"];
+const BOOLEAN_FLAGS = ["auto-capture", "json", "stream", "dry-run", "stop-on-error", "fail-fast", "clear", "submit", "all", "case-sensitive", "hard", "annotate", "fullpage", "full-page", "reset", "no-screenshot", "full", "soft-fail", "has-body", "exclude-static", "v", "vv", "request", "by-tab", "har", "jsonl", "no-save", "no-auto-wait", "no-lock"];
 
 const AUTO_SCREENSHOT_TOOLS = ["click", "type", "key", "smart_type", "form.fill", "form_input", "drag", "hover", "scroll", "scroll.top", "scroll.bottom", "scroll.to", "dialog.accept", "dialog.dismiss", "js", "eval"];
 
@@ -3011,6 +3071,16 @@ const performAutoCapture = async () => {
     console.error(`Auto-capture failed: ${captureErr.message}`);
   }
 };
+
+// Acquire browser lock unless --no-lock
+const useLock = !options["no-lock"];
+if (useLock) {
+  if (!acquireLock()) {
+    console.error("Error: Timed out waiting for browser lock (another agent may be stuck). Use --no-lock to bypass.");
+    process.exit(1);
+  }
+}
+process.on("exit", () => { if (useLock) releaseLock(); });
 
 const socket = net.createConnection(SOCKET_PATH, () => {
   socket.write(JSON.stringify(request) + "\n");

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -13,7 +13,7 @@ const { version: VERSION } = require("../package.json");
 
 const IS_WIN = process.platform === "win32";
 const SURF_TMP = IS_WIN ? path.join(os.tmpdir(), "surf") : "/tmp";
-const SOCKET_PATH = IS_WIN ? "//./pipe/surf" : "/tmp/surf.sock";
+let SOCKET_PATH = process.env.SURF_SOCKET || (IS_WIN ? "//./pipe/surf" : "/tmp/surf.sock");
 if (IS_WIN) { try { fs.mkdirSync(SURF_TMP, { recursive: true }); } catch {} }
 
 // ============================================================================
@@ -1811,7 +1811,12 @@ TIPS
   - Refs (e0, e1...) come from page.read — run it first before clicking
   - Use --json flag on any command for raw JSON output
   - Use --tab-id <id> to target a specific tab
-  - Use --window-id <id> to isolate from user's browsing`);
+  - Use --window-id <id> to isolate from user's browsing
+
+PARALLEL SESSIONS (multiple agents)
+  SURF_SOCKET=/tmp/surf-qa.sock surf navigate "URL"   Run agent on separate socket
+  surf --socket /tmp/surf-qa.sock navigate "URL"       Same via flag
+  NOTE: Each socket needs its own host process. Start host with SURF_SOCKET set.`);
   process.exit(0);
 }
 
@@ -2736,6 +2741,10 @@ if (toolArgs["window-id"] !== undefined) {
   }
   globalOpts.windowId = wid;
   delete toolArgs["window-id"];
+}
+if (toolArgs.socket !== undefined) {
+  SOCKET_PATH = toolArgs.socket;
+  delete toolArgs.socket;
 }
 if (toolArgs["network-path"] !== undefined) {
   networkStore.setBasePath(toolArgs["network-path"]);

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -2475,6 +2475,16 @@ if (REMOVED_COMMANDS[tool]) {
 
 tool = ALIASES[tool] || tool;
 
+// Join space-separated subcommands: "cookie list" -> "cookie.list"
+if (tool === "cookie" && firstArg && ["list", "get", "set", "clear", "delete"].includes(firstArg)) {
+  if (firstArg === "delete") {
+    tool = "cookie.clear";
+  } else {
+    tool = `cookie.${firstArg}`;
+  }
+  firstArg = undefined;
+}
+
 // Auto-save screenshots to temp file when no --output specified
 // This ensures agents always get a usable file path, not just an in-memory ID
 // Can be disabled with --no-save flag or autoSaveScreenshots: false in surf.json
@@ -2559,6 +2569,8 @@ const PRIMARY_ARG_MAP = {
   "frame.js": "code",
   "element.styles": "selector",
   "select": "selector",
+  "cookie.get": "name",
+  "cookie.clear": "name",
 };
 
 const toolArgs = { ...options };

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -2414,7 +2414,7 @@ if (args[0] === "workflow.validate") {
   }
 }
 
-const BOOLEAN_FLAGS = ["auto-capture", "json", "stream", "dry-run", "stop-on-error", "fail-fast", "clear", "submit", "all", "case-sensitive", "hard", "annotate", "fullpage", "reset", "no-screenshot", "full", "soft-fail", "has-body", "exclude-static", "v", "vv", "request", "by-tab", "har", "jsonl", "no-save", "no-auto-wait"];
+const BOOLEAN_FLAGS = ["auto-capture", "json", "stream", "dry-run", "stop-on-error", "fail-fast", "clear", "submit", "all", "case-sensitive", "hard", "annotate", "fullpage", "full-page", "reset", "no-screenshot", "full", "soft-fail", "has-body", "exclude-static", "v", "vv", "request", "by-tab", "har", "jsonl", "no-save", "no-auto-wait"];
 
 const AUTO_SCREENSHOT_TOOLS = ["click", "type", "key", "smart_type", "form.fill", "form_input", "drag", "hover", "scroll", "scroll.top", "scroll.bottom", "scroll.to", "dialog.accept", "dialog.dismiss", "js", "eval"];
 
@@ -2459,6 +2459,13 @@ const parseArgs = (rawArgs) => {
 };
 
 let { positional, options } = parseArgs(args);
+
+// Normalize hyphenated flag aliases
+if (options["full-page"]) {
+  options.fullpage = true;
+  delete options["full-page"];
+}
+
 let tool = positional[0];
 let firstArg = positional[1];
 

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -1747,6 +1747,74 @@ if (args[0] === "--help-topic" && args[1]) {
   process.exit(0);
 }
 
+if (args[0] === "--llm-context") {
+  console.log(`SURF-CLI QUICK REFERENCE (for AI agents)
+
+NAVIGATION
+  surf navigate "URL"                    Open URL (always sleep 2 after)
+  surf back                              Go back
+  surf forward                           Go forward
+  surf tab.new "URL"                     Open in new tab
+  surf tab.list                          List open tabs
+  surf tab.switch <id>                   Switch to tab
+
+READING
+  surf page.read --depth 2 --compact     Get interactive elements with refs (e0, e1...)
+  surf page.text                         Get page text content
+  surf page.state                        Get URL, title, meta info
+  surf js "expression"                   Evaluate JS and return result
+
+INTERACTION
+  surf click e5                          Click element by ref
+  surf click 100 200                     Click at coordinates
+  surf type "text" --submit              Type text (--submit to press Enter)
+  surf key Enter                         Press key
+  surf scroll down 800                   Scroll by pixels (up/down/left/right)
+  surf scroll bottom                     Scroll to bottom
+  surf scroll top                        Scroll to top
+  surf select "selector" "value"         Select dropdown option
+
+SCREENSHOTS
+  surf screenshot /tmp/name.png          Viewport screenshot
+  surf screenshot --fullpage /tmp/f.png  Full page screenshot
+  surf screenshot --annotate /tmp/a.png  Screenshot with element labels
+
+FORMS & INPUT
+  surf locate.role button --name "Submit" --action click   Find and click by role
+  surf locate.text "Sign in" --action click                Find and click by text
+  surf form.fill --data '{"#email":"a@b.com"}'             Fill form fields
+
+DEVICE EMULATION
+  surf emulate.device "iPhone 14"        Emulate device
+  surf resize 375 812                    Set viewport size
+  surf emulate.network 3g               Throttle network
+
+COOKIES
+  surf cookie list                       List all cookies
+  surf cookie get "name"                 Get cookie value
+  surf cookie set --name "n" --value "v" Set cookie
+  surf cookie clear --all                Clear all cookies
+
+NETWORK
+  surf network                           List captured requests
+  surf network --filter "api"            Filter by URL pattern
+  surf console                           Read console messages
+
+WAIT COMMANDS
+  surf wait 2                            Wait seconds
+  surf wait.element "selector"           Wait for element
+  surf wait.network                      Wait for network idle
+  surf wait.url "pattern"                Wait for URL change
+
+TIPS
+  - Always sleep 2 after navigate before reading/screenshotting
+  - Refs (e0, e1...) come from page.read — run it first before clicking
+  - Use --json flag on any command for raw JSON output
+  - Use --tab-id <id> to target a specific tab
+  - Use --window-id <id> to isolate from user's browsing`);
+  process.exit(0);
+}
+
 if (args[0] === "--version" || args[0] === "-v") {
   console.log(`surf version ${VERSION}`);
   process.exit(0);

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -2574,6 +2574,14 @@ if (tool === "click" && firstArg) {
   }
 }
 
+if (tool === "resize" && firstArg) {
+  toolArgs.width = parseInt(firstArg, 10);
+  if (positional[2]) {
+    toolArgs.height = parseInt(positional[2], 10);
+  }
+  firstArg = undefined;
+}
+
 if (firstArg !== undefined) {
   const primaryKey = PRIMARY_ARG_MAP[tool];
   if (primaryKey && toolArgs[primaryKey] === undefined) {

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -2574,6 +2574,18 @@ if (tool === "click" && firstArg) {
   }
 }
 
+if (tool === "scroll" && firstArg) {
+  if (firstArg === "top" || firstArg === "bottom") {
+    tool = `scroll.${firstArg}`;
+    firstArg = undefined;
+  } else if (["up", "down", "left", "right"].includes(firstArg)) {
+    toolArgs.scroll_direction = firstArg;
+    const px = positional[2] ? parseInt(positional[2], 10) : 300;
+    toolArgs.scroll_amount = Math.max(1, Math.round(px / 100));
+    firstArg = undefined;
+  }
+}
+
 if (firstArg !== undefined) {
   const primaryKey = PRIMARY_ARG_MAP[tool];
   if (primaryKey && toolArgs[primaryKey] === undefined) {

--- a/native/host.cjs
+++ b/native/host.cjs
@@ -16,7 +16,7 @@ const { mapToolToMessage, mapComputerAction, formatToolContent } = require("./ho
 
 const IS_WIN = process.platform === "win32";
 const SURF_TMP = IS_WIN ? path.join(os.tmpdir(), "surf") : "/tmp";
-const SOCKET_PATH = IS_WIN ? "//./pipe/surf" : "/tmp/surf.sock";
+const SOCKET_PATH = process.env.SURF_SOCKET || (IS_WIN ? "//./pipe/surf" : "/tmp/surf.sock");
 if (IS_WIN) { try { fs.mkdirSync(SURF_TMP, { recursive: true }); } catch {} }
 
 // Cross-platform image resize (macOS: sips, Linux: ImageMagick)

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -1773,7 +1773,14 @@ export async function handleMessage(
         await cdp.evaluateScript(tabId, piHelpersCode);
         
         const escaped = message.code.replace(/`/g, "\\`").replace(/\$/g, "\\$");
-        const expression = `(async () => { 'use strict'; ${escaped} })()`;
+
+        // Auto-prepend return for single expressions so values are returned
+        const trimmedCode = message.code.trim();
+        const statementKeywords = /^(if|for|while|do|switch|try|const|let|var|function|class|throw|return)\b/;
+        const isExpression = !trimmedCode.includes(';') && !statementKeywords.test(trimmedCode);
+        const wrappedCode = isExpression ? `return ${escaped}` : escaped;
+
+        const expression = `(async () => { 'use strict'; ${wrappedCode} })()`;
         
         const result = await cdp.evaluateScript(tabId, expression);
         


### PR DESCRIPTION
Closes #55

## Summary
- Built-in browser lock serializes concurrent agent access (atomic `mkdir` mutex, inspired by [browser-lock](https://github.com/m13v/browser-lock))
- `SURF_SOCKET` env var and `--socket` flag for custom socket paths (advanced use)
- `--no-lock` flag to bypass locking when not needed
- Updated `--llm-context` with multi-agent workflow documentation

## How it works

Every `surf` CLI invocation automatically acquires a file-based lock before sending a request to the browser, and releases it after the response. If another agent holds the lock, the CLI waits with polling (up to 60s). Stale locks (from crashed agents) expire after 30s.

Each socket path gets its own independent lock, so agents on different `SURF_SOCKET` values don't block each other.

## Usage
```bash
# Automatic — agents serialize naturally
# Agent A runs, Agent B waits, Agent B runs when A finishes
surf navigate "https://example.com/page1"  # Agent A
surf navigate "https://example.com/page2"  # Agent B (waits for A)

# Isolate agents in separate windows (recommended)
surf window.new "https://example.com" --window-id 123
surf --window-id 123 navigate "https://page1.com"  # Agent A
surf --window-id 456 navigate "https://page2.com"  # Agent B

# Bypass lock for read-only operations
surf page.state --no-lock

# Advanced: custom socket path
SURF_SOCKET=/tmp/surf-qa.sock surf navigate "URL"
```

## Test plan
- [ ] Two concurrent `surf` invocations serialize correctly (second waits)
- [ ] `--no-lock` bypasses the lock
- [ ] Stale lock (kill agent mid-request) is recovered after 30s
- [ ] `SURF_SOCKET` / `--socket` still work for custom paths
- [ ] Default behavior unchanged for single-agent usage