### PR TITLE
fix: harden ChatGPT response polling against DOM selector drift

### DIFF
--- a/native/chatgpt-client.cjs
+++ b/native/chatgpt-client.cjs
@@ -6,10 +6,11 @@ const SELECTORS = {
   modelButton: '[data-testid="model-switcher-dropdown-button"]',
   menuContainer: '[role="menu"], [data-radix-collection-root]',
   menuItem: 'button, [role="menuitem"], [role="menuitemradio"], [data-testid*="model-switcher-"]',
-  assistantMessage: '[data-message-author-role="assistant"], [data-turn="assistant"]',
-  stopButton: '[data-testid="stop-button"]',
-  finishedActions: 'button[data-testid="copy-turn-action-button"], button[data-testid="good-response-turn-action-button"]',
-  conversationTurn: 'article[data-testid^="conversation-turn"], div[data-testid^="conversation-turn"]',
+  assistantMessage: '[data-message-author-role="assistant"], [data-turn="assistant"], [data-testid*="assistant-message"], [data-testid*="assistant-turn"], [data-testid*="assistant-response"]',
+  assistantContent: '.markdown, [data-message-content], .prose, [class*="markdown"], [dir="auto"]',
+  stopButton: '[data-testid="stop-button"], [data-testid*="stop"], button[aria-label*="Stop"], button[aria-label*="stop"]',
+  finishedActions: 'button[data-testid="copy-turn-action-button"], button[data-testid="good-response-turn-action-button"], button[data-testid*="turn-action"], button[aria-label*="Copy"], button[aria-label*="copy"], button[aria-label*="Read aloud"], button[aria-label*="read aloud"]',
+  conversationTurn: '[data-testid^="conversation-turn"], [data-testid*="conversation-turn"]',
   fileInput: 'input[type="file"]',
   cloudflareScript: 'script[src*="/challenge-platform/"]',
 };
@@ -42,6 +43,148 @@ function hasRequiredCookies(cookies) {
     (c) => c.name === "__Secure-next-auth.session-token" && c.value
   );
   return Boolean(sessionCookie);
+}
+
+function cleanChatGPTResponseText(rawText) {
+  if (!rawText) return "";
+
+  const chromeLines = new Set([
+    "copy",
+    "good response",
+    "bad response",
+    "read aloud",
+    "edit",
+    "retry",
+    "continue generating",
+    "share",
+  ]);
+
+  const lines = [];
+  let inCodeFence = false;
+
+  for (const line of String(rawText).replace(/\r\n?/g, "\n").split("\n")) {
+    const trimmed = line.trim();
+    const isFenceLine = trimmed.startsWith("```");
+    const normalizedLine = inCodeFence || isFenceLine ? line.replace(/[\t ]+$/g, "") : line;
+
+    lines.push({
+      text: normalizedLine,
+      trimmed,
+      isChrome: trimmed.length > 0 && chromeLines.has(trimmed.toLowerCase()),
+      inCodeFence,
+      isFenceLine,
+    });
+
+    if (isFenceLine) {
+      inCodeFence = !inCodeFence;
+    }
+  }
+
+  while (lines.length > 0 && lines[0].trimmed.length === 0) {
+    lines.shift();
+  }
+  while (lines.length > 0 && lines[lines.length - 1].trimmed.length === 0) {
+    lines.pop();
+  }
+
+  let trailingChromeStart = lines.length;
+  while (trailingChromeStart > 0) {
+    const line = lines[trailingChromeStart - 1];
+    if (line.inCodeFence || line.isFenceLine || !line.isChrome) break;
+    trailingChromeStart--;
+  }
+
+  const trailingChromeCount = lines.length - trailingChromeStart;
+  if (trailingChromeCount >= 2) {
+    lines.splice(trailingChromeStart);
+  }
+
+  while (lines.length > 0 && lines[0].trimmed.length === 0) {
+    lines.shift();
+  }
+  while (lines.length > 0 && lines[lines.length - 1].trimmed.length === 0) {
+    lines.pop();
+  }
+
+  return lines.map((line) => line.text).join("\n");
+}
+
+function extractLatestAssistantSnapshot(candidates) {
+  if (!Array.isArray(candidates)) return null;
+
+  let latestEmptyAssistant = null;
+
+  for (let i = candidates.length - 1; i >= 0; i--) {
+    const candidate = candidates[i];
+    if (!candidate?.isAssistant) continue;
+
+    const snapshot = {
+      ...candidate,
+      text: cleanChatGPTResponseText(candidate?.text || ""),
+      turnIndex: i,
+    };
+
+    if (snapshot.text) {
+      return snapshot;
+    }
+
+    if (!latestEmptyAssistant) {
+      latestEmptyAssistant = snapshot;
+    }
+  }
+
+  return latestEmptyAssistant;
+}
+
+function normalizeResponseSnapshot(rawSnapshot) {
+  const candidates = rawSnapshot?.candidates;
+  return {
+    latestAssistant: extractLatestAssistantSnapshot(candidates),
+    assistantCount: Array.isArray(candidates)
+      ? candidates.filter((candidate) => candidate?.isAssistant).length
+      : 0,
+    stopVisible: Boolean(rawSnapshot?.stopVisible),
+  };
+}
+
+function isNewAssistantContent(
+  latestAssistant,
+  baselineAssistant,
+  assistantCount = 0,
+  baselineAssistantCount = 0
+) {
+  if (!latestAssistant) return false;
+  if (!baselineAssistant) return true;
+  if (latestAssistant.messageId && baselineAssistant.messageId) {
+    if (latestAssistant.messageId !== baselineAssistant.messageId) {
+      return true;
+    }
+  }
+
+  const currentText = latestAssistant.text || "";
+  const baselineText = baselineAssistant.text || "";
+
+  if (assistantCount > baselineAssistantCount) {
+    if (latestAssistant.turnIndex !== baselineAssistant.turnIndex) {
+      return true;
+    }
+    if (currentText !== baselineText) {
+      return true;
+    }
+    return false;
+  }
+
+  if (currentText !== baselineText) {
+    return true;
+  }
+  return false;
+}
+
+function isChatGPTResponseComplete(snapshot, stableCycles, stableMs) {
+  if (!snapshot?.text) return false;
+  if (snapshot.stopVisible) return false;
+  if (snapshot.hasFinishedActions) return true;
+  return stableCycles >= 6 && stableMs >= 1200;
 }
 
 async function evaluate(cdp, expression) {
@@ -314,78 +457,144 @@ async function clickSend(cdp, inputCdp) {
   return true;
 }
 
-async function waitForResponse(cdp, timeoutMs = 2700000) {
-  const deadline = Date.now() + timeoutMs;
-  let previousLength = 0;
-  let stableCycles = 0;
-  const requiredStableCycles = 6;
-  const minStableMs = 1200;
-  let lastChangeAt = Date.now();
-  while (Date.now() < deadline) {
-    const snapshot = await evaluate(
-      cdp,
-      `(() => {
-        const CONVERSATION_SELECTOR = '${SELECTORS.conversationTurn}';
-        const ASSISTANT_SELECTOR = '${SELECTORS.assistantMessage}';
-        const STOP_SELECTOR = '${SELECTORS.stopButton}';
-        const FINISHED_SELECTOR = '${SELECTORS.finishedActions}';
-        const isAssistantTurn = (node) => {
-          if (!(node instanceof HTMLElement)) return false;
-          const role = (node.getAttribute('data-message-author-role') || '').toLowerCase();
-          if (role === 'assistant') return true;
-          const turn = (node.getAttribute('data-turn') || '').toLowerCase();
-          if (turn === 'assistant') return true;
-          return Boolean(node.querySelector(ASSISTANT_SELECTOR));
-        };
-        const turns = Array.from(document.querySelectorAll(CONVERSATION_SELECTOR));
-        let lastAssistantTurn = null;
-        for (let i = turns.length - 1; i >= 0; i--) {
-          if (isAssistantTurn(turns[i])) {
-            lastAssistantTurn = turns[i];
+async function readChatGPTResponseSnapshot(cdp) {
+  return evaluate(
+    cdp,
+    `(() => {
+      const scope = document.querySelector('main') || document;
+      const CONVERSATION_SELECTOR = ${JSON.stringify(SELECTORS.conversationTurn)};
+      const ASSISTANT_SELECTOR = ${JSON.stringify(SELECTORS.assistantMessage)};
+      const CONTENT_SELECTORS = ${JSON.stringify(SELECTORS.assistantContent.split(", "))};
+      const STOP_SELECTOR = ${JSON.stringify(SELECTORS.stopButton)};
+      const FINISHED_SELECTOR = ${JSON.stringify(SELECTORS.finishedActions)};
+
+      const toCandidate = (turnNode, messageRoot = null) => {
+        const resolvedMessageRoot = messageRoot || (turnNode.matches?.(ASSISTANT_SELECTOR)
+          ? turnNode
+          : turnNode.querySelector(ASSISTANT_SELECTOR));
+        const searchRoot = resolvedMessageRoot || turnNode;
+        let contentRoot = null;
+
+        for (const selector of CONTENT_SELECTORS) {
+          const match = selector === '[dir="auto"]'
+            ? (searchRoot.matches?.(selector) ? searchRoot : null)
+            : (searchRoot.matches?.(selector) ? searchRoot : searchRoot.querySelector(selector));
+          if (match) {
+            contentRoot = match;
             break;
           }
         }
-        if (!lastAssistantTurn) {
-          return { text: '', stopVisible: Boolean(document.querySelector(STOP_SELECTOR)), finished: false };
-        }
-        const messageRoot = lastAssistantTurn.querySelector(ASSISTANT_SELECTOR) || lastAssistantTurn;
-        const contentRoot = messageRoot.querySelector('.markdown') || 
-                           messageRoot.querySelector('[data-message-content]') ||
-                           messageRoot.querySelector('.prose') ||
-                           messageRoot;
-        const text = (contentRoot?.innerText || contentRoot?.textContent || '').trim();
-        const stopVisible = Boolean(document.querySelector(STOP_SELECTOR));
-        const finished = Boolean(lastAssistantTurn.querySelector(FINISHED_SELECTOR));
-        const messageId = messageRoot.getAttribute('data-message-id') || null;
-        return { text, stopVisible, finished, messageId, turnIndex: turns.length - 1 };
-      })()`
-    );
+
+        const role =
+          resolvedMessageRoot?.getAttribute('data-message-author-role') ||
+          turnNode.getAttribute('data-message-author-role') ||
+          null;
+        const turn =
+          resolvedMessageRoot?.getAttribute('data-turn') ||
+          turnNode.getAttribute('data-turn') ||
+          null;
+        const isAssistant =
+          role === 'assistant' ||
+          turn === 'assistant' ||
+          resolvedMessageRoot !== null;
+        const text = (contentRoot || turnNode).innerText || (contentRoot || turnNode).textContent || '';
+        const messageId =
+          resolvedMessageRoot?.getAttribute('data-message-id') ||
+          turnNode.getAttribute('data-message-id') ||
+          null;
+        const hasFinishedActions = Boolean(turnNode.querySelector(FINISHED_SELECTOR));
+
+        return {
+          role,
+          turn,
+          isAssistant,
+          text,
+          messageId,
+          hasFinishedActions,
+        };
+      };
+
+      let candidates = Array.from(scope.querySelectorAll(CONVERSATION_SELECTOR)).map((turnNode) =>
+        toCandidate(turnNode)
+      );
+
+      if (candidates.length === 0) {
+        candidates = Array.from(scope.querySelectorAll(ASSISTANT_SELECTOR)).map((messageRoot) =>
+          toCandidate(messageRoot, messageRoot)
+        );
+      }
+
+      return {
+        candidates,
+        stopVisible: Boolean(scope.querySelector(STOP_SELECTOR)),
+      };
+    })()`
+  );
+}
+
+async function waitForResponse(
+  cdp,
+  timeoutMs = 2700000,
+  baselineAssistant,
+  baselineAssistantCount
+) {
+  const deadline = Date.now() + timeoutMs;
+  let previousText = "";
+  let stableCycles = 0;
+  let lastChangeAt = Date.now();
+
+  previousText = baselineAssistant?.text || "";
+  lastChangeAt = Date.now();
+
+  while (Date.now() < deadline) {
+    const snapshot = await readChatGPTResponseSnapshot(cdp);
+
     if (!snapshot) {
       await delay(400);
       continue;
     }
-    const currentLength = (snapshot.text || "").length;
-    if (currentLength > previousLength) {
-      previousLength = currentLength;
+
+    const { latestAssistant, assistantCount, stopVisible } = normalizeResponseSnapshot(snapshot);
+    const currentText = latestAssistant?.text || "";
+    const hasNewAssistantContent = isNewAssistantContent(
+      latestAssistant,
+      baselineAssistant,
+      assistantCount,
+      baselineAssistantCount
+    );
+
+    if (!hasNewAssistantContent) {
+      await delay(400);
+      continue;
+    }
+
+    if (currentText !== previousText) {
+      previousText = currentText;
       stableCycles = 0;
       lastChangeAt = Date.now();
-    } else {
+    } else if (currentText) {
       stableCycles++;
+    } else {
+      stableCycles = 0;
+      lastChangeAt = Date.now();
     }
+
     const stableMs = Date.now() - lastChangeAt;
-    if (!snapshot.stopVisible) {
-      const stableEnough = stableCycles >= requiredStableCycles && stableMs >= minStableMs;
-      const finishedVisible = snapshot.finished;
-      if ((finishedVisible || stableEnough) && currentLength > 0) {
-        return {
-          text: snapshot.text,
-          messageId: snapshot.messageId,
-          turnIndex: snapshot.turnIndex,
-        };
-      }
+    const completionSnapshot = latestAssistant
+      ? { ...latestAssistant, stopVisible }
+      : { text: "", stopVisible, hasFinishedActions: false };
+
+    if (isChatGPTResponseComplete(completionSnapshot, stableCycles, stableMs)) {
+      return {
+        text: latestAssistant.text,
+        messageId: latestAssistant.messageId,
+        turnIndex: latestAssistant.turnIndex,
+      };
     }
+
     await delay(400);
   }
+
   throw new Error("Response timeout");
 }
 
@@ -444,9 +653,15 @@ async function query(options) {
     }
     await typePrompt(cdp, inputCdp, prompt);
     log("Prompt typed");
+    const baseline = normalizeResponseSnapshot(await readChatGPTResponseSnapshot(cdp));
     await clickSend(cdp, inputCdp);
     log("Prompt sent, waiting for response...");
-    const response = await waitForResponse(cdp, timeout);
+    const response = await waitForResponse(
+      cdp,
+      timeout,
+      baseline.latestAssistant,
+      baseline.assistantCount
+    );
     log(`Response received (${response.text.length} chars)`);
     return {
       response: response.text,
@@ -459,4 +674,12 @@ async function query(options) {
   }
 }
 
-module.exports = { query, hasRequiredCookies, CHATGPT_URL };
+module.exports = {
+  query,
+  hasRequiredCookies,
+  cleanChatGPTResponseText,
+  extractLatestAssistantSnapshot,
+  isNewAssistantContent,
+  isChatGPTResponseComplete,
+  CHATGPT_URL,
+};

--- a/test/unit/chatgpt-client.test.ts
+++ b/test/unit/chatgpt-client.test.ts
@@ -1,0 +1,278 @@
+// @ts-expect-error - CommonJS module without type definitions
+import * as chatgptClient from "../../native/chatgpt-client.cjs";
+
+describe("chatgpt-client", () => {
+  describe("cleanChatGPTResponseText", () => {
+    it.each([
+      [
+        "trims outer blank lines and strips only trailing chrome clusters",
+        ["", "Copy", "Answer line", "Read aloud", "Share", ""].join("\n"),
+        "Copy\nAnswer line",
+      ],
+      [
+        "preserves markdown and code fences",
+        [
+          "Good response",
+          "Here is code:",
+          "```js",
+          "Copy",
+          "const x = 1;    ",
+          "```",
+          "Retry",
+        ].join("\r\n"),
+        [
+          "Good response",
+          "Here is code:",
+          "```js",
+          "Copy",
+          "const x = 1;",
+          "```",
+          "Retry",
+        ].join("\n"),
+      ],
+      ["preserves legitimate standalone single-word response: Copy", "Copy", "Copy"],
+      ["preserves legitimate standalone single-word response: Edit", "Edit", "Edit"],
+      [
+        "strips only trailing chrome clusters",
+        ["Answer line", "Copy", "Read aloud"].join("\n"),
+        "Answer line",
+      ],
+      [
+        "preserves a single trailing chrome-like line",
+        ["Answer line", "Edit"].join("\n"),
+        "Answer line\nEdit",
+      ],
+    ])("%s", (_, input, expected) => {
+      expect(chatgptClient.cleanChatGPTResponseText(input)).toBe(expected);
+    });
+  });
+
+  describe("extractLatestAssistantSnapshot", () => {
+    it("returns latest populated assistant", () => {
+      const snapshot = chatgptClient.extractLatestAssistantSnapshot([
+        { role: "user", turn: "user", text: "hello" },
+        {
+          role: "assistant",
+          turn: "assistant",
+          isAssistant: true,
+          text: "Earlier answer",
+          messageId: "msg-1",
+        },
+        {
+          role: "assistant",
+          turn: "assistant",
+          isAssistant: true,
+          text: "Final answer\nCopy\nRead aloud",
+          messageId: "msg-2",
+          hasFinishedActions: true,
+        },
+      ]);
+
+      expect(snapshot).toEqual({
+        role: "assistant",
+        turn: "assistant",
+        isAssistant: true,
+        text: "Final answer",
+        messageId: "msg-2",
+        hasFinishedActions: true,
+        turnIndex: 2,
+      });
+    });
+
+    it("prefers populated over empty trailing shell", () => {
+      const snapshot = chatgptClient.extractLatestAssistantSnapshot([
+        { role: "assistant", turn: "assistant", isAssistant: true, text: "Actual reply", messageId: "msg-1" },
+        { role: "assistant", turn: "assistant", isAssistant: true, text: "\n\nCopy\nRead aloud\n", messageId: "msg-2" },
+      ]);
+
+      expect(snapshot).toEqual({
+        role: "assistant",
+        turn: "assistant",
+        isAssistant: true,
+        text: "Actual reply",
+        messageId: "msg-1",
+        turnIndex: 0,
+      });
+    });
+
+    it("falls back to empty assistant when all are empty", () => {
+      const snapshot = chatgptClient.extractLatestAssistantSnapshot([
+        { role: "assistant", turn: "assistant", isAssistant: true, text: "", messageId: "msg-1" },
+        { role: "assistant", turn: "assistant", isAssistant: true, text: "\n\n", messageId: "msg-2" },
+      ]);
+
+      expect(snapshot).toEqual({
+        role: "assistant",
+        turn: "assistant",
+        isAssistant: true,
+        text: "",
+        messageId: "msg-2",
+        turnIndex: 1,
+      });
+    });
+
+    it("returns null for non-assistant candidates only", () => {
+      expect(
+        chatgptClient.extractLatestAssistantSnapshot([
+          { role: "user", turn: "user", text: "hello" },
+        ])
+      ).toBeNull();
+    });
+
+    it("accepts isAssistant: true without role/turn metadata", () => {
+      const snapshot = chatgptClient.extractLatestAssistantSnapshot([
+        { role: null, turn: null, isAssistant: true, text: "Answer from testid-only node" },
+      ]);
+
+      expect(snapshot?.text).toBe("Answer from testid-only node");
+      expect(snapshot?.turnIndex).toBe(0);
+    });
+  });
+
+  describe("isNewAssistantContent", () => {
+    it.each([
+      ["no latest", null, { text: "Answer" }, 2, 1, false],
+      ["no baseline", { text: "Answer" }, null, 1, 0, true],
+      [
+        "identical snapshot",
+        { text: "Answer", messageId: "msg-1" },
+        { text: "Answer", messageId: "msg-1" },
+        2,
+        2,
+        false,
+      ],
+      [
+        "new turn with same text",
+        { text: "4", messageId: null, turnIndex: 1 },
+        { text: "4", messageId: null, turnIndex: 0 },
+        2,
+        1,
+        true,
+      ],
+      [
+        "empty shell growth",
+        { text: "4", messageId: null, turnIndex: 0 },
+        { text: "4", messageId: null, turnIndex: 0 },
+        2,
+        1,
+        false,
+      ],
+      [
+        "text changed",
+        { text: "New answer", messageId: "msg-1" },
+        { text: "Old answer", messageId: "msg-1" },
+        2,
+        2,
+        true,
+      ],
+      [
+        "messageId changed",
+        { text: "Answer", messageId: "msg-2" },
+        { text: "Answer", messageId: "msg-1" },
+        2,
+        2,
+        true,
+      ],
+    ])(
+      "%s",
+      (_, latestAssistant, baselineAssistant, assistantCount, baselineAssistantCount, expected) => {
+        expect(
+          chatgptClient.isNewAssistantContent(
+            latestAssistant,
+            baselineAssistant,
+            assistantCount,
+            baselineAssistantCount,
+          ),
+        ).toBe(expected);
+      },
+    );
+  });
+
+  describe("isChatGPTResponseComplete", () => {
+    it("returns false for empty text", () => {
+      expect(
+        chatgptClient.isChatGPTResponseComplete(
+          { text: "", stopVisible: false, hasFinishedActions: true },
+          6,
+          1200,
+        ),
+      ).toBe(false);
+    });
+
+    it("returns false when stop button is still visible", () => {
+      expect(
+        chatgptClient.isChatGPTResponseComplete(
+          { text: "Answer", stopVisible: true, hasFinishedActions: true },
+          6,
+          1200,
+        ),
+      ).toBe(false);
+    });
+
+    it("returns true when finished actions are visible and stop is hidden", () => {
+      expect(
+        chatgptClient.isChatGPTResponseComplete(
+          { text: "Answer", stopVisible: false, hasFinishedActions: true },
+          0,
+          0,
+        ),
+      ).toBe(true);
+    });
+
+    it("returns true when text has been stable long enough", () => {
+      expect(
+        chatgptClient.isChatGPTResponseComplete(
+          { text: "Answer", stopVisible: false, hasFinishedActions: false },
+          6,
+          1200,
+        ),
+      ).toBe(true);
+    });
+
+    it("returns false when stability thresholds are not met", () => {
+      expect(
+        chatgptClient.isChatGPTResponseComplete(
+          { text: "Answer", stopVisible: false, hasFinishedActions: false },
+          5,
+          1199,
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("hasRequiredCookies", () => {
+    it("accepts exact session cookie", () => {
+      expect(
+        chatgptClient.hasRequiredCookies([
+          { name: "__Secure-next-auth.session-token", value: "abc" },
+        ])
+      ).toBe(true);
+    });
+
+    it("rejects exact cookie with empty value", () => {
+      expect(
+        chatgptClient.hasRequiredCookies([
+          { name: "__Secure-next-auth.session-token", value: "" },
+        ])
+      ).toBe(false);
+    });
+
+    it("rejects null and undefined", () => {
+      expect(chatgptClient.hasRequiredCookies(null)).toBe(false);
+      expect(chatgptClient.hasRequiredCookies(undefined)).toBe(false);
+    });
+
+    it("rejects non-array input", () => {
+      expect(chatgptClient.hasRequiredCookies({} as unknown as [])).toBe(false);
+    });
+
+    it("rejects unrelated cookies", () => {
+      expect(
+        chatgptClient.hasRequiredCookies([
+          { name: "oai-did", value: "abc" },
+          { name: "__Host-next-auth.csrf-token", value: "abc" },
+        ])
+      ).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #98 — `surf chatgpt` times out because ChatGPT changed conversation turn wrappers from `<article>`/`<div>` to `<section>` elements.

- Drop tag restriction from `conversationTurn` selector (`[data-testid^="conversation-turn"]` instead of `article[data-testid^="..."]`)
- Broaden `assistantMessage`, `stopButton`, `finishedActions` selectors with fallback variants
- Add `assistantContent` selector for layered content extraction
- Add pure helpers: `cleanChatGPTResponseText`, `extractLatestAssistantSnapshot`, `isNewAssistantContent`, `isChatGPTResponseComplete`
- Rework `waitForResponse()` to use serialized candidate snapshots, text-equality stability tracking, and pre-send baseline to avoid race conditions
- Add fallback to direct assistant node queries when turn wrappers aren't found

## Test plan

- [x] Unit tests for all new helpers (249 tests passing)
- [x] E2E verified: `surf chatgpt "What is 2+2?"` → `4`
- [x] E2E verified: `surf chatgpt "Name 3 primary colors, one per line"` → `Red\nBlue\nYellow`
- [x] Lint: 0 new issues (2 pre-existing in untouched code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)