### PR TITLE
feat: add animation capture tools (record, animate-audit, perf-audit)

### DIFF
--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -556,6 +556,50 @@ const TOOLS = {
         ]
       },
       "snap": { desc: "Alias for screenshot (auto-saves to /tmp)", args: [], alias: "screenshot" },
+      "record": {
+        desc: "Record screenshot burst → GIF animation",
+        args: [],
+        opts: {
+          duration: "Recording duration in ms (default: 2000)",
+          fps: "Frames per second (default: 10)",
+          output: "Output GIF path (default: /tmp/surf-record-<timestamp>.gif)",
+          trigger: "Action to execute before recording (e.g. click:#btn)",
+          rect: "Clip to viewport region: x,y,width,height",
+        },
+        examples: [
+          { cmd: "record", desc: "Record 2s at 10fps → GIF" },
+          { cmd: "record --duration 3000 --fps 5", desc: "Record 3s at 5fps" },
+          { cmd: "record --trigger \"click:#seasons-btn\"", desc: "Click then record" },
+          { cmd: "record --rect 0,200,1440,800", desc: "Record viewport region" },
+        ]
+      },
+      "animate-audit": {
+        desc: "Capture animation timeline as structured JSON",
+        args: [],
+        opts: {
+          selector: "CSS selector(s) to track (comma-separated)",
+          duration: "Observation duration in ms (default: 2000)",
+          output: "Output JSON path",
+          trigger: "Action to execute before observing (e.g. click:.cta-btn)",
+        },
+        examples: [
+          { cmd: "animate-audit --selector .group-picker --duration 2000", desc: "Track element during animation" },
+          { cmd: "animate-audit --selector \".a,.b\" --trigger \"click:.cta\"", desc: "Track multiple elements after click" },
+        ]
+      },
+      "perf-audit": {
+        desc: "Capture layout shifts, long frames, event timing",
+        args: [],
+        opts: {
+          duration: "Observation duration in ms (default: 3000)",
+          output: "Output JSON path",
+          trigger: "Action to execute before observing (e.g. click:.cta-btn)",
+        },
+        examples: [
+          { cmd: "perf-audit --duration 3000", desc: "Capture perf events for 3s" },
+          { cmd: "perf-audit --trigger \"click:.cta-btn\"", desc: "Click then capture" },
+        ]
+      },
     }
   },
   scroll: {
@@ -2678,6 +2722,11 @@ if (tool === "screenshot" && outputPath) {
   if (options["max-size"]) toolArgs["max-size"] = options["max-size"];
 }
 
+if (tool === "record") {
+  const saveTo = outputPath || path.join(SURF_TMP, `surf-record-${Date.now()}.gif`);
+  toolArgs.savePath = saveTo;
+}
+
 const methodFlag = toolArgs.method;
 // Keep method for network filtering, only delete for other tools
 if (tool !== 'network' && tool !== 'get_network_entries') {
@@ -2906,6 +2955,12 @@ if (tool === "aistudio.build") {
   const userTimeoutSec = parseInt(options.timeout || "600", 10);
   requestTimeout = (userTimeoutSec * 1000) + 60000;
 }
+const TIMED_TOOLS = ["record", "animate-audit", "perf-audit"];
+if (TIMED_TOOLS.includes(tool)) {
+  const duration = parseInt(options.duration || toolArgs.duration || "3000", 10);
+  const buffer = tool === "record" ? 120000 : 30000;
+  requestTimeout = duration + buffer;
+}
 const timeout = setTimeout(() => {
   console.error(`Error: Request timed out (${requestTimeout / 1000}s)`);
   socket.destroy();
@@ -3020,6 +3075,52 @@ async function handleResponse(response) {
     console.log(data.message);
     if (data.screenshotId) {
       console.log(`[Screenshot ID: ${data.screenshotId}]`);
+    }
+  } else if (tool === "record" && data?.message) {
+    console.log(data.message);
+  } else if (tool === "record" && data?.frames) {
+    const saveTo = outputPath || path.join(SURF_TMP, `surf-record-${Date.now()}.gif`);
+    const tmpDir = path.join(SURF_TMP, `surf-record-cli-${Date.now()}`);
+    fs.mkdirSync(tmpDir, { recursive: true });
+    for (let i = 0; i < data.frames.length; i++) {
+      fs.writeFileSync(path.join(tmpDir, `frame-${String(i).padStart(4, "0")}.png`), Buffer.from(data.frames[i], "base64"));
+    }
+    const fps = data.fps || 10;
+    const delay = Math.round(100 / fps);
+    const glob = path.join(tmpDir, "frame-*.png");
+    try {
+      try {
+        execSync(`convert -delay ${delay} -loop 0 "${glob}" "${saveTo}"`, { stdio: "pipe" });
+      } catch {
+        execSync(`magick -delay ${delay} -loop 0 "${glob}" "${saveTo}"`, { stdio: "pipe" });
+      }
+      const sizeKB = Math.round(fs.statSync(saveTo).size / 1024);
+      console.log(`Recorded ${data.frames.length} frames at ${fps}fps → ${saveTo} (${sizeKB}KB)`);
+    } catch (e) {
+      console.error(`GIF assembly failed: ${e.message}. Is ImageMagick installed?`);
+    }
+    for (const f of fs.readdirSync(tmpDir)) { try { fs.unlinkSync(path.join(tmpDir, f)); } catch {} }
+    try { fs.rmdirSync(tmpDir); } catch {}
+  } else if ((tool === "animate-audit" || tool === "animate_audit") && data?.timeline) {
+    const saveTo = outputPath;
+    const output = JSON.stringify(data.timeline, null, 2);
+    if (saveTo) {
+      fs.writeFileSync(saveTo, output);
+      console.log(`Timeline saved to ${saveTo} (${data.timeline.frames?.length || 0} frames)`);
+    } else {
+      console.log(output);
+    }
+  } else if ((tool === "perf-audit" || tool === "perf_audit") && data?.perfData) {
+    const saveTo = outputPath;
+    const output = JSON.stringify(data.perfData, null, 2);
+    if (saveTo) {
+      fs.writeFileSync(saveTo, output);
+      const ls = data.perfData.layoutShifts?.length || 0;
+      const laf = data.perfData.longAnimationFrames?.length || 0;
+      const ev = data.perfData.events?.length || 0;
+      console.log(`Perf audit saved to ${saveTo} (${ls} layout shifts, ${laf} long frames, ${ev} events)`);
+    } else {
+      console.log(output);
     }
   } else if (tool === "tab.list") {
     const tabs = data?.tabs || data || [];

--- a/native/host-helpers.cjs
+++ b/native/host-helpers.cjs
@@ -1127,6 +1127,33 @@ function mapToolToMessage(tool, args, tabId) {
         top: a.top !== undefined ? parseInt(a.top, 10) : undefined,
         state: a.state,
       };
+    case "record":
+      return {
+        type: "EXECUTE_RECORD",
+        duration: parseInt(a.duration || "2000", 10),
+        fps: parseInt(a.fps || "10", 10),
+        trigger: a.trigger,
+        rect: a.rect,
+        savePath: a.savePath || a.output,
+        ...baseMsg,
+      };
+    case "animate-audit":
+    case "animate_audit":
+      return {
+        type: "ANIMATE_AUDIT",
+        selector: a.selector,
+        duration: parseInt(a.duration || "2000", 10),
+        trigger: a.trigger,
+        ...baseMsg,
+      };
+    case "perf-audit":
+    case "perf_audit":
+      return {
+        type: "PERF_AUDIT",
+        duration: parseInt(a.duration || "3000", 10),
+        trigger: a.trigger,
+        ...baseMsg,
+      };
     default:
       return null;
   }

--- a/native/host.cjs
+++ b/native/host.cjs
@@ -1423,7 +1423,46 @@ function processInput() {
           const { socket, originalId, savePath, autoScreenshot, tabId: storedTabId } = pending;
           const tabId = storedTabId || msg._resolvedTabId;
           
-          if (savePath && msg.base64) {
+          if (savePath && msg.frames && Array.isArray(msg.frames)) {
+            // GIF assembly for surf record
+            try {
+              const dir = path.dirname(savePath);
+              if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+              const tmpDir = path.join(SURF_TMP, `surf-record-${Date.now()}`);
+              fs.mkdirSync(tmpDir, { recursive: true });
+
+              for (let i = 0; i < msg.frames.length; i++) {
+                const framePath = path.join(tmpDir, `frame-${String(i).padStart(4, "0")}.png`);
+                fs.writeFileSync(framePath, Buffer.from(msg.frames[i], "base64"));
+              }
+
+              const fps = msg.fps || 10;
+              const delay = Math.round(100 / fps);
+              const globPattern = path.join(tmpDir, "frame-*.png");
+              try {
+                execSync(`convert -delay ${delay} -loop 0 "${globPattern}" "${savePath}"`, { stdio: "pipe" });
+              } catch {
+                execSync(`magick -delay ${delay} -loop 0 "${globPattern}" "${savePath}"`, { stdio: "pipe" });
+              }
+
+              for (const f of fs.readdirSync(tmpDir)) {
+                try { fs.unlinkSync(path.join(tmpDir, f)); } catch {}
+              }
+              try { fs.rmdirSync(tmpDir); } catch {}
+
+              const stats = fs.statSync(savePath);
+              const sizeKB = Math.round(stats.size / 1024);
+              sendToolResponse(socket, originalId, {
+                message: `Recorded ${msg.frames.length} frames at ${fps}fps → ${savePath} (${sizeKB}KB)`,
+                path: savePath,
+                frameCount: msg.frames.length,
+                fps,
+                duration: msg.duration,
+              }, null);
+            } catch (e) {
+              sendToolResponse(socket, originalId, null, `GIF assembly failed: ${e.message}. Is ImageMagick installed?`);
+            }
+          } else if (savePath && msg.base64) {
             try {
               const dir = path.dirname(savePath);
               if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -3114,6 +3114,247 @@ export async function handleMessage(
       };
     }
 
+    case "EXECUTE_RECORD": {
+      if (!tabId) throw new Error("No tabId provided");
+
+      const duration: number = message.duration || 2000;
+      const fps: number = message.fps || 10;
+      const interval = Math.round(1000 / fps);
+      const frameCount = Math.ceil(duration / interval);
+      const rect = message.rect ? String(message.rect).split(",").map(Number) : null;
+
+      try {
+        await chrome.tabs.sendMessage(tabId, { type: "HIDE_FOR_TOOL_USE" });
+      } catch (e) {}
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      if (message.trigger) {
+        const triggerParts = message.trigger.match(/^(\w+):(.+)$/);
+        if (triggerParts) {
+          const [, action, selector] = triggerParts;
+          if (action === "click") {
+            await cdp.evaluateScript(tabId, `document.querySelector(${JSON.stringify(selector)})?.click()`);
+            await new Promise(resolve => setTimeout(resolve, 50));
+          } else if (action === "scroll") {
+            await cdp.evaluateScript(tabId, `document.querySelector(${JSON.stringify(selector)})?.scrollIntoView({behavior:'smooth'})`);
+            await new Promise(resolve => setTimeout(resolve, 50));
+          }
+        }
+      }
+
+      try {
+        const frames: string[] = [];
+        for (let i = 0; i < frameCount; i++) {
+          let result: { base64: string; width: number; height: number };
+          if (rect && rect.length === 4) {
+            result = await cdp.captureRegion(tabId, rect[0], rect[1], rect[2], rect[3]);
+          } else {
+            result = await cdp.captureScreenshot(tabId);
+          }
+          frames.push(result.base64);
+          if (i < frameCount - 1) {
+            await new Promise(resolve => setTimeout(resolve, interval));
+          }
+        }
+
+        const { width, height } = await cdp.getViewportSize(tabId);
+        return { frames, width, height, fps, duration, frameCount: frames.length };
+      } finally {
+        try {
+          await chrome.tabs.sendMessage(tabId, { type: "SHOW_AFTER_TOOL_USE" });
+        } catch (e) {}
+      }
+    }
+
+    case "ANIMATE_AUDIT": {
+      if (!tabId) throw new Error("No tabId provided");
+      if (!message.selector) throw new Error("--selector required");
+
+      const duration: number = message.duration || 2000;
+      const selectors = String(message.selector).split(",").map((s: string) => s.trim());
+
+      if (message.trigger) {
+        const triggerParts = message.trigger.match(/^(\w+):(.+)$/);
+        if (triggerParts) {
+          const [, action, selector] = triggerParts;
+          if (action === "click") {
+            await cdp.evaluateScript(tabId, `document.querySelector(${JSON.stringify(selector)})?.click()`);
+            await new Promise(resolve => setTimeout(resolve, 50));
+          } else if (action === "scroll") {
+            await cdp.evaluateScript(tabId, `document.querySelector(${JSON.stringify(selector)})?.scrollIntoView({behavior:'smooth'})`);
+            await new Promise(resolve => setTimeout(resolve, 50));
+          }
+        }
+      }
+
+      const auditScript = `
+        (function() {
+          return new Promise((resolve) => {
+            const selectors = ${JSON.stringify(selectors)};
+            const duration = ${duration};
+            const frames = [];
+            const start = performance.now();
+            const interval = 16;
+
+            function captureFrame() {
+              const t = Math.round(performance.now() - start);
+              const frame = { t, scrollY: Math.round(window.scrollY), elements: {} };
+
+              for (const sel of selectors) {
+                const el = document.querySelector(sel);
+                if (!el) continue;
+                const rect = el.getBoundingClientRect();
+                const style = getComputedStyle(el);
+                frame.elements[sel] = {
+                  rect: {
+                    top: Math.round(rect.top),
+                    left: Math.round(rect.left),
+                    width: Math.round(rect.width),
+                    height: Math.round(rect.height),
+                  },
+                  opacity: style.opacity,
+                  transform: style.transform === "none" ? "" : style.transform,
+                  visibility: style.visibility,
+                  display: style.display,
+                };
+              }
+              frames.push(frame);
+
+              if (t < duration) {
+                setTimeout(captureFrame, interval);
+              } else {
+                resolve(JSON.stringify({
+                  meta: {
+                    url: location.href,
+                    viewport: [window.innerWidth, window.innerHeight],
+                    duration,
+                    selectors,
+                  },
+                  frames,
+                }));
+              }
+            }
+            setTimeout(captureFrame, 0);
+          });
+        })()
+      `;
+
+      const result = await cdp.evaluateScript(tabId, auditScript);
+      if (result.exceptionDetails) {
+        throw new Error(result.exceptionDetails.text || result.exceptionDetails.exception?.description || "animate-audit failed");
+      }
+
+      let timeline;
+      try {
+        timeline = JSON.parse(result.result?.value || "{}");
+      } catch {
+        timeline = result.result?.value;
+      }
+      return { timeline };
+    }
+
+    case "PERF_AUDIT": {
+      if (!tabId) throw new Error("No tabId provided");
+
+      const duration: number = message.duration || 3000;
+
+      if (message.trigger) {
+        const triggerParts = message.trigger.match(/^(\w+):(.+)$/);
+        if (triggerParts) {
+          const [, action, selector] = triggerParts;
+          if (action === "click") {
+            await cdp.evaluateScript(tabId, `document.querySelector(${JSON.stringify(selector)})?.click()`);
+            await new Promise(resolve => setTimeout(resolve, 50));
+          } else if (action === "scroll") {
+            await cdp.evaluateScript(tabId, `document.querySelector(${JSON.stringify(selector)})?.scrollIntoView({behavior:'smooth'})`);
+            await new Promise(resolve => setTimeout(resolve, 50));
+          }
+        }
+      }
+
+      const perfScript = `
+        (function() {
+          return new Promise((resolve) => {
+            const duration = ${duration};
+            const layoutShifts = [];
+            const longAnimationFrames = [];
+            const events = [];
+            const start = performance.now();
+
+            const observers = [];
+
+            try {
+              const lsObserver = new PerformanceObserver((list) => {
+                for (const entry of list.getEntries()) {
+                  const sources = [];
+                  if (entry.sources) {
+                    for (const s of entry.sources) {
+                      const node = s.node;
+                      sources.push(node ? (node.id ? '#' + node.id : node.className ? '.' + node.className.split(' ')[0] : node.tagName?.toLowerCase()) : 'unknown');
+                    }
+                  }
+                  layoutShifts.push({
+                    t: Math.round(entry.startTime),
+                    score: parseFloat(entry.value?.toFixed(4) || '0'),
+                    sources,
+                  });
+                }
+              });
+              lsObserver.observe({ type: 'layout-shift', buffered: false });
+              observers.push(lsObserver);
+            } catch (e) {}
+
+            try {
+              const lafObserver = new PerformanceObserver((list) => {
+                for (const entry of list.getEntries()) {
+                  longAnimationFrames.push({
+                    t: Math.round(entry.startTime),
+                    duration: Math.round(entry.duration),
+                    blockingDuration: Math.round(entry.blockingDuration || 0),
+                  });
+                }
+              });
+              lafObserver.observe({ type: 'long-animation-frame', buffered: false });
+              observers.push(lafObserver);
+            } catch (e) {}
+
+            try {
+              const eventObserver = new PerformanceObserver((list) => {
+                for (const entry of list.getEntries()) {
+                  events.push({
+                    t: Math.round(entry.startTime),
+                    name: entry.name,
+                    processingDuration: Math.round((entry.processingEnd || 0) - (entry.processingStart || 0)),
+                    duration: Math.round(entry.duration),
+                  });
+                }
+              });
+              eventObserver.observe({ type: 'event', buffered: false });
+              observers.push(eventObserver);
+            } catch (e) {}
+
+            setTimeout(() => {
+              for (const obs of observers) obs.disconnect();
+              resolve(JSON.stringify({ layoutShifts, longAnimationFrames, events }));
+            }, duration);
+          });
+        })()
+      `;
+
+      const result = await cdp.evaluateScript(tabId, perfScript);
+      if (result.exceptionDetails) {
+        throw new Error(result.exceptionDetails.text || result.exceptionDetails.exception?.description || "perf-audit failed");
+      }
+
+      let perfData;
+      try {
+        perfData = JSON.parse(result.result?.value || "{}");
+      } catch {
+        perfData = result.result?.value;
+      }
+      return { perfData };
+    }
+
     default:
       throw new Error(`Unknown message type: ${message.type}`);
   }


### PR DESCRIPTION
## Summary
- Adds `surf record` command: captures screenshot burst via CDP and assembles into GIF using ImageMagick
- Adds `surf animate-audit` command: captures element rect/opacity/transform timeline as structured JSON
- Adds `surf perf-audit` command: captures layout shifts, long animation frames, and event timing via PerformanceObserver

All three commands support `--trigger`, `--duration`, and `--output` flags.

Closes #66

## Changes
- **native/cli.cjs**: New tool definitions, timeout handling, savePath setup, and response handlers for all three commands
- **native/host-helpers.cjs**: Message mapping for `EXECUTE_RECORD`, `ANIMATE_AUDIT`, and `PERF_AUDIT`
- **native/host.cjs**: Server-side GIF assembly from base64 frames via ImageMagick
- **src/service-worker/index.ts**: CDP-based frame capture loop, in-page animation audit script, and perf observer script

## Test plan
- [ ] `surf record` produces a GIF in `/tmp` (requires ImageMagick)
- [ ] `surf record --duration 3000 --fps 5` adjusts frame count accordingly
- [ ] `surf record --trigger "click:#btn"` clicks element before recording
- [ ] `surf record --rect 0,200,1440,800` clips to viewport region
- [ ] `surf animate-audit --selector ".el" --duration 2000` outputs JSON timeline
- [ ] `surf perf-audit --duration 3000` captures layout shifts and long frames
- [ ] `surf perf-audit --trigger "click:.cta-btn"` clicks then captures
- [ ] All three commands respect `--output` for custom save paths
- [ ] Timeout handling works (record gets 120s buffer, audits get 30s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)