### PR TITLE
build: restore baseline validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,13 @@
 ## [Unreleased]
 
 ### Fixed
+- **Baseline CI validation** - Restored lint, typecheck, tests, and critical audit checks on current dependencies.
 - **Native messaging host portability** - Generated Unix wrappers now use `#!/usr/bin/env bash` so Chrome can launch the host on NixOS, Guix, and other non-FHS Linux systems. (@ppetru)
 - **Gemini blob-backed generated images** - Detect and extract Gemini-generated `blob:` images from the page while preserving existing `gg-dl` URL downloads. (@goneflyin)
 - **Accessibility tree nested labels** - Include nested text content when naming interactive links, buttons, and summaries so child spans contribute accessible names. (@skyeryg)
+
+### Dependencies
+- Bump Vitest package group from 4.0.18 to 4.1.9 to clear the critical audit advisory.
 
 ## [2.7.2] - 2026-04-10
 

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
   "files": {
     "includes": ["test/**/*.ts"]
   },
@@ -12,7 +12,6 @@
         "noFloatingPromises": "error",
         "noMisusedPromises": "error",
         "noShadow": "error",
-        "noUnusedExpressions": "error",
         "useAwaitThenable": "error",
         "noUnnecessaryConditions": "warn"
       },
@@ -38,7 +37,8 @@
         "noEmptyBlockStatements": "error",
         "noAssignInExpressions": "error",
         "noAsyncPromiseExecutor": "error",
-        "noTsIgnore": "error"
+        "noTsIgnore": "error",
+        "noUnusedExpressions": "error"
       },
       "style": {
         "noNonNullAssertion": "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,17 +24,17 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.4",
         "@types/chrome": "^0.1.37",
-        "@vitest/coverage-v8": "^4.0.18",
-        "@vitest/ui": "^4.0.18",
+        "@vitest/coverage-v8": "^4.1.9",
+        "@vitest/ui": "^4.1.9",
         "typescript": "^5.7.2",
         "vite": "^7.3.1",
-        "vitest": "^4.0.18"
+        "vitest": "^4.1.9"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -42,9 +42,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -52,13 +52,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -68,14 +68,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1162,29 +1162,29 @@
       "license": "MIT"
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz",
-      "integrity": "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.0.18",
-        "ast-v8-to-istanbul": "^0.3.10",
+        "@vitest/utils": "4.1.9",
+        "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.1",
+        "magicast": "^0.5.2",
         "obug": "^2.1.1",
-        "std-env": "^3.10.0",
-        "tinyrainbow": "^3.0.3"
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.0.18",
-        "vitest": "4.0.18"
+        "@vitest/browser": "4.1.9",
+        "vitest": "4.1.9"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -1193,31 +1193,31 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
-      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "chai": "^6.2.1",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
-      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.0.18",
+        "@vitest/spy": "4.1.9",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1226,7 +1226,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -1248,26 +1248,26 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
-      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
-      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.18",
+        "@vitest/utils": "4.1.9",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1275,13 +1275,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
-      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1290,9 +1291,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
-      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1300,37 +1301,37 @@
       }
     },
     "node_modules/@vitest/ui": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.0.18.tgz",
-      "integrity": "sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.9.tgz",
+      "integrity": "sha512-U/cRvtqfEPj27FI1n9cyUvi4vXXdcLhjJiI+InYKdk8hP4VrS6RXOjGL7rfFaeBc37iRKANsR6eEzIoC7lmgBQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@vitest/utils": "4.0.18",
+        "@vitest/utils": "4.1.9",
         "fflate": "^0.8.2",
-        "flatted": "^3.3.3",
+        "flatted": "^3.4.2",
         "pathe": "^2.0.3",
         "sirv": "^3.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "4.0.18"
+        "vitest": "4.1.9"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
-      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -1423,15 +1424,15 @@
       }
     },
     "node_modules/ast-v8-to-istanbul": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.10.tgz",
-      "integrity": "sha512-p4K7vMz2ZSk3wN8l5o3y2bJAoZXT3VuJI5OLTATY/01CYWumWvwkUw0SqDBnNq6IiTO3qDa1eSQDibAV8g7XOQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.31",
         "estree-walker": "^3.0.3",
-        "js-tokens": "^9.0.1"
+        "js-tokens": "^10.0.0"
       }
     },
     "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
@@ -1753,6 +1754,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cookie": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
@@ -2047,9 +2055,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2168,9 +2176,9 @@
       }
     },
     "node_modules/expect-type": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
-      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2182,7 +2190,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2279,9 +2286,9 @@
       }
     },
     "node_modules/fflate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2323,9 +2330,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2543,7 +2550,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.1.tgz",
       "integrity": "sha512-hi9afu8g0lfJVLolxElAZGANCTTl6bewIdsRNhaywfP9K8BPf++F2z6OLrYGIinUwpRKzbZHMhPwvc0ZEpAwGw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2828,9 +2834,9 @@
       }
     },
     "node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -2871,14 +2877,14 @@
       }
     },
     "node_modules/magicast": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.1.tgz",
-      "integrity": "sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
         "source-map-js": "^1.2.1"
       }
     },
@@ -3181,15 +3187,18 @@
       }
     },
     "node_modules/obug": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -3622,7 +3631,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.54.0.tgz",
       "integrity": "sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -3966,9 +3974,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4082,9 +4090,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4108,9 +4116,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4259,7 +4267,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4346,32 +4353,31 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
-      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@vitest/expect": "4.0.18",
-        "@vitest/mocker": "4.0.18",
-        "@vitest/pretty-format": "4.0.18",
-        "@vitest/runner": "4.0.18",
-        "@vitest/snapshot": "4.0.18",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "es-module-lexer": "^1.7.0",
-        "expect-type": "^1.2.2",
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
         "obug": "^2.1.1",
         "pathe": "^2.0.3",
         "picomatch": "^4.0.3",
-        "std-env": "^3.10.0",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -4387,12 +4393,15 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.18",
-        "@vitest/browser-preview": "4.0.18",
-        "@vitest/browser-webdriverio": "4.0.18",
-        "@vitest/ui": "4.0.18",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
@@ -4413,6 +4422,12 @@
         "@vitest/browser-webdriverio": {
           "optional": true
         },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
         "@vitest/ui": {
           "optional": true
         },
@@ -4421,6 +4436,9 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },
@@ -4515,7 +4533,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -62,10 +62,10 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.4",
     "@types/chrome": "^0.1.37",
-    "@vitest/coverage-v8": "^4.0.18",
-    "@vitest/ui": "^4.0.18",
+    "@vitest/coverage-v8": "^4.1.9",
+    "@vitest/ui": "^4.1.9",
     "typescript": "^5.7.2",
     "vite": "^7.3.1",
-    "vitest": "^4.0.18"
+    "vitest": "^4.1.9"
   }
 }

--- a/src/cdp/controller.ts
+++ b/src/cdp/controller.ts
@@ -1155,13 +1155,21 @@ export class CDPController {
     });
   }
 
-  private async send(tabId: number, method: string, params?: object): Promise<any> {
+  private async send(
+    tabId: number,
+    method: string,
+    params?: { [key: string]: unknown },
+  ): Promise<any> {
     await this.ensureAttached(tabId);
     const target = this.targets.get(tabId)!;
     return chrome.debugger.sendCommand(target, method, params);
   }
 
-  async sendCommand(tabId: number, method: string, params?: object): Promise<any> {
+  async sendCommand(
+    tabId: number,
+    method: string,
+    params?: { [key: string]: unknown },
+  ): Promise<any> {
     return this.send(tabId, method, params);
   }
 

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -2152,7 +2152,7 @@ export async function handleMessage(
     case "SWITCH_TAB": {
       const targetTabId = message.tabId;
       if (!targetTabId) throw new Error("No tabId provided");
-      const tab = await chrome.tabs.update(targetTabId, { active: true });
+      const tab = (await chrome.tabs.update(targetTabId, { active: true })) as chrome.tabs.Tab;
       if (tab.windowId) {
         await chrome.windows.update(tab.windowId, { focused: true });
       }
@@ -2341,28 +2341,29 @@ export async function handleMessage(
     }
 
     case "TAB_GROUP_CREATE": {
-      const tabIds = [...(message.tabIds || [])];
+      const tabIds: number[] = [...(message.tabIds || [])];
       const name = message.name || "Surf";
-      const validColors = ['grey', 'blue', 'red', 'yellow', 'green', 'pink', 'purple', 'cyan', 'orange'];
-      const color = validColors.includes(message.color) ? message.color : 'blue';
+      const validColors = ["grey", "blue", "red", "yellow", "green", "pink", "purple", "cyan", "orange"];
+      const color = validColors.includes(message.color) ? message.color : "blue";
       
       if (tabIds.length === 0 && tabId) {
         tabIds.push(tabId);
       }
       
       if (tabIds.length === 0) throw new Error("No tabs specified");
+      const groupTabIds = tabIds.length === 1 ? tabIds[0] : (tabIds as [number, ...number[]]);
       
       const existingGroups = await chrome.tabGroups.query({ title: name });
       let groupId: number;
       
       if (existingGroups.length > 0) {
         groupId = existingGroups[0].id;
-        await chrome.tabs.group({ tabIds, groupId });
+        await chrome.tabs.group({ tabIds: groupTabIds, groupId });
       } else {
-        groupId = await chrome.tabs.group({ tabIds });
+        groupId = await chrome.tabs.group({ tabIds: groupTabIds });
         await chrome.tabGroups.update(groupId, {
           title: name,
-          color: color as chrome.tabGroups.ColorEnum,
+          color: color as `${chrome.tabGroups.Color}`,
           collapsed: false,
         });
       }
@@ -2371,14 +2372,15 @@ export async function handleMessage(
     }
 
     case "TAB_GROUP_REMOVE": {
-      const tabIds = [...(message.tabIds || [])];
+      const tabIds: number[] = [...(message.tabIds || [])];
       if (tabIds.length === 0 && tabId) {
         tabIds.push(tabId);
       }
       
       if (tabIds.length === 0) throw new Error("No tabs specified");
+      const ungroupTabIds = tabIds.length === 1 ? tabIds[0] : (tabIds as [number, ...number[]]);
       
-      await chrome.tabs.ungroup(tabIds);
+      await chrome.tabs.ungroup(ungroupTabIds);
       return { success: true, ungrouped: tabIds };
     }
 
@@ -2629,7 +2631,7 @@ export async function handleMessage(
       const currentTab = await chrome.tabs.get(tab.id);
       if (currentTab.status !== "complete") {
         await new Promise<void>((resolve) => {
-          const listener = (tabId: number, info: chrome.tabs.TabChangeInfo) => {
+          const listener = (tabId: number, info: chrome.tabs.OnUpdatedInfo) => {
             if (tabId === tab.id && info.status === "complete") {
               chrome.tabs.onUpdated.removeListener(listener);
               resolve();
@@ -2681,7 +2683,7 @@ export async function handleMessage(
       const currentTab = await chrome.tabs.get(tab.id);
       if (currentTab.status !== "complete") {
         await new Promise<void>((resolve) => {
-          const listener = (tabId: number, info: chrome.tabs.TabChangeInfo) => {
+          const listener = (tabId: number, info: chrome.tabs.OnUpdatedInfo) => {
             if (tabId === tab.id && info.status === "complete") {
               chrome.tabs.onUpdated.removeListener(listener);
               resolve();
@@ -2766,7 +2768,7 @@ export async function handleMessage(
       const currentTab = await chrome.tabs.get(tab.id);
       if (currentTab.status !== "complete") {
         await new Promise<void>((resolve) => {
-          const listener = (tabId: number, info: chrome.tabs.TabChangeInfo) => {
+          const listener = (tabId: number, info: chrome.tabs.OnUpdatedInfo) => {
             if (tabId === tab.id && info.status === "complete") {
               chrome.tabs.onUpdated.removeListener(listener);
               resolve();
@@ -2936,7 +2938,7 @@ export async function handleMessage(
       const currentTab = await chrome.tabs.get(tab.id);
       if (currentTab.status !== "complete") {
         await new Promise<void>((resolve) => {
-          const listener = (tabId: number, info: chrome.tabs.TabChangeInfo) => {
+          const listener = (tabId: number, info: chrome.tabs.OnUpdatedInfo) => {
             if (tabId === tab.id && info.status === "complete") {
               chrome.tabs.onUpdated.removeListener(listener);
               resolve();
@@ -3038,7 +3040,7 @@ export async function handleMessage(
         createOptions.incognito = true;
       }
       
-      const window = await chrome.windows.create(createOptions);
+      const window = (await chrome.windows.create(createOptions)) as chrome.windows.Window;
       
       if (!window.id) throw new Error("Failed to create window");
       
@@ -3103,9 +3105,9 @@ export async function handleMessage(
       if (message.height) updateInfo.height = message.height;
       if (message.left !== undefined) updateInfo.left = message.left;
       if (message.top !== undefined) updateInfo.top = message.top;
-      if (message.state) updateInfo.state = message.state as chrome.windows.windowStateEnum;
+      if (message.state) updateInfo.state = message.state as `${chrome.windows.WindowState}`;
       
-      const window = await chrome.windows.update(message.windowId, updateInfo);
+      const window = (await chrome.windows.update(message.windowId, updateInfo)) as chrome.windows.Window;
       return { 
         success: true, 
         windowId: message.windowId,

--- a/test/mocks/chrome.ts
+++ b/test/mocks/chrome.ts
@@ -256,6 +256,7 @@ export function createMockTab(overrides: Partial<chrome.tabs.Tab> = {}): chrome.
     status: "complete",
     discarded: false,
     autoDiscardable: true,
+    frozen: false,
     groupId: -1,
     ...overrides,
   };

--- a/test/types/cjs-modules.d.ts
+++ b/test/types/cjs-modules.d.ts
@@ -1,0 +1,5 @@
+declare module "node:module" {
+  export function createRequire(filename: string | URL): (id: string) => {
+    [key: string]: (...args: unknown[]) => unknown;
+  };
+}

--- a/test/unit/accessibility-tree.test.ts
+++ b/test/unit/accessibility-tree.test.ts
@@ -1,3 +1,5 @@
+import { vi } from "vitest";
+
 class FakeNode {
   static TEXT_NODE = 3;
 }
@@ -42,7 +44,7 @@ class FakeElement extends FakeNode {
   }
 
   get textContent(): string {
-    return this.childNodes.map(child => child.textContent || "").join("");
+    return this.childNodes.map((child) => child.textContent || "").join("");
   }
 
   set textContent(value: string) {
@@ -51,7 +53,9 @@ class FakeElement extends FakeNode {
 
   append(...children: Array<FakeElement | FakeText>): void {
     for (const child of children) {
-      if (child instanceof FakeElement) child.parentElement = this;
+      if (child instanceof FakeElement) {
+        child.parentElement = this;
+      }
       this.childNodes.push(child);
     }
   }
@@ -92,12 +96,16 @@ function text(value: string): FakeText {
 
 function element(tagName: string, attrs: Record<string, string> = {}): FakeElement {
   const node = tagName === "button" ? new FakeButtonElement(tagName) : new FakeElement(tagName);
-  for (const [name, value] of Object.entries(attrs)) node.setAttribute(name, value);
+  for (const [name, value] of Object.entries(attrs)) {
+    node.setAttribute(name, value);
+  }
   return node;
 }
 
 describe("accessibility tree", () => {
-  let messageHandler: ((message: any, sender: any, sendResponse: (response: any) => void) => boolean) | undefined;
+  let messageHandler:
+    | ((message: any, sender: any, sendResponse: (response: any) => void) => boolean)
+    | undefined;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -159,7 +167,7 @@ describe("accessibility tree", () => {
     messageHandler?.(
       { type: "GENERATE_ACCESSIBILITY_TREE", options: { filter: "interactive" } },
       {},
-      result => {
+      (result) => {
         response = result;
       },
     );

--- a/test/unit/aistudio-parser.test.ts
+++ b/test/unit/aistudio-parser.test.ts
@@ -1,166 +1,148 @@
-import { createRequire } from 'node:module';
-import { describe, expect, it } from 'vitest';
+import { createRequire } from "node:module";
+import { describe, expect, it } from "vitest";
 
 const require = createRequire(import.meta.url);
-const parser = require('../../native/aistudio-parser.cjs');
+const parser = require("../../native/aistudio-parser.cjs");
 
-describe('normalizeAiStudioRpcJson', () => {
-  it('strips XSSI prefix', () => {
+describe("normalizeAiStudioRpcJson", () => {
+  it("strips XSSI prefix", () => {
     const body = ")]}'\n[1,2,3]";
-    expect(parser.normalizeAiStudioRpcJson(body)).toBe('[1,2,3]');
+    expect(parser.normalizeAiStudioRpcJson(body)).toBe("[1,2,3]");
   });
 
-  it('normalizes array elision for RPC error payloads', () => {
+  it("normalizes array elision for RPC error payloads", () => {
     const body = '[,[7,"permission denied"]]';
     expect(parser.normalizeAiStudioRpcJson(body)).toBe('[null,[7,"permission denied"]]');
   });
 });
 
-describe('parseAiStudioRpcError', () => {
-  it('extracts code and message from RPC array payload', () => {
+describe("parseAiStudioRpcError", () => {
+  it("extracts code and message from RPC array payload", () => {
     const body = '[,[7,"The caller does not have permission"]]';
     expect(parser.parseAiStudioRpcError(body)).toEqual({
       code: 7,
-      message: 'The caller does not have permission',
+      message: "The caller does not have permission",
     });
   });
 
-  it('returns null for non-error payloads', () => {
+  it("returns null for non-error payloads", () => {
     expect(parser.parseAiStudioRpcError('{"ok":true}')).toBeNull();
   });
 });
 
-describe('parseAiStudioGenerateContentText', () => {
-  it('extracts model text from nested GenerateContent payload', () => {
+describe("parseAiStudioGenerateContentText", () => {
+  it("extracts model text from nested GenerateContent payload", () => {
     const payload = [
-      [
-        [[[null, 'Hello']]],
-        'model',
-      ],
-      [
-        [[[null, ' world!']]],
-        'model',
-      ],
+      [[[[null, "Hello"]]], "model"],
+      [[[[null, " world!"]]], "model"],
     ];
 
-    expect(parser.parseAiStudioGenerateContentText(JSON.stringify(payload))).toBe('Hello world!');
+    expect(parser.parseAiStudioGenerateContentText(JSON.stringify(payload))).toBe("Hello world!");
   });
 
-  it('filters thinking chunks before returning final content', () => {
+  it("filters thinking chunks before returning final content", () => {
     const payload = [
-      [
-        [[null, 'Considering options...', null, 1]],
-        'model',
-      ],
-      [
-        [[null, '# Final\nShipped answer']],
-        'model',
-      ],
+      [[[null, "Considering options...", null, 1]], "model"],
+      [[[null, "# Final\nShipped answer"]], "model"],
     ];
 
-    expect(parser.parseAiStudioGenerateContentText(JSON.stringify(payload))).toBe('# Final\nShipped answer');
+    expect(parser.parseAiStudioGenerateContentText(JSON.stringify(payload))).toBe(
+      "# Final\nShipped answer",
+    );
   });
 
-  it('handles XSSI-prefixed GenerateContent responses', () => {
-    const payload = [
-      [
-        [[null, 'Ready']],
-        'model',
-      ],
-    ];
-    const xssi = ")]}'\n" + JSON.stringify(payload);
+  it("handles XSSI-prefixed GenerateContent responses", () => {
+    const payload = [[[[null, "Ready"]], "model"]];
+    const xssi = `)]}'\n${JSON.stringify(payload)}`;
 
-    expect(parser.parseAiStudioGenerateContentText(xssi)).toBe('Ready');
+    expect(parser.parseAiStudioGenerateContentText(xssi)).toBe("Ready");
   });
 });
 
-describe('cleanAiStudioResponse', () => {
-  it('removes prompt echo and UI chrome while preserving code fences', () => {
+describe("cleanAiStudioResponse", () => {
+  it("removes prompt echo and UI chrome while preserving code fences", () => {
     const raw = [
-      'User',
-      'Explain this code',
-      'Model',
-      'Answer line',
-      'thumb_up',
-      '```js',
-      'const x = 1;    ',
-      '```',
-      'Google AI models may make mistakes, so double-check outputs.',
-    ].join('\n');
+      "User",
+      "Explain this code",
+      "Model",
+      "Answer line",
+      "thumb_up",
+      "```js",
+      "const x = 1;    ",
+      "```",
+      "Google AI models may make mistakes, so double-check outputs.",
+    ].join("\n");
 
-    const cleaned = parser.cleanAiStudioResponse(raw, 'Explain this code');
-    expect(cleaned).toBe([
-      'Answer line',
-      '```js',
-      'const x = 1;',
-      '```',
-    ].join('\n'));
+    const cleaned = parser.cleanAiStudioResponse(raw, "Explain this code");
+    expect(cleaned).toBe(["Answer line", "```js", "const x = 1;", "```"].join("\n"));
   });
 
-  it('collapses redundant blank lines outside code blocks', () => {
-    const raw = ['Model', 'Line 1', '', '', 'Line 2', '', ''].join('\n');
-    expect(parser.cleanAiStudioResponse(raw)).toBe('Line 1\n\nLine 2');
+  it("collapses redundant blank lines outside code blocks", () => {
+    const raw = ["Model", "Line 1", "", "", "Line 2", "", ""].join("\n");
+    expect(parser.cleanAiStudioResponse(raw)).toBe("Line 1\n\nLine 2");
   });
 });
 
-describe('extractModelKeywords', () => {
-  it('extracts stable, meaningful tokens', () => {
-    expect(parser.extractModelKeywords('gemini-3-pro-preview')).toEqual(['pro']);
-    expect(parser.extractModelKeywords('gemini-flash-lite-latest')).toEqual(['flash', 'lite']);
+describe("extractModelKeywords", () => {
+  it("extracts stable, meaningful tokens", () => {
+    expect(parser.extractModelKeywords("gemini-3-pro-preview")).toEqual(["pro"]);
+    expect(parser.extractModelKeywords("gemini-flash-lite-latest")).toEqual(["flash", "lite"]);
   });
 
-  it('ignores empty or numeric-only tokens', () => {
-    expect(parser.extractModelKeywords('')).toEqual([]);
-    expect(parser.extractModelKeywords('gemini-2.5-preview')).toEqual([]);
+  it("ignores empty or numeric-only tokens", () => {
+    expect(parser.extractModelKeywords("")).toEqual([]);
+    expect(parser.extractModelKeywords("gemini-2.5-preview")).toEqual([]);
   });
 });
 
-describe('buildAiStudioUrl', () => {
-  it('returns base URL when model is absent', () => {
-    expect(parser.buildAiStudioUrl(undefined)).toBe('https://aistudio.google.com/prompts/new_chat');
+describe("buildAiStudioUrl", () => {
+  it("returns base URL when model is absent", () => {
+    expect(parser.buildAiStudioUrl(undefined)).toBe("https://aistudio.google.com/prompts/new_chat");
   });
 
-  it('adds model param only for preview/latest ids', () => {
-    expect(parser.buildAiStudioUrl('gemini-3-flash-preview')).toBe(
-      'https://aistudio.google.com/prompts/new_chat?model=gemini-3-flash-preview'
+  it("adds model param only for preview/latest ids", () => {
+    expect(parser.buildAiStudioUrl("gemini-3-flash-preview")).toBe(
+      "https://aistudio.google.com/prompts/new_chat?model=gemini-3-flash-preview",
     );
-    expect(parser.buildAiStudioUrl('gemini-3-pro')).toBe('https://aistudio.google.com/prompts/new_chat');
+    expect(parser.buildAiStudioUrl("gemini-3-pro")).toBe(
+      "https://aistudio.google.com/prompts/new_chat",
+    );
   });
 
-  it('handles model ids with dots (e.g. 3.1)', () => {
-    expect(parser.buildAiStudioUrl('gemini-3.1-pro-preview')).toBe(
-      'https://aistudio.google.com/prompts/new_chat?model=gemini-3.1-pro-preview'
+  it("handles model ids with dots (e.g. 3.1)", () => {
+    expect(parser.buildAiStudioUrl("gemini-3.1-pro-preview")).toBe(
+      "https://aistudio.google.com/prompts/new_chat?model=gemini-3.1-pro-preview",
     );
   });
 });
 
-describe('doesGenerateEntryMatchPrompt', () => {
-  it('matches against parsed last user prompt in request body', () => {
+describe("doesGenerateEntryMatchPrompt", () => {
+  it("matches against parsed last user prompt in request body", () => {
     const entry = {
       requestBody: JSON.stringify([
         null,
         [
-          [[[null, 'old prompt']], 'user'],
-          [[[null, 'assistant text']], 'model'],
-          [[[null, 'latest prompt']], 'user'],
+          [[[null, "old prompt"]], "user"],
+          [[[null, "assistant text"]], "model"],
+          [[[null, "latest prompt"]], "user"],
         ],
       ]),
     };
 
-    expect(parser.doesGenerateEntryMatchPrompt(entry, 'latest prompt')).toBe(true);
-    expect(parser.doesGenerateEntryMatchPrompt(entry, 'other')).toBe(false);
+    expect(parser.doesGenerateEntryMatchPrompt(entry, "latest prompt")).toBe(true);
+    expect(parser.doesGenerateEntryMatchPrompt(entry, "other")).toBe(false);
   });
 
-  it('falls back to substring probe when body parsing fails', () => {
-    const entry = { requestBody: 'raw payload with expected phrase inside' };
-    expect(parser.doesGenerateEntryMatchPrompt(entry, 'expected phrase inside')).toBe(true);
+  it("falls back to substring probe when body parsing fails", () => {
+    const entry = { requestBody: "raw payload with expected phrase inside" };
+    expect(parser.doesGenerateEntryMatchPrompt(entry, "expected phrase inside")).toBe(true);
   });
 });
 
-describe('hasRequiredCookies', () => {
-  it('requires __Secure-1PSID cookie with a value', () => {
-    expect(parser.hasRequiredCookies([{ name: '__Secure-1PSID', value: 'abc' }])).toBe(true);
-    expect(parser.hasRequiredCookies([{ name: '__Secure-1PSID', value: '' }])).toBe(false);
-    expect(parser.hasRequiredCookies([{ name: 'OTHER', value: 'abc' }])).toBe(false);
+describe("hasRequiredCookies", () => {
+  it("requires __Secure-1PSID cookie with a value", () => {
+    expect(parser.hasRequiredCookies([{ name: "__Secure-1PSID", value: "abc" }])).toBe(true);
+    expect(parser.hasRequiredCookies([{ name: "__Secure-1PSID", value: "" }])).toBe(false);
+    expect(parser.hasRequiredCookies([{ name: "OTHER", value: "abc" }])).toBe(false);
   });
 });

--- a/test/unit/chatgpt-client.test.ts
+++ b/test/unit/chatgpt-client.test.ts
@@ -20,15 +20,9 @@ describe("chatgpt-client", () => {
           "```",
           "Retry",
         ].join("\r\n"),
-        [
-          "Good response",
-          "Here is code:",
-          "```js",
-          "Copy",
-          "const x = 1;",
-          "```",
-          "Retry",
-        ].join("\n"),
+        ["Good response", "Here is code:", "```js", "Copy", "const x = 1;", "```", "Retry"].join(
+          "\n",
+        ),
       ],
       ["preserves legitimate standalone single-word response: Copy", "Copy", "Copy"],
       ["preserves legitimate standalone single-word response: Edit", "Edit", "Edit"],
@@ -110,7 +104,13 @@ describe("chatgpt-client", () => {
     it("falls back to empty assistant when all are empty", () => {
       const snapshot = chatgptClient.extractLatestAssistantSnapshot([
         { role: "assistant", turn: "assistant", isAssistant: true, text: "", messageId: "msg-1" },
-        { role: "assistant", turn: "assistant", isAssistant: true, text: "\n\n", messageId: "msg-2" },
+        {
+          role: "assistant",
+          turn: "assistant",
+          isAssistant: true,
+          text: "\n\n",
+          messageId: "msg-2",
+        },
       ]);
 
       expect(snapshot).toEqual({
@@ -125,7 +125,9 @@ describe("chatgpt-client", () => {
 
     it("returns null for non-assistant candidates only", () => {
       expect(
-        chatgptClient.extractLatestAssistantSnapshot([{ role: "user", turn: "user", text: "hello" }]),
+        chatgptClient.extractLatestAssistantSnapshot([
+          { role: "user", turn: "user", text: "hello" },
+        ]),
       ).toBeNull();
     });
 
@@ -249,19 +251,16 @@ describe("chatgpt-client", () => {
         2,
         true,
       ],
-    ])(
-      "%s",
-      (_, latestAssistant, baselineAssistant, assistantCount, baselineAssistantCount, expected) => {
-        expect(
-          chatgptClient.isNewAssistantContent(
-            latestAssistant,
-            baselineAssistant,
-            assistantCount,
-            baselineAssistantCount,
-          ),
-        ).toBe(expected);
-      },
-    );
+    ])("%s", (_, latestAssistant, baselineAssistant, assistantCount, baselineAssistantCount, expected) => {
+      expect(
+        chatgptClient.isNewAssistantContent(
+          latestAssistant,
+          baselineAssistant,
+          assistantCount,
+          baselineAssistantCount,
+        ),
+      ).toBe(expected);
+    });
   });
 
   describe("isChatGPTResponseComplete", () => {
@@ -390,9 +389,7 @@ describe("chatgpt-client", () => {
 
     it("rejects exact cookie with empty value", () => {
       expect(
-        chatgptClient.hasRequiredCookies([
-          { name: "__Secure-next-auth.session-token", value: "" },
-        ]),
+        chatgptClient.hasRequiredCookies([{ name: "__Secure-next-auth.session-token", value: "" }]),
       ).toBe(false);
     });
 

--- a/test/unit/do-executor.test.ts
+++ b/test/unit/do-executor.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 // @ts-expect-error - CommonJS module without type definitions
 import * as executor from "../../native/do-executor.cjs";

--- a/test/unit/do-parser.test.ts
+++ b/test/unit/do-parser.test.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 // @ts-expect-error - CommonJS module without type definitions
 import * as parser from "../../native/do-parser.cjs";
 
 describe("parseDoCommands", () => {
   it("parses single command", () => {
-    const input = 'screenshot';
+    const input = "screenshot";
     const steps = parser.parseDoCommands(input);
     expect(steps).toHaveLength(1);
     expect(steps[0].cmd).toBe("screenshot");
@@ -34,7 +34,7 @@ describe("parseDoCommands", () => {
   });
 
   it("parses click with coordinates", () => {
-    const input = 'click 100 200';
+    const input = "click 100 200";
     const steps = parser.parseDoCommands(input);
     expect(steps).toHaveLength(1);
     expect(steps[0].cmd).toBe("click");
@@ -92,13 +92,13 @@ describe("parseDoCommands", () => {
   });
 
   it("parses numeric option values", () => {
-    const input = 'wait --duration 500';
+    const input = "wait --duration 500";
     const steps = parser.parseDoCommands(input);
     expect(steps[0].args.duration).toBe(500);
   });
 
   it("parses boolean option values", () => {
-    const input = 'screenshot --fullpage true';
+    const input = "screenshot --fullpage true";
     const steps = parser.parseDoCommands(input);
     expect(steps[0].args.fullpage).toBe(true);
   });
@@ -142,7 +142,7 @@ screenshot --output /tmp/result.png
     const steps = parser.parseDoCommands(input);
     expect(steps[0].cmd).toBe("select");
     expect(steps[0].args.selector).toBe("e5");
-    expect(steps[0].args.values).toBe("US");  // Single value as string (host wraps in array)
+    expect(steps[0].args.values).toBe("US"); // Single value as string (host wraps in array)
   });
 
   it("parses select with multiple values", () => {
@@ -158,7 +158,7 @@ screenshot --output /tmp/result.png
     const steps = parser.parseDoCommands(input);
     expect(steps[0].cmd).toBe("select");
     expect(steps[0].args.selector).toBe("e5");
-    expect(steps[0].args.values).toBe("United States");  // Single value as string
+    expect(steps[0].args.values).toBe("United States"); // Single value as string
     expect(steps[0].args.by).toBe("label");
   });
 });
@@ -177,7 +177,7 @@ describe("tokenize", () => {
   });
 
   it("handles mixed quotes", () => {
-    expect(parser.tokenize('type "hello" --ref \'e5\'')).toEqual(["type", "hello", "--ref", "e5"]);
+    expect(parser.tokenize("type \"hello\" --ref 'e5'")).toEqual(["type", "hello", "--ref", "e5"]);
   });
 
   it("handles empty input", () => {

--- a/test/unit/gemini-client.test.ts
+++ b/test/unit/gemini-client.test.ts
@@ -51,25 +51,31 @@ describe("gemini-client", () => {
             expect(code).toContain("canvas.toDataURL");
             expect(code).not.toContain("alt");
             expect(code).not.toContain("className");
-            return asChromeOutput(JSON.stringify({
-              images: [{
-                url: "blob:https://gemini.google.com/generated-image",
-                blobIndex: 0,
-                type: "image/png",
-              }],
-              loading: false,
-              text: "",
-              turns: 1,
-            }));
+            return asChromeOutput(
+              JSON.stringify({
+                images: [
+                  {
+                    url: "blob:https://gemini.google.com/generated-image",
+                    blobIndex: 0,
+                    type: "image/png",
+                  },
+                ],
+                loading: false,
+                text: "",
+                turns: 1,
+              }),
+            );
           }
 
           if (code.includes("window.__surfGeminiBlobImages?.[0]")) {
-            return asChromeOutput(JSON.stringify({
-              chunk: "ZmFrZS1wbmc=",
-              done: true,
-              type: "image/png",
-              url: "blob:https://gemini.google.com/generated-image",
-            }));
+            return asChromeOutput(
+              JSON.stringify({
+                chunk: "ZmFrZS1wbmc=",
+                done: true,
+                type: "image/png",
+                url: "blob:https://gemini.google.com/generated-image",
+              }),
+            );
           }
 
           throw new Error(`Unexpected script: ${code}`);
@@ -116,13 +122,17 @@ describe("gemini-client", () => {
           if (imagesPolled(code)) {
             expect(code).toContain(`const baselineKeys = new Set(["${baselineKey}"])`);
             expect(code).toContain(".filter((img) => !baselineKeys.has(imageKey(img)))");
-            expect(code.indexOf("!baselineKeys.has(imageKey(img))")).toBeLessThan(code.indexOf("canvas.toDataURL"));
-            return asChromeOutput(JSON.stringify({
-              images: [],
-              loading: false,
-              text: "No new image was generated.",
-              turns: 1,
-            }));
+            expect(code.indexOf("!baselineKeys.has(imageKey(img))")).toBeLessThan(
+              code.indexOf("canvas.toDataURL"),
+            );
+            return asChromeOutput(
+              JSON.stringify({
+                images: [],
+                loading: false,
+                text: "No new image was generated.",
+                turns: 1,
+              }),
+            );
           }
 
           throw new Error(`Unexpected script: ${code}`);
@@ -164,12 +174,14 @@ describe("gemini-client", () => {
           }
 
           if (imagesPolled(code)) {
-            return asChromeOutput(JSON.stringify({
-              images: [{ url: "https://lh3.googleusercontent.com/gg-dl/generated" }],
-              loading: false,
-              text: "",
-              turns: 1,
-            }));
+            return asChromeOutput(
+              JSON.stringify({
+                images: [{ url: "https://lh3.googleusercontent.com/gg-dl/generated" }],
+                loading: false,
+                text: "",
+                turns: 1,
+              }),
+            );
           }
 
           throw new Error(`Unexpected script: ${code}`);

--- a/test/unit/host-helpers.test.ts
+++ b/test/unit/host-helpers.test.ts
@@ -72,12 +72,18 @@ describe("mapToolToMessage", () => {
     });
 
     it("normalizes aistudio model to lowercase", () => {
-      const msg = helpers.mapToolToMessage("aistudio", { query: "hi", model: "GEMINI-3-FLASH-PREVIEW" });
+      const msg = helpers.mapToolToMessage("aistudio", {
+        query: "hi",
+        model: "GEMINI-3-FLASH-PREVIEW",
+      });
       expect(msg.model).toBe("gemini-3-flash-preview");
     });
 
     it("does not validate aistudio model ids (passes through)", () => {
-      const msg = helpers.mapToolToMessage("aistudio", { query: "hi", model: "gemini-flash-lite-latest" });
+      const msg = helpers.mapToolToMessage("aistudio", {
+        query: "hi",
+        model: "gemini-flash-lite-latest",
+      });
       expect(msg.model).toBe("gemini-flash-lite-latest");
     });
   });

--- a/test/unit/service-worker/scroll-handlers.test.ts
+++ b/test/unit/service-worker/scroll-handlers.test.ts
@@ -27,29 +27,24 @@ describe("EXECUTE_SCROLL handler", () => {
   it("uses Runtime.evaluate with scrollBy, not CDP mouseWheel", async () => {
     const chrome = (globalThis as any).chrome;
     const sendCommandCalls: { method: string; params: any }[] = [];
-    chrome.debugger.sendCommand.mockImplementation(
-      (_target: any, method: string, params: any) => {
-        sendCommandCalls.push({ method, params });
-        if (method === "Runtime.evaluate") {
-          return Promise.resolve({
-            result: { value: { scrollX: 0, scrollY: 300, scrolled: true } },
-          });
-        }
-        return Promise.resolve({});
+    chrome.debugger.sendCommand.mockImplementation((_target: any, method: string, params: any) => {
+      sendCommandCalls.push({ method, params });
+      if (method === "Runtime.evaluate") {
+        return Promise.resolve({
+          result: { value: { scrollX: 0, scrollY: 300, scrolled: true } },
+        });
       }
-    );
+      return Promise.resolve({});
+    });
 
-    await handleMessage(
-      { type: "EXECUTE_SCROLL", deltaX: 0, deltaY: 300, tabId: 123 },
-      {}
-    );
+    await handleMessage({ type: "EXECUTE_SCROLL", deltaX: 0, deltaY: 300, tabId: 123 }, {});
 
-    const runtimeEvalCalls = sendCommandCalls.filter(c => c.method === "Runtime.evaluate");
+    const runtimeEvalCalls = sendCommandCalls.filter((c) => c.method === "Runtime.evaluate");
     expect(runtimeEvalCalls.length).toBeGreaterThan(0);
     expect(runtimeEvalCalls[0].params.expression).toContain("scrollBy");
 
     const mouseWheelCalls = sendCommandCalls.filter(
-      c => c.method === "Input.dispatchMouseEvent" && c.params?.type === "mouseWheel"
+      (c) => c.method === "Input.dispatchMouseEvent" && c.params?.type === "mouseWheel",
     );
     expect(mouseWheelCalls).toHaveLength(0);
   });
@@ -57,22 +52,17 @@ describe("EXECUTE_SCROLL handler", () => {
   it("passes correct delta values to the scrollBy script", async () => {
     const chrome = (globalThis as any).chrome;
     let capturedExpression = "";
-    chrome.debugger.sendCommand.mockImplementation(
-      (_target: any, method: string, params: any) => {
-        if (method === "Runtime.evaluate") {
-          capturedExpression = params.expression;
-          return Promise.resolve({
-            result: { value: { scrollX: 100, scrollY: 500, scrolled: true } },
-          });
-        }
-        return Promise.resolve({});
+    chrome.debugger.sendCommand.mockImplementation((_target: any, method: string, params: any) => {
+      if (method === "Runtime.evaluate") {
+        capturedExpression = params.expression;
+        return Promise.resolve({
+          result: { value: { scrollX: 100, scrollY: 500, scrolled: true } },
+        });
       }
-    );
+      return Promise.resolve({});
+    });
 
-    await handleMessage(
-      { type: "EXECUTE_SCROLL", deltaX: 100, deltaY: 500, tabId: 123 },
-      {}
-    );
+    await handleMessage({ type: "EXECUTE_SCROLL", deltaX: 100, deltaY: 500, tabId: 123 }, {});
 
     expect(capturedExpression).toContain("100");
     expect(capturedExpression).toContain("500");
@@ -85,10 +75,7 @@ describe("EXECUTE_SCROLL handler", () => {
       { result: { scrollX: 0, scrollY: 300, scrolled: true } },
     ]);
 
-    await handleMessage(
-      { type: "EXECUTE_SCROLL", deltaX: 0, deltaY: 300, tabId: 123 },
-      {}
-    );
+    await handleMessage({ type: "EXECUTE_SCROLL", deltaX: 0, deltaY: 300, tabId: 123 }, {});
 
     expect(chrome.scripting.executeScript).toHaveBeenCalled();
     const scriptCall = chrome.scripting.executeScript.mock.calls[0][0];
@@ -97,20 +84,18 @@ describe("EXECUTE_SCROLL handler", () => {
 
   it("returns scroll result from the script", async () => {
     const chrome = (globalThis as any).chrome;
-    chrome.debugger.sendCommand.mockImplementation(
-      (_target: any, method: string) => {
-        if (method === "Runtime.evaluate") {
-          return Promise.resolve({
-            result: { value: { scrollX: 0, scrollY: 500, scrolled: true } },
-          });
-        }
-        return Promise.resolve({});
+    chrome.debugger.sendCommand.mockImplementation((_target: any, method: string) => {
+      if (method === "Runtime.evaluate") {
+        return Promise.resolve({
+          result: { value: { scrollX: 0, scrollY: 500, scrolled: true } },
+        });
       }
-    );
+      return Promise.resolve({});
+    });
 
     const result = await handleMessage(
       { type: "EXECUTE_SCROLL", deltaX: 0, deltaY: 300, tabId: 123 },
-      {}
+      {},
     );
 
     expect(result.scrollY).toBe(500);
@@ -118,30 +103,25 @@ describe("EXECUTE_SCROLL handler", () => {
   });
 
   it("requires tabId", async () => {
-    await expect(
-      handleMessage({ type: "EXECUTE_SCROLL", deltaY: 300 }, {})
-    ).rejects.toThrow("No tabId provided");
+    await expect(handleMessage({ type: "EXECUTE_SCROLL", deltaY: 300 }, {})).rejects.toThrow(
+      "No tabId provided",
+    );
   });
 
   it("handles missing deltas by defaulting to 0", async () => {
     const chrome = (globalThis as any).chrome;
     let capturedExpression = "";
-    chrome.debugger.sendCommand.mockImplementation(
-      (_target: any, method: string, params: any) => {
-        if (method === "Runtime.evaluate") {
-          capturedExpression = params.expression;
-          return Promise.resolve({
-            result: { value: { scrolled: false } },
-          });
-        }
-        return Promise.resolve({});
+    chrome.debugger.sendCommand.mockImplementation((_target: any, method: string, params: any) => {
+      if (method === "Runtime.evaluate") {
+        capturedExpression = params.expression;
+        return Promise.resolve({
+          result: { value: { scrolled: false } },
+        });
       }
-    );
+      return Promise.resolve({});
+    });
 
-    await handleMessage(
-      { type: "EXECUTE_SCROLL", tabId: 123 },
-      {}
-    );
+    await handleMessage({ type: "EXECUTE_SCROLL", tabId: 123 }, {});
 
     expect(capturedExpression).toContain("scrollBy");
     expect(capturedExpression).toContain("0");


### PR DESCRIPTION
Restores the repo's baseline validation so follow-up feature branches have a reliable gate.

This updates the Biome config for the installed version, fixes current Chrome/test typing drift, tracks the small test-only CommonJS module declaration needed for `node:module`, and refreshes the Vitest package group to clear the critical advisory that was failing the audit job.

Validation:
- `npm run lint`
- `npm run check`
- `npm test`
- `npm audit --audit-level=critical`
