### PR TITLE
fix: accept NextAuth chunked session cookies for ChatGPT login check

### DIFF
--- a/native/chatgpt-client.cjs
+++ b/native/chatgpt-client.cjs
@@ -38,10 +38,13 @@ function buildClickDispatcher() {
 
 function hasRequiredCookies(cookies) {
   if (!cookies || !Array.isArray(cookies)) return false;
-  const sessionCookie = cookies.find(
-    (c) => c.name === "__Secure-next-auth.session-token" && c.value
+  return cookies.some(
+    (c) =>
+      typeof c?.name === "string" &&
+      Boolean(c.value) &&
+      (c.name === "__Secure-next-auth.session-token" ||
+        /^__Secure-next-auth\.session-token\.\d+$/.test(c.name))
   );
-  return Boolean(sessionCookie);
 }
 
 async function evaluate(cdp, expression) {

--- a/test/unit/chatgpt-client.test.ts
+++ b/test/unit/chatgpt-client.test.ts
@@ -1,0 +1,88 @@
+// @ts-expect-error - CommonJS module without type definitions
+import * as chatgptClient from "../../native/chatgpt-client.cjs";
+
+describe("chatgpt-client", () => {
+  describe("hasRequiredCookies", () => {
+    it("accepts exact session cookie", () => {
+      expect(
+        chatgptClient.hasRequiredCookies([
+          { name: "__Secure-next-auth.session-token", value: "abc" },
+        ])
+      ).toBe(true);
+    });
+
+    it("accepts chunked session cookie .0", () => {
+      expect(
+        chatgptClient.hasRequiredCookies([
+          { name: "__Secure-next-auth.session-token.0", value: "abc" },
+        ])
+      ).toBe(true);
+    });
+
+    it("accepts chunked session cookie .1", () => {
+      expect(
+        chatgptClient.hasRequiredCookies([
+          { name: "__Secure-next-auth.session-token.1", value: "abc" },
+        ])
+      ).toBe(true);
+    });
+
+    it("rejects exact cookie with empty value", () => {
+      expect(
+        chatgptClient.hasRequiredCookies([
+          { name: "__Secure-next-auth.session-token", value: "" },
+        ])
+      ).toBe(false);
+    });
+
+    it("rejects chunked cookie with empty value", () => {
+      expect(
+        chatgptClient.hasRequiredCookies([
+          { name: "__Secure-next-auth.session-token.0", value: "" },
+        ])
+      ).toBe(false);
+    });
+
+    it("rejects non-numeric chunk suffix", () => {
+      expect(
+        chatgptClient.hasRequiredCookies([
+          { name: "__Secure-next-auth.session-token.foo", value: "abc" },
+        ])
+      ).toBe(false);
+    });
+
+    it("rejects trailing dot without suffix", () => {
+      expect(
+        chatgptClient.hasRequiredCookies([
+          { name: "__Secure-next-auth.session-token.", value: "abc" },
+        ])
+      ).toBe(false);
+    });
+
+    it("rejects lookalike with different separator", () => {
+      expect(
+        chatgptClient.hasRequiredCookies([
+          { name: "__Secure-next-auth.session-token-extra", value: "abc" },
+        ])
+      ).toBe(false);
+    });
+
+    it("rejects null and undefined", () => {
+      expect(chatgptClient.hasRequiredCookies(null)).toBe(false);
+      expect(chatgptClient.hasRequiredCookies(undefined)).toBe(false);
+    });
+
+    it("rejects non-array input", () => {
+      expect(chatgptClient.hasRequiredCookies({} as unknown as [])).toBe(false);
+    });
+
+    it("rejects unrelated cookies", () => {
+      expect(
+        chatgptClient.hasRequiredCookies([
+          { name: "oai-did", value: "abc" },
+          { name: "__Host-next-auth.csrf-token", value: "abc" },
+        ])
+      ).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fix `hasRequiredCookies()` to accept NextAuth.js chunked session cookies (`__Secure-next-auth.session-token.0`, `.1`, etc.)
- Add unit tests for the ChatGPT cookie matcher

## Problem

`surf chatgpt` fails with `Error: ChatGPT login required` for all logged-in users. ChatGPT's session JWT now exceeds the ~4KB browser cookie size limit, so NextAuth.js automatically chunks it into numbered cookies. The existing exact-match check only accepted the un-chunked name.

**Evidence from `surf cookie.list` on chatgpt.com:**
- `__Secure-next-auth.session-token.0` ✅ exists
- `__Secure-next-auth.session-token.1` ✅ exists
- `__Secure-next-auth.session-token` ❌ does not exist

The cookie check fails at the preflight stage, before `createTab()` is ever called — so the working runtime `/backend-api/me` verification never executes.

## Fix

Broadens `hasRequiredCookies()` to accept both the exact cookie name and numbered chunk suffixes using a precise regex (`/^__Secure-next-auth\.session-token\.\d+$/`). No changes to `query()` control flow.

## Test plan

- [x] Unit tests: exact match, chunked `.0`/`.1`, empty values, null/undefined, non-array, unrelated cookies
- [x] `npm test` passes (229 tests)
- [x] E2E: installed fork globally, killed stale host, ran `surf chatgpt "hello"` — gets past cookie check and proceeds through login verification, prompt typing, and send (response timeout is a separate pre-existing UI selector issue)

## Scope

**In this PR:** cookie matcher fix + unit tests

**Explicitly deferred:** Making the cookie precheck non-fatal (warn + continue to runtime check). That changes auth-flow policy and should be a separate PR if desired.

Fixes #96