### PR TITLE
fix(gemini): handle blob-backed generated images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **Gemini blob-backed generated images** - Detect and extract Gemini-generated `blob:` images from the page while preserving existing `gg-dl` URL downloads. (@goneflyin)
+
 ## [2.7.2] - 2026-04-10
 
 ### Fixed

--- a/native/gemini-client.cjs
+++ b/native/gemini-client.cjs
@@ -652,7 +652,15 @@ async function runGeminiWebViaPage(input) {
     if (typed.error) throw new Error(typed.error);
 
     const beforeResult = await jsEval(tabId, `
-      return String(Array.from(document.querySelectorAll('img[src*="gg-dl"]')).filter(i => i.naturalWidth >= 512).length);
+      const generatedImgs = Array.from(document.images).filter((img) => {
+        const src = img.currentSrc || img.src || "";
+        const alt = img.alt || "";
+        const className = String(img.className || "");
+        if (img.naturalWidth < 512 || img.naturalHeight < 512) return false;
+        if (src.includes("gg-dl")) return true;
+        return src.startsWith("blob:") && (alt.includes("AI generated") || className.includes("image"));
+      });
+      return String(generatedImgs.length);
     `);
     const imgCountBefore = parseInt(JSON.parse(checkJsResult(beforeResult, "Count images")) || "0", 10);
 
@@ -669,26 +677,49 @@ async function runGeminiWebViaPage(input) {
     // Poll for response
     if (log) log("Waiting for response...");
     const deadline = Date.now() + timeoutMs;
-    let imageUrls = [];
+    let imageEntries = [];
     let responseText = "";
 
     while (Date.now() < deadline) {
       await new Promise(r => setTimeout(r, 2000));
       const pollResult = await jsEval(tabId, `
-        const ggImgs = Array.from(document.querySelectorAll('img[src*="gg-dl"]'))
-          .filter(i => i.naturalWidth >= 512)
-          .map(i => i.src);
+        const generatedImgs = Array.from(document.images).filter((img) => {
+          const src = img.currentSrc || img.src || "";
+          const alt = img.alt || "";
+          const className = String(img.className || "");
+          if (img.naturalWidth < 512 || img.naturalHeight < 512) return false;
+          if (src.includes("gg-dl")) return true;
+          return src.startsWith("blob:") && (alt.includes("AI generated") || className.includes("image"));
+        });
+        window.__surfGeminiBlobImages = window.__surfGeminiBlobImages || [];
+        const images = await Promise.all(generatedImgs.map(async (img) => {
+          const url = img.currentSrc || img.src || "";
+          if (!url.startsWith("blob:")) return { url };
+          const canvas = document.createElement("canvas");
+          canvas.width = img.naturalWidth;
+          canvas.height = img.naturalHeight;
+          const ctx = canvas.getContext("2d");
+          if (!ctx) throw new Error("Canvas context unavailable");
+          ctx.drawImage(img, 0, 0);
+          const dataUrl = canvas.toDataURL("image/png");
+          const blobIndex = window.__surfGeminiBlobImages.push({
+            url,
+            b64: dataUrl.split(",")[1],
+            type: "image/png",
+          }) - 1;
+          return { url, blobIndex, type: "image/png" };
+        }));
         const loading = !!document.querySelector('mat-progress-bar, .loading-indicator, message-loading');
         const turns = document.querySelectorAll('message-content');
         const lastTurn = turns.length ? turns[turns.length - 1] : null;
         const text = lastTurn ? lastTurn.textContent?.trim() : "";
-        return JSON.stringify({ ggImgs, loading, text, turns: turns.length });
+        return JSON.stringify({ images, loading, text, turns: turns.length });
       `);
       const poll = JSON.parse(JSON.parse(checkJsResult(pollResult, "Poll response")));
-      const newImgs = poll.ggImgs.slice(imgCountBefore);
+      const newImgs = (poll.images || []).slice(imgCountBefore);
 
       if (newImgs.length > 0) {
-        imageUrls = newImgs;
+        imageEntries = newImgs;
         responseText = poll.text || "";
         if (log) log(`Found ${newImgs.length} generated image(s)`);
         break;
@@ -699,23 +730,47 @@ async function runGeminiWebViaPage(input) {
       }
     }
 
-    if (!imageUrls.length && !responseText) {
+    if (!imageEntries.length && !responseText) {
       throw new Error("Gemini response timed out");
     }
 
-    // Download images via extension
+    // Download URL-backed images via extension; read blob images from the page in chunks.
     const images = [];
-    if (fetchUrl) {
-      for (const url of imageUrls) {
-        if (log) log(`Downloading image (${url.slice(0, 60)}...)...`);
-        const dlResult = await fetchUrl(url);
-        if (dlResult?.b64) {
-          images.push({ url, b64: dlResult.b64, type: dlResult.type || "image/png" });
+    for (const img of imageEntries) {
+      if (Number.isInteger(img?.blobIndex)) {
+        let b64 = "";
+        let offset = 0;
+        const chunkSize = 40000;
+        let type = img.type || "image/png";
+        while (true) {
+          const chunkResult = await jsEval(tabId, `
+            const item = window.__surfGeminiBlobImages?.[${img.blobIndex}];
+            if (!item) return JSON.stringify({ error: "Blob image not found" });
+            return JSON.stringify({
+              chunk: item.b64.slice(${offset}, ${offset + chunkSize}),
+              done: ${offset + chunkSize} >= item.b64.length,
+              type: item.type || "image/png",
+              url: item.url,
+            });
+          `);
+          const chunk = JSON.parse(JSON.parse(checkJsResult(chunkResult, "Read blob image chunk")));
+          if (chunk.error) throw new Error(chunk.error);
+          b64 += chunk.chunk || "";
+          type = chunk.type || type;
+          if (chunk.done) break;
+          offset += chunkSize;
         }
+        images.push({ url: img.url, b64, type });
+        continue;
       }
-    } else {
-      for (const url of imageUrls) {
-        images.push({ url });
+      if (img?.url && fetchUrl) {
+        if (log) log(`Downloading image (${img.url.slice(0, 60)}...)...`);
+        const dlResult = await fetchUrl(img.url);
+        if (dlResult?.b64) {
+          images.push({ url: img.url, b64: dlResult.b64, type: dlResult.type || "image/png" });
+        }
+      } else if (img?.url) {
+        images.push({ url: img.url });
       }
     }
 
@@ -917,6 +972,7 @@ module.exports = {
   hasRequiredCookies,
   buildCookieMap,
   parseGeminiStreamGenerateResponse,
+  runGeminiWebViaPage,
   REQUIRED_COOKIES,
   ALL_COOKIE_NAMES,
   GEMINI_APP_URL,

--- a/native/gemini-client.cjs
+++ b/native/gemini-client.cjs
@@ -652,17 +652,21 @@ async function runGeminiWebViaPage(input) {
     if (typed.error) throw new Error(typed.error);
 
     const beforeResult = await jsEval(tabId, `
-      const generatedImgs = Array.from(document.images).filter((img) => {
-        const src = img.currentSrc || img.src || "";
-        const alt = img.alt || "";
-        const className = String(img.className || "");
-        if (img.naturalWidth < 512 || img.naturalHeight < 512) return false;
-        if (src.includes("gg-dl")) return true;
-        return src.startsWith("blob:") && (alt.includes("AI generated") || className.includes("image"));
-      });
-      return String(generatedImgs.length);
+      const imageKey = (img) => {
+        const url = img.currentSrc || img.src || "";
+        return url + "|" + img.naturalWidth + "x" + img.naturalHeight;
+      };
+      const baselineKeys = Array.from(document.images)
+        .filter((img) => {
+          const url = img.currentSrc || img.src || "";
+          return img.naturalWidth >= 512
+            && img.naturalHeight >= 512
+            && (url.includes("gg-dl") || url.startsWith("blob:"));
+        })
+        .map(imageKey);
+      return JSON.stringify(baselineKeys);
     `);
-    const imgCountBefore = parseInt(JSON.parse(checkJsResult(beforeResult, "Count images")) || "0", 10);
+    const baselineImageKeys = JSON.parse(JSON.parse(checkJsResult(beforeResult, "Count images")) || "[]");
 
     if (log) log("Submitting...");
     const sendResult = await jsEval(tabId, `
@@ -683,18 +687,28 @@ async function runGeminiWebViaPage(input) {
     while (Date.now() < deadline) {
       await new Promise(r => setTimeout(r, 2000));
       const pollResult = await jsEval(tabId, `
-        const generatedImgs = Array.from(document.images).filter((img) => {
-          const src = img.currentSrc || img.src || "";
-          const alt = img.alt || "";
-          const className = String(img.className || "");
-          if (img.naturalWidth < 512 || img.naturalHeight < 512) return false;
-          if (src.includes("gg-dl")) return true;
-          return src.startsWith("blob:") && (alt.includes("AI generated") || className.includes("image"));
-        });
+        const baselineKeys = new Set(${JSON.stringify(baselineImageKeys)});
+        const imageKey = (img) => {
+          const url = img.currentSrc || img.src || "";
+          return url + "|" + img.naturalWidth + "x" + img.naturalHeight;
+        };
+        const generatedImgs = Array.from(document.images)
+          .filter((img) => {
+            const url = img.currentSrc || img.src || "";
+            return img.naturalWidth >= 512
+              && img.naturalHeight >= 512
+              && (url.includes("gg-dl") || url.startsWith("blob:"));
+          })
+          .filter((img) => !baselineKeys.has(imageKey(img)));
         window.__surfGeminiBlobImages = window.__surfGeminiBlobImages || [];
+        window.__surfGeminiBlobImageIndexes = window.__surfGeminiBlobImageIndexes || Object.create(null);
         const images = await Promise.all(generatedImgs.map(async (img) => {
           const url = img.currentSrc || img.src || "";
           if (!url.startsWith("blob:")) return { url };
+          const key = imageKey(img);
+          if (Number.isInteger(window.__surfGeminiBlobImageIndexes[key])) {
+            return { url, blobIndex: window.__surfGeminiBlobImageIndexes[key], type: "image/png" };
+          }
           const canvas = document.createElement("canvas");
           canvas.width = img.naturalWidth;
           canvas.height = img.naturalHeight;
@@ -707,6 +721,7 @@ async function runGeminiWebViaPage(input) {
             b64: dataUrl.split(",")[1],
             type: "image/png",
           }) - 1;
+          window.__surfGeminiBlobImageIndexes[key] = blobIndex;
           return { url, blobIndex, type: "image/png" };
         }));
         const loading = !!document.querySelector('mat-progress-bar, .loading-indicator, message-loading');
@@ -716,7 +731,7 @@ async function runGeminiWebViaPage(input) {
         return JSON.stringify({ images, loading, text, turns: turns.length });
       `);
       const poll = JSON.parse(JSON.parse(checkJsResult(pollResult, "Poll response")));
-      const newImgs = (poll.images || []).slice(imgCountBefore);
+      const newImgs = poll.images || [];
 
       if (newImgs.length > 0) {
         imageEntries = newImgs;

--- a/test/unit/gemini-client.test.ts
+++ b/test/unit/gemini-client.test.ts
@@ -1,0 +1,80 @@
+import { vi } from "vitest";
+// @ts-expect-error - CommonJS module without type definitions
+import * as geminiClient from "../../native/gemini-client.cjs";
+
+describe("gemini-client", () => {
+  describe("runGeminiWebViaPage", () => {
+    it("detects and returns blob-backed Gemini generated images", async () => {
+      vi.useFakeTimers();
+      const seenScripts: string[] = [];
+      const logs: string[] = [];
+
+      const asChromeOutput = (value: string) => ({ output: JSON.stringify(value) });
+
+      const run = geminiClient.runGeminiWebViaPage({
+        prompt: "generate a test image",
+        model: "gemini-3-pro",
+        timeoutMs: 10_000,
+        log: (msg: string) => logs.push(msg),
+        createTab: async () => ({ tabId: 123 }),
+        closeTab: async () => ({ ok: true }),
+        jsEval: async (_tabId: number, code: string) => {
+          seenScripts.push(code);
+
+          if (code.includes("document.execCommand('insertText'")) {
+            return asChromeOutput(JSON.stringify({ ok: true, len: 21 }));
+          }
+
+          if (code.includes("return String(generatedImgs.length)")) {
+            expect(code).toContain('src.startsWith("blob:")');
+            return asChromeOutput("0");
+          }
+
+          if (code.includes('button[aria-label="Send message"]')) {
+            return asChromeOutput("sent");
+          }
+
+          if (code.includes("const images = await Promise.all")) {
+            expect(code).toContain('src.startsWith("blob:")');
+            expect(code).toContain("canvas.toDataURL");
+            return asChromeOutput(JSON.stringify({
+              images: [{
+                url: "blob:https://gemini.google.com/generated-image",
+                blobIndex: 0,
+                type: "image/png",
+              }],
+              loading: false,
+              text: "",
+              turns: 1,
+            }));
+          }
+
+          if (code.includes("window.__surfGeminiBlobImages?.[0]")) {
+            return asChromeOutput(JSON.stringify({
+              chunk: "ZmFrZS1wbmc=",
+              done: true,
+              type: "image/png",
+              url: "blob:https://gemini.google.com/generated-image",
+            }));
+          }
+
+          throw new Error(`Unexpected script: ${code}`);
+        },
+      });
+
+      await vi.runAllTimersAsync();
+      const result = await run;
+      vi.useRealTimers();
+
+      expect(result.images).toEqual([
+        {
+          url: "blob:https://gemini.google.com/generated-image",
+          b64: "ZmFrZS1wbmc=",
+          type: "image/png",
+        },
+      ]);
+      expect(logs).toContain("Found 1 generated image(s)");
+      expect(seenScripts.some((script) => script.includes("gg-dl"))).toBe(true);
+    });
+  });
+});

--- a/test/unit/gemini-client.test.ts
+++ b/test/unit/gemini-client.test.ts
@@ -1,15 +1,24 @@
-import { vi } from "vitest";
+import { afterEach, vi } from "vitest";
 // @ts-expect-error - CommonJS module without type definitions
 import * as geminiClient from "../../native/gemini-client.cjs";
 
+const asChromeOutput = (value: string) => ({ output: JSON.stringify(value) });
+
+const promptTyped = (code: string) => code.includes("document.execCommand('insertText'");
+const baselineCollected = (code: string) => code.includes("return JSON.stringify(baselineKeys)");
+const sendClicked = (code: string) => code.includes('button[aria-label="Send message"]');
+const imagesPolled = (code: string) => code.includes("window.__surfGeminiBlobImageIndexes");
+
 describe("gemini-client", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   describe("runGeminiWebViaPage", () => {
-    it("detects and returns blob-backed Gemini generated images", async () => {
+    it("detects and extracts large blob-backed generated images without alt or class markers", async () => {
       vi.useFakeTimers();
       const seenScripts: string[] = [];
       const logs: string[] = [];
-
-      const asChromeOutput = (value: string) => ({ output: JSON.stringify(value) });
 
       const run = geminiClient.runGeminiWebViaPage({
         prompt: "generate a test image",
@@ -21,22 +30,27 @@ describe("gemini-client", () => {
         jsEval: async (_tabId: number, code: string) => {
           seenScripts.push(code);
 
-          if (code.includes("document.execCommand('insertText'")) {
+          if (promptTyped(code)) {
             return asChromeOutput(JSON.stringify({ ok: true, len: 21 }));
           }
 
-          if (code.includes("return String(generatedImgs.length)")) {
-            expect(code).toContain('src.startsWith("blob:")');
-            return asChromeOutput("0");
+          if (baselineCollected(code)) {
+            expect(code).toContain('url.startsWith("blob:")');
+            expect(code).toContain('url.includes("gg-dl")');
+            expect(code).not.toContain("alt");
+            expect(code).not.toContain("className");
+            return asChromeOutput(JSON.stringify([]));
           }
 
-          if (code.includes('button[aria-label="Send message"]')) {
+          if (sendClicked(code)) {
             return asChromeOutput("sent");
           }
 
-          if (code.includes("const images = await Promise.all")) {
-            expect(code).toContain('src.startsWith("blob:")');
+          if (imagesPolled(code)) {
+            expect(code).toContain('url.startsWith("blob:")');
             expect(code).toContain("canvas.toDataURL");
+            expect(code).not.toContain("alt");
+            expect(code).not.toContain("className");
             return asChromeOutput(JSON.stringify({
               images: [{
                 url: "blob:https://gemini.google.com/generated-image",
@@ -64,7 +78,6 @@ describe("gemini-client", () => {
 
       await vi.runAllTimersAsync();
       const result = await run;
-      vi.useRealTimers();
 
       expect(result.images).toEqual([
         {
@@ -75,6 +88,105 @@ describe("gemini-client", () => {
       ]);
       expect(logs).toContain("Found 1 generated image(s)");
       expect(seenScripts.some((script) => script.includes("gg-dl"))).toBe(true);
+    });
+
+    it("excludes pre-existing large images before serializing blob candidates", async () => {
+      vi.useFakeTimers();
+      const baselineKey = "blob:https://gemini.google.com/baseline|1024x1024";
+
+      const run = geminiClient.runGeminiWebViaPage({
+        prompt: "generate a new image",
+        model: "gemini-3-pro",
+        timeoutMs: 10_000,
+        createTab: async () => ({ tabId: 123 }),
+        closeTab: async () => ({ ok: true }),
+        jsEval: async (_tabId: number, code: string) => {
+          if (promptTyped(code)) {
+            return asChromeOutput(JSON.stringify({ ok: true, len: 20 }));
+          }
+
+          if (baselineCollected(code)) {
+            return asChromeOutput(JSON.stringify([baselineKey]));
+          }
+
+          if (sendClicked(code)) {
+            return asChromeOutput("sent");
+          }
+
+          if (imagesPolled(code)) {
+            expect(code).toContain(`const baselineKeys = new Set(["${baselineKey}"])`);
+            expect(code).toContain(".filter((img) => !baselineKeys.has(imageKey(img)))");
+            expect(code.indexOf("!baselineKeys.has(imageKey(img))")).toBeLessThan(code.indexOf("canvas.toDataURL"));
+            return asChromeOutput(JSON.stringify({
+              images: [],
+              loading: false,
+              text: "No new image was generated.",
+              turns: 1,
+            }));
+          }
+
+          throw new Error(`Unexpected script: ${code}`);
+        },
+      });
+
+      await vi.runAllTimersAsync();
+      const result = await run;
+
+      expect(result.images).toEqual([]);
+      expect(result.text).toBe("No new image was generated.");
+    });
+
+    it("keeps existing gg-dl image URL download support", async () => {
+      vi.useFakeTimers();
+      const fetchUrl = vi.fn(async (url: string) => ({
+        b64: url === "https://lh3.googleusercontent.com/gg-dl/generated" ? "Z2ctZGw=" : "",
+        type: "image/jpeg",
+      }));
+
+      const run = geminiClient.runGeminiWebViaPage({
+        prompt: "generate a test image",
+        model: "gemini-3-pro",
+        timeoutMs: 10_000,
+        createTab: async () => ({ tabId: 123 }),
+        closeTab: async () => ({ ok: true }),
+        fetchUrl,
+        jsEval: async (_tabId: number, code: string) => {
+          if (promptTyped(code)) {
+            return asChromeOutput(JSON.stringify({ ok: true, len: 21 }));
+          }
+
+          if (baselineCollected(code)) {
+            return asChromeOutput(JSON.stringify([]));
+          }
+
+          if (sendClicked(code)) {
+            return asChromeOutput("sent");
+          }
+
+          if (imagesPolled(code)) {
+            return asChromeOutput(JSON.stringify({
+              images: [{ url: "https://lh3.googleusercontent.com/gg-dl/generated" }],
+              loading: false,
+              text: "",
+              turns: 1,
+            }));
+          }
+
+          throw new Error(`Unexpected script: ${code}`);
+        },
+      });
+
+      await vi.runAllTimersAsync();
+      const result = await run;
+
+      expect(fetchUrl).toHaveBeenCalledWith("https://lh3.googleusercontent.com/gg-dl/generated");
+      expect(result.images).toEqual([
+        {
+          url: "https://lh3.googleusercontent.com/gg-dl/generated",
+          b64: "Z2ctZGw=",
+          type: "image/jpeg",
+        },
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Summary
- detect Gemini generated images that now render as blob: URLs, not only lh3 gg-dl URLs
- convert blob-backed images to base64 in the Gemini page context before saving
- keep existing gg-dl URL download path for older UI responses
- add a regression test for blob-backed image detection

## Why
Gemini image generation can complete successfully in the browser but `surf gemini --generate-image` keeps polling until timeout because the UI now renders the generated image as `blob:https://gemini.google.com/...`. The existing poller only looks for `img[src*="gg-dl"]`, so image-only responses have no success condition.

## Test plan
- `npm test -- --run test/unit/gemini-client.test.ts`
- `npm test -- --run test/unit/chatgpt-client.test.ts test/unit/grok-client.test.ts`

Note: `npm run check` and `npm run lint` currently fail on main due to unrelated existing TypeScript/Biome config errors.
