### PR TITLE
fix: use portable native host wrapper shebang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- **Native messaging host portability** - Generated Unix wrappers now use `#!/usr/bin/env bash` so Chrome can launch the host on NixOS, Guix, and other non-FHS Linux systems. (@ppetru)
 - **Gemini blob-backed generated images** - Detect and extract Gemini-generated `blob:` images from the page while preserving existing `gg-dl` URL downloads. (@goneflyin)
 - **Accessibility tree nested labels** - Include nested text content when naming interactive links, buttons, and summaries so child spans contribute accessible names. (@skyeryg)
 

--- a/scripts/install-native-host.cjs
+++ b/scripts/install-native-host.cjs
@@ -129,7 +129,7 @@ function createWrapper(wrapperDir, nodePath, hostPath) {
   } else {
     const shPath = path.join(wrapperDir, "host-wrapper.sh");
     const hostDir = path.dirname(hostPath);
-    const content = `#!/bin/bash
+    const content = `#!/usr/bin/env bash
 cd "${hostDir}"
 exec "${nodePath}" "${hostPath}"
 `;


### PR DESCRIPTION
This rescues #45 on a clean branch from current `main`.

It applies @ppetru's portable native messaging host wrapper shebang fix and credits the contribution in `CHANGELOG.md`.

Validation:
- `node -c scripts/install-native-host.cjs`
- `git diff --check -- CHANGELOG.md scripts/install-native-host.cjs`
