### PR TITLE
fix: include nested text in accessibility names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - **Gemini blob-backed generated images** - Detect and extract Gemini-generated `blob:` images from the page while preserving existing `gg-dl` URL downloads. (@goneflyin)
+- **Accessibility tree nested labels** - Include nested text content when naming interactive links, buttons, and summaries so child spans contribute accessible names. (@skyeryg)
 
 ## [2.7.2] - 2026-04-10
 

--- a/src/content/accessibility-tree.ts
+++ b/src/content/accessibility-tree.ts
@@ -445,12 +445,7 @@ function generateAccessibilityTree(
       }
 
       if (["button", "a", "summary"].includes(tag)) {
-        let textContent = "";
-        for (const node of element.childNodes) {
-          if (node.nodeType === Node.TEXT_NODE) {
-            textContent += node.textContent;
-          }
-        }
+        const textContent = element.textContent || "";
         if (textContent.trim()) return textContent.trim();
       }
 
@@ -896,12 +891,7 @@ function generateYamlTree(
       }
 
       if (["button", "a", "summary"].includes(tag)) {
-        let textContent = "";
-        for (const node of element.childNodes) {
-          if (node.nodeType === Node.TEXT_NODE) {
-            textContent += node.textContent;
-          }
-        }
+        const textContent = element.textContent || "";
         if (textContent.trim()) return textContent.trim();
       }
 

--- a/test/unit/accessibility-tree.test.ts
+++ b/test/unit/accessibility-tree.test.ts
@@ -1,0 +1,171 @@
+class FakeNode {
+  static TEXT_NODE = 3;
+}
+
+class FakeText extends FakeNode {
+  nodeType = 3;
+
+  constructor(public textContent: string) {
+    super();
+  }
+}
+
+class FakeElement extends FakeNode {
+  childNodes: Array<FakeElement | FakeText> = [];
+  parentElement: FakeElement | null = null;
+  offsetWidth = 10;
+  offsetHeight = 10;
+  selectedIndex = -1;
+  options: FakeElement[] = [];
+  value = "";
+  disabled = false;
+  indeterminate = false;
+  checked = false;
+
+  private attrs = new Map<string, string>();
+
+  constructor(public tagName: string) {
+    super();
+    this.tagName = tagName.toUpperCase();
+  }
+
+  get id(): string {
+    return this.getAttribute("id") || "";
+  }
+
+  get type(): string {
+    return this.getAttribute("type") || "";
+  }
+
+  get children(): FakeElement[] {
+    return this.childNodes.filter((child): child is FakeElement => child instanceof FakeElement);
+  }
+
+  get textContent(): string {
+    return this.childNodes.map(child => child.textContent || "").join("");
+  }
+
+  set textContent(value: string) {
+    this.childNodes = [new FakeText(value)];
+  }
+
+  append(...children: Array<FakeElement | FakeText>): void {
+    for (const child of children) {
+      if (child instanceof FakeElement) child.parentElement = this;
+      this.childNodes.push(child);
+    }
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attrs.get(name) ?? null;
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attrs.set(name, value);
+  }
+
+  hasAttribute(name: string): boolean {
+    return this.attrs.has(name);
+  }
+
+  closest(): FakeElement | null {
+    return null;
+  }
+
+  querySelector(): FakeElement | null {
+    return null;
+  }
+
+  getBoundingClientRect(): { top: number; bottom: number; left: number; right: number } {
+    return { top: 0, bottom: 10, left: 0, right: 10 };
+  }
+}
+
+class FakeButtonElement extends FakeElement {}
+class FakeInputElement extends FakeElement {}
+class FakeSelectElement extends FakeElement {}
+class FakeTextAreaElement extends FakeElement {}
+
+function text(value: string): FakeText {
+  return new FakeText(value);
+}
+
+function element(tagName: string, attrs: Record<string, string> = {}): FakeElement {
+  const node = tagName === "button" ? new FakeButtonElement(tagName) : new FakeElement(tagName);
+  for (const [name, value] of Object.entries(attrs)) node.setAttribute(name, value);
+  return node;
+}
+
+describe("accessibility tree", () => {
+  let messageHandler: ((message: any, sender: any, sendResponse: (response: any) => void) => boolean) | undefined;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    messageHandler = undefined;
+
+    (globalThis as any).Element = FakeElement;
+    (globalThis as any).HTMLElement = FakeElement;
+    (globalThis as any).HTMLButtonElement = FakeButtonElement;
+    (globalThis as any).HTMLInputElement = FakeInputElement;
+    (globalThis as any).HTMLSelectElement = FakeSelectElement;
+    (globalThis as any).HTMLTextAreaElement = FakeTextAreaElement;
+    (globalThis as any).Node = FakeNode;
+
+    (globalThis as any).window = {
+      innerWidth: 1024,
+      innerHeight: 768,
+      getComputedStyle: () => ({
+        display: "block",
+        visibility: "visible",
+        opacity: "1",
+        cursor: "default",
+      }),
+    };
+
+    (globalThis as any).document = {
+      body: new FakeElement("body"),
+      getElementById: () => null,
+      querySelector: () => null,
+      querySelectorAll: () => [],
+    };
+
+    (globalThis as any).chrome = {
+      runtime: {
+        onMessage: {
+          addListener: (handler: typeof messageHandler) => {
+            messageHandler = handler;
+          },
+        },
+      },
+    };
+
+    await import("../../src/content/accessibility-tree");
+  });
+
+  it("uses nested text for interactive link and button names", () => {
+    const link = element("a", { href: "/docs" });
+    const linkLabel = element("span");
+    linkLabel.append(text("Read docs"));
+    link.append(linkLabel);
+
+    const button = element("button");
+    const buttonLabel = element("span");
+    buttonLabel.append(text("Save changes"));
+    button.append(buttonLabel);
+
+    (document.body as unknown as FakeElement).append(link, button);
+
+    let response: any;
+    messageHandler?.(
+      { type: "GENERATE_ACCESSIBILITY_TREE", options: { filter: "interactive" } },
+      {},
+      result => {
+        response = result;
+      },
+    );
+
+    expect(response.error).toBeUndefined();
+    expect(response.pageContent).toContain('link "Read docs"');
+    expect(response.pageContent).toContain('button "Save changes"');
+  });
+});


### PR DESCRIPTION
This rescues #87 as a clean maintainer branch from current `main`.

It keeps the useful part of @skyeryg's original PR: interactive links, buttons, and summaries now include nested text content in their generated accessibility names, so labels inside child elements are not dropped.

The original PR branch had accumulated stale unrelated changes, so this replacement keeps the final diff focused and credits @skyeryg in `CHANGELOG.md`.

Validation:
- `npm test -- --run test/unit/accessibility-tree.test.ts`
- `npx tsc --noEmit --target ES2022 --module ESNext --moduleResolution bundler --strict --esModuleInterop --skipLibCheck --lib ES2022,DOM,DOM.Iterable --types chrome,vitest/globals src/content/accessibility-tree.ts test/unit/accessibility-tree.test.ts`
