### PR TITLE
fix: support WSL2 native host installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- **WSL2 native messaging host install** - Install/uninstall now target Windows browser manifests from WSL2 by default, preserve manifest origins, forward wrapper arguments, and include clearer socket diagnostics.
 - **JavaScript expression evaluation** - `surf js` now returns single-expression values while preserving statement-script fallback behavior.
 - **Baseline CI validation** - Restored lint, typecheck, tests, and critical audit checks on current dependencies.
 - **Native messaging host portability** - Generated Unix wrappers now use `#!/usr/bin/env bash` so Chrome can launch the host on NixOS, Guix, and other non-FHS Linux systems. (@ppetru)

--- a/README.md
+++ b/README.md
@@ -76,9 +76,20 @@ surf install <extension-id>                    # Chrome (default)
 surf install <extension-id> --browser brave    # Brave
 surf install <extension-id> --browser helium   # Helium
 surf install <extension-id> --browser all      # All supported browsers
+surf install <extension-id> --target linux     # WSLg/Linux browser from WSL2
 ```
 
 Supported: `chrome`, `chromium`, `brave`, `edge`, `arc`, `helium`
+
+**WSL2 with Windows Chrome**
+When you run `surf install <extension-id>` inside WSL2, Surf detects WSL2 and installs a Windows-side native messaging manifest for Windows Chrome/Brave/Edge by default. The generated Windows wrapper launches the WSL2 host with `wsl.exe`, so `surf` commands run inside WSL2 still connect to the WSL socket.
+
+If you use a Linux browser inside WSLg instead, install with:
+```bash
+surf install <extension-id> --target linux
+```
+
+Restart Windows Chrome after installing. If the extension reports `Access to the specified native messaging host is forbidden`, rerun `surf install <extension-id>` from the same WSL distro and confirm the extension ID was copied from `chrome://extensions`.
 
 **Package Manager Installs (Nix, Homebrew, etc.)**
 If surf is installed via a package manager that stores binaries in non-standard locations, set these environment variables before running `surf install`:
@@ -94,6 +105,7 @@ See [Environment Variables](#environment-variables) for details.
 ```bash
 surf uninstall                  # Chrome only
 surf uninstall --all            # All browsers + wrapper files
+surf uninstall --target linux   # Remove WSLg/Linux-browser config from WSL2
 ```
 
 ### Development Setup
@@ -538,12 +550,14 @@ surf workflow.validate ./my-workflow.json
 
 ```bash
 SURF_NETWORK_PATH         # Path for network capture logs (default: /tmp/surf)
+SURF_SOCKET               # Socket path or named pipe (default: /tmp/surf.sock, Windows: //./pipe/surf)
 SURF_NODE_PATH            # Path to node binary (for native host wrapper)
 SURF_HOST_PATH            # Path to native/host.cjs (for native host wrapper)
 SURF_EXTENSION_PATH       # Path to extension dist/ directory
 ```
 
 **Use cases:**
+- `SURF_SOCKET`: Advanced socket override. Set it for both the native host and CLI if you need a non-default socket.
 - `SURF_NODE_PATH` / `SURF_HOST_PATH`: Package manager installs (e.g., Nix) that store binaries in non-standard locations
 - `SURF_EXTENSION_PATH`: Package managers that create stable symlinks instead of changing paths on reinstall
 
@@ -554,9 +568,19 @@ export SURF_HOST_PATH=~/.local/share/surf-cli/native/host.cjs
 export SURF_EXTENSION_PATH=~/.local/share/surf-cli/extension
 ```
 
+## Troubleshooting native host connections
+
+If a command fails with `Socket connect failed`, read the `Attempted socket:` line first. The CLI and native host must agree on the same socket path. By default this is `/tmp/surf.sock` on macOS/Linux/WSL2 and `//./pipe/surf` on Windows.
+
+Common fixes:
+- Restart the browser after `surf install <extension-id>`.
+- Confirm the Surf extension is enabled and the extension ID matches the one passed to `surf install`.
+- On WSL2 with Windows Chrome, run `surf install <extension-id>` from WSL2 and restart Windows Chrome. Use `--target linux` only for a Linux browser running inside WSLg.
+- If `SURF_SOCKET` is set, set the same value for both the browser-launched native host and the shell running `surf`.
+
 ## Socket API
 
-For programmatic integration, send JSON to `/tmp/surf.sock`:
+For programmatic integration, send JSON to `/tmp/surf.sock` by default, or to `SURF_SOCKET` when set:
 
 ```bash
 echo '{"type":"tool_request","method":"execute_tool","params":{"tool":"tab.list","args":{}},"id":"1"}' | nc -U /tmp/surf.sock

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -12,8 +12,7 @@ const { executeDoSteps } = require("./do-executor.cjs");
 const { version: VERSION } = require("../package.json");
 
 const IS_WIN = process.platform === "win32";
-const SURF_TMP = IS_WIN ? path.join(os.tmpdir(), "surf") : "/tmp";
-const SOCKET_PATH = IS_WIN ? "//./pipe/surf" : "/tmp/surf.sock";
+const { SOCKET_PATH, SURF_TMP, formatSocketError } = require("./socket-path.cjs");
 if (IS_WIN) { try { fs.mkdirSync(SURF_TMP, { recursive: true }); } catch {} }
 
 // ============================================================================
@@ -1809,11 +1808,14 @@ Options:
   -b, --browser   Browser(s) to install for (default: chrome)
                   Values: chrome, chromium, brave, edge, arc, helium, all
                   Multiple: --browser chrome,brave
+  --target        Install target: auto, linux, windows
+                  On WSL2, auto installs for Windows Chrome. Use linux for WSLg/Linux browsers.
 
 Examples:
   surf install hnfbepgmaoklhekckbpjnleifhahkcpl
   surf install hnfbepgmaoklhekckbpjnleifhahkcpl --browser brave
   surf install hnfbepgmaoklhekckbpjnleifhahkcpl --browser all
+  surf install hnfbepgmaoklhekckbpjnleifhahkcpl --target linux
 `);
     process.exit(0);
   }
@@ -1839,11 +1841,14 @@ Options:
   -b, --browser   Browser(s) to uninstall from (default: chrome)
                   Values: chrome, chromium, brave, edge, arc, helium, all
   -a, --all       Uninstall from all browsers and remove wrapper
+  --target        Install target to remove: auto, linux, windows
+                  On WSL2, auto removes Windows-browser manifests. Use linux for WSLg/Linux browsers.
 
 Examples:
   surf uninstall
   surf uninstall --browser brave
   surf uninstall --all
+  surf uninstall --target linux
 `);
     process.exit(0);
   }
@@ -1977,7 +1982,7 @@ if (args.includes("--script")) {
           }
         }
       });
-      sock.on("error", (e) => reject(e));
+      sock.on("error", (e) => reject(new Error(formatSocketError(e))));
       let timeoutId;
       timeoutId = setTimeout(() => { sock.destroy(); reject(new Error("Timeout")); }, 30000);
       sock.on("close", () => clearTimeout(timeoutId));
@@ -2794,11 +2799,7 @@ if (streamMode && (tool === "console" || tool === "network")) {
   });
 
   sock.on("error", (e) => {
-    if (e.code === "ENOENT") {
-      console.error("Error: Socket not found. Is Chrome running with the extension?");
-    } else {
-      console.error("Error:", e.message);
-    }
+    console.error("Error:", formatSocketError(e));
     process.exit(1);
   });
 
@@ -2853,7 +2854,7 @@ const sendRequest = (toolName, toolArgs = {}) => {
         }
       }
     });
-    sock.on("error", (e) => reject(e));
+    sock.on("error", (e) => reject(new Error(formatSocketError(e))));
     let timeoutId;
     timeoutId = setTimeout(() => { sock.destroy(); reject(new Error("Timeout")); }, 5000);
     sock.on("close", () => clearTimeout(timeoutId));
@@ -2944,13 +2945,7 @@ socket.on("data", (data) => {
 
 socket.on("error", (err) => {
   clearTimeout(timeout);
-  if (err.code === "ENOENT") {
-    console.error("Error: Socket not found. Is Chrome running with the extension?");
-  } else if (err.code === "ECONNREFUSED") {
-    console.error("Error: Connection refused. Native host not running.");
-  } else {
-    console.error("Error:", err.message);
-  }
+  console.error("Error:", formatSocketError(err));
   process.exit(1);
 });
 

--- a/native/do-executor.cjs
+++ b/native/do-executor.cjs
@@ -11,8 +11,7 @@
  */
 
 const net = require("net");
-
-const SOCKET_PATH = process.platform === "win32" ? "//./pipe/surf" : "/tmp/surf.sock";
+const { SOCKET_PATH, formatSocketError } = require("./socket-path.cjs");
 
 // Maximum iterations for loops (safety cap)
 const MAX_LOOP_ITERATIONS = 100;
@@ -104,13 +103,7 @@ function sendDoRequest(toolName, toolArgs, context = {}) {
     });
     
     sock.on("error", (e) => {
-      if (e.code === "ENOENT") {
-        reject(new Error("Socket not found. Is Chrome running with the extension?"));
-      } else if (e.code === "ECONNREFUSED") {
-        reject(new Error("Connection refused. Native host not running."));
-      } else {
-        reject(e);
-      }
+      reject(new Error(formatSocketError(e)));
     });
     
     const timeoutId = setTimeout(() => { 

--- a/native/host.cjs
+++ b/native/host.cjs
@@ -15,8 +15,7 @@ const aistudioBuild = require("./aistudio-build.cjs");
 const { mapToolToMessage, mapComputerAction, formatToolContent } = require("./host-helpers.cjs");
 
 const IS_WIN = process.platform === "win32";
-const SURF_TMP = IS_WIN ? path.join(os.tmpdir(), "surf") : "/tmp";
-const SOCKET_PATH = IS_WIN ? "//./pipe/surf" : "/tmp/surf.sock";
+const { SOCKET_PATH, SURF_TMP } = require("./socket-path.cjs");
 if (IS_WIN) { try { fs.mkdirSync(SURF_TMP, { recursive: true }); } catch {} }
 
 // Cross-platform image resize (macOS: sips, Linux: ImageMagick)

--- a/native/mcp-server.cjs
+++ b/native/mcp-server.cjs
@@ -3,8 +3,8 @@ const net = require("net");
 const { McpServer } = require("@modelcontextprotocol/sdk/server/mcp.js");
 const { StdioServerTransport } = require("@modelcontextprotocol/sdk/server/stdio.js");
 const { z } = require("zod");
+const { SOCKET_PATH, formatSocketError } = require("./socket-path.cjs");
 
-const SOCKET_PATH = process.platform === "win32" ? "//./pipe/surf" : "/tmp/surf.sock";
 const REQUEST_TIMEOUT = 30000;
 
 const TOOL_SCHEMAS = {
@@ -279,7 +279,9 @@ function sendSocketRequest(tool, args = {}) {
     });
 
     let buf = "";
+    let settled = false;
     const timeout = setTimeout(() => {
+      settled = true;
       sock.destroy();
       reject(new Error("Request timeout"));
     }, REQUEST_TIMEOUT);
@@ -291,11 +293,13 @@ function sendSocketRequest(tool, args = {}) {
       for (const line of lines) {
         if (!line.trim()) continue;
         try {
+          settled = true;
           clearTimeout(timeout);
           const resp = JSON.parse(line);
           sock.end();
           resolve(resp);
         } catch {
+          settled = true;
           clearTimeout(timeout);
           sock.end();
           reject(new Error("Invalid JSON response"));
@@ -304,17 +308,16 @@ function sendSocketRequest(tool, args = {}) {
     });
 
     sock.on("error", (e) => {
+      settled = true;
       clearTimeout(timeout);
-      if (e.code === "ENOENT") {
-        reject(new Error("Socket not found. Is Chrome running with the surf extension?"));
-      } else {
-        reject(e);
-      }
+      reject(new Error(formatSocketError(e)));
     });
 
     sock.on("close", () => {
       clearTimeout(timeout);
-      reject(new Error("Socket closed unexpectedly"));
+      if (!settled) {
+        reject(new Error(`Socket closed unexpectedly\nAttempted socket: ${SOCKET_PATH}`));
+      }
     });
   });
 }

--- a/native/socket-path.cjs
+++ b/native/socket-path.cjs
@@ -1,0 +1,45 @@
+const path = require("path");
+const os = require("os");
+
+const IS_WIN = process.platform === "win32";
+const DEFAULT_SOCKET_PATH = IS_WIN ? "//./pipe/surf" : "/tmp/surf.sock";
+const SOCKET_PATH = process.env.SURF_SOCKET || DEFAULT_SOCKET_PATH;
+const SURF_TMP = IS_WIN ? path.join(os.tmpdir(), "surf") : "/tmp";
+
+function getSocketTroubleshootingHint() {
+  const lines = [
+    `Attempted socket: ${SOCKET_PATH}`,
+    "Make sure the browser is running with the Surf extension enabled, then restart the browser after native host install changes.",
+  ];
+
+  if (process.env.SURF_SOCKET) {
+    lines.push("SURF_SOCKET is set; make sure the native host and CLI use the same value.");
+  }
+
+  if (process.platform === "linux") {
+    lines.push("On WSL2 with Windows Chrome, run `surf install <extension-id>` from WSL and restart Windows Chrome.");
+  }
+
+  return lines.join("\n");
+}
+
+function formatSocketError(error, context = "connect") {
+  let message;
+  if (error && error.code === "ENOENT") {
+    message = "Socket not found.";
+  } else if (error && error.code === "ECONNREFUSED") {
+    message = "Connection refused. Native host is not accepting connections.";
+  } else {
+    message = error && error.message ? error.message : String(error);
+  }
+
+  return `Socket ${context} failed: ${message}\n${getSocketTroubleshootingHint()}`;
+}
+
+module.exports = {
+  DEFAULT_SOCKET_PATH,
+  SOCKET_PATH,
+  SURF_TMP,
+  formatSocketError,
+  getSocketTroubleshootingHint,
+};

--- a/scripts/install-native-host.cjs
+++ b/scripts/install-native-host.cjs
@@ -2,7 +2,7 @@
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
-const { execSync, spawnSync } = require("child_process");
+const { execFileSync, execSync } = require("child_process");
 
 const HOST_NAME = "surf.browser.host";
 
@@ -12,12 +12,14 @@ const BROWSERS = {
     darwin: "Library/Application Support/Google/Chrome/NativeMessagingHosts",
     linux: ".config/google-chrome/NativeMessagingHosts",
     win32: "Google\\Chrome",
+    wsl: "Google/Chrome/User Data/NativeMessagingHosts",
   },
   chromium: {
     name: "Chromium",
     darwin: "Library/Application Support/Chromium/NativeMessagingHosts",
     linux: ".config/chromium/NativeMessagingHosts",
     win32: "Chromium",
+    wsl: "Chromium/User Data/NativeMessagingHosts",
   },
   brave: {
     name: "Brave",
@@ -25,12 +27,14 @@ const BROWSERS = {
       "Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts",
     linux: ".config/BraveSoftware/Brave-Browser/NativeMessagingHosts",
     win32: "BraveSoftware\\Brave-Browser",
+    wsl: "BraveSoftware/Brave-Browser/User Data/NativeMessagingHosts",
   },
   edge: {
     name: "Microsoft Edge",
     darwin: "Library/Application Support/Microsoft Edge/NativeMessagingHosts",
     linux: ".config/microsoft-edge/NativeMessagingHosts",
     win32: "Microsoft\\Edge",
+    wsl: "Microsoft/Edge/User Data/NativeMessagingHosts",
   },
   arc: {
     name: "Arc",
@@ -38,12 +42,14 @@ const BROWSERS = {
       "Library/Application Support/Arc/User Data/NativeMessagingHosts",
     linux: null,
     win32: null,
+    wsl: null,
   },
   helium: {
     name: "Helium",
     darwin: "Library/Application Support/net.imput.helium/NativeMessagingHosts",
     linux: null,
     win32: null,
+    wsl: null,
   },
 };
 
@@ -62,6 +68,16 @@ const NODE_PATHS = {
     "C:\\Program Files (x86)\\nodejs\\node.exe",
   ],
 };
+
+function isWsl() {
+  if (process.platform !== "linux") return false;
+  if (process.env.WSL_DISTRO_NAME || process.env.WSL_INTEROP) return true;
+  try {
+    return /microsoft|wsl/i.test(fs.readFileSync("/proc/version", "utf8"));
+  } catch {
+    return false;
+  }
+}
 
 function findNode() {
   if (process.env.SURF_NODE_PATH && fs.existsSync(process.env.SURF_NODE_PATH)) {
@@ -88,10 +104,14 @@ function findNpmGlobalRoot() {
   }
 }
 
-function getWrapperDir() {
-  const platform = process.platform;
+function getWrapperDir(target = process.platform) {
   const home = os.homedir();
-  switch (platform) {
+  if (target === "wsl-windows") {
+    const localAppData = getWindowsEnv("LOCALAPPDATA");
+    if (!localAppData) return null;
+    return path.join(windowsPathToWslPath(localAppData), "surf-cli");
+  }
+  switch (process.platform) {
     case "darwin":
       return path.join(home, "Library/Application Support/surf-cli");
     case "linux":
@@ -117,54 +137,114 @@ function getHostPath() {
   return null;
 }
 
-function createWrapper(wrapperDir, nodePath, hostPath) {
-  const platform = process.platform;
-  fs.mkdirSync(wrapperDir, { recursive: true });
-
-  if (platform === "win32") {
-    const batPath = path.join(wrapperDir, "host-wrapper.bat");
-    const content = `@echo off\r\n"${nodePath}" "${hostPath}"\r\n`;
-    fs.writeFileSync(batPath, content);
-    return batPath;
-  } else {
-    const shPath = path.join(wrapperDir, "host-wrapper.sh");
-    const hostDir = path.dirname(hostPath);
-    const content = `#!/usr/bin/env bash
-cd "${hostDir}"
-exec "${nodePath}" "${hostPath}"
-`;
-    fs.writeFileSync(shPath, content);
-    fs.chmodSync(shPath, "755");
-    return shPath;
+function getWindowsEnv(name) {
+  try {
+    return execFileSync("cmd.exe", ["/c", "echo", `%${name}%`], { encoding: "utf8" })
+      .trim()
+      .replace(/\r/g, "");
+  } catch {
+    return null;
   }
 }
 
-function installManifest(browser, extensionId, wrapperPath) {
-  const platform = process.platform;
+function windowsPathToWslPath(winPath) {
+  const normalized = winPath.replace(/\\/g, "/");
+  const match = normalized.match(/^([A-Za-z]):\/(.*)$/);
+  if (!match) return normalized;
+  return `/mnt/${match[1].toLowerCase()}/${match[2]}`;
+}
+
+function wslPathToWindowsPath(wslPath) {
+  try {
+    return execFileSync("wslpath", ["-w", wslPath], { encoding: "utf8" }).trim().replace(/\r/g, "");
+  } catch {
+    const match = wslPath.match(/^\/mnt\/([a-zA-Z])\/(.*)$/);
+    if (match) return `${match[1].toUpperCase()}:\\${match[2].replace(/\//g, "\\")}`;
+    return wslPath;
+  }
+}
+
+function createWrapper(wrapperDir, nodePath, hostPath, target = process.platform) {
+  fs.mkdirSync(wrapperDir, { recursive: true });
+
+  if (target === "wsl-windows") {
+    const cmdPath = path.join(wrapperDir, "host-wrapper-wsl.cmd");
+    const distroArg = process.env.WSL_DISTRO_NAME ? ` -d "${process.env.WSL_DISTRO_NAME}"` : "";
+    const content = `@echo off\r\nwsl.exe${distroArg} --cd "${path.dirname(hostPath)}" --exec "${nodePath}" "${hostPath}" %*\r\n`;
+    fs.writeFileSync(cmdPath, content);
+    return wslPathToWindowsPath(cmdPath);
+  }
+
+  if (process.platform === "win32") {
+    const batPath = path.join(wrapperDir, "host-wrapper.bat");
+    const content = `@echo off\r\n"${nodePath}" "${hostPath}" %*\r\n`;
+    fs.writeFileSync(batPath, content);
+    return batPath;
+  }
+
+  const shPath = path.join(wrapperDir, "host-wrapper.sh");
+  const hostDir = path.dirname(hostPath);
+  const content = `#!/usr/bin/env bash
+cd "${hostDir}"
+exec "${nodePath}" "${hostPath}" "$@"
+`;
+  fs.writeFileSync(shPath, content);
+  fs.chmodSync(shPath, "755");
+  return shPath;
+}
+
+function readExistingManifest(manifestPath) {
+  if (!fs.existsSync(manifestPath)) return {};
+  return JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+}
+
+function writeManifest(manifestPath, extensionId, wrapperPath) {
+  const origin = `chrome-extension://${extensionId}/`;
+  const existing = readExistingManifest(manifestPath);
+  const allowedOrigins = Array.isArray(existing.allowed_origins) ? existing.allowed_origins : [];
+
+  const manifest = {
+    ...existing,
+    name: HOST_NAME,
+    description: existing.description || "Surf CLI Native Host",
+    path: wrapperPath,
+    type: "stdio",
+    allowed_origins: Array.from(new Set([...allowedOrigins, origin])),
+  };
+
+  fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+  return manifestPath;
+}
+
+function getWslWindowsManifestDir(browserConfig) {
+  const localAppData = getWindowsEnv("LOCALAPPDATA");
+  if (!localAppData || !browserConfig.wsl) return null;
+  return path.join(windowsPathToWslPath(localAppData), browserConfig.wsl);
+}
+
+function installManifest(browser, extensionId, wrapperPath, target) {
   const browserConfig = BROWSERS[browser];
 
-  if (!browserConfig || !browserConfig[platform]) {
-    return null;
+  if (!browserConfig) return null;
+
+  if (target === "wsl-windows") {
+    const manifestDir = getWslWindowsManifestDir(browserConfig);
+    if (!manifestDir) return null;
+    const manifestPath = path.join(manifestDir, `${HOST_NAME}.json`);
+    return writeManifest(manifestPath, extensionId, wrapperPath);
   }
+
+  const platform = process.platform;
+  if (!browserConfig[platform]) return null;
 
   if (platform === "win32") {
     return installWindowsRegistry(browser, extensionId, wrapperPath);
   }
 
   const manifestDir = path.join(os.homedir(), browserConfig[platform]);
-  fs.mkdirSync(manifestDir, { recursive: true });
-
-  const manifest = {
-    name: HOST_NAME,
-    description: "Surf CLI Native Host",
-    path: wrapperPath,
-    type: "stdio",
-    allowed_origins: [`chrome-extension://${extensionId}/`],
-  };
-
   const manifestPath = path.join(manifestDir, `${HOST_NAME}.json`);
-  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
-  return manifestPath;
+  return writeManifest(manifestPath, extensionId, wrapperPath);
 }
 
 function installWindowsRegistry(browser, extensionId, wrapperPath) {
@@ -173,16 +253,7 @@ function installWindowsRegistry(browser, extensionId, wrapperPath) {
 
   const manifestDir = getWrapperDir();
   const manifestPath = path.join(manifestDir, `${HOST_NAME}.json`);
-
-  const manifest = {
-    name: HOST_NAME,
-    description: "Surf CLI Native Host",
-    path: wrapperPath,
-    type: "stdio",
-    allowed_origins: [`chrome-extension://${extensionId}/`],
-  };
-
-  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+  writeManifest(manifestPath, extensionId, wrapperPath);
 
   try {
     execSync(`reg add "${regPath}" /ve /t REG_SZ /d "${manifestPath}" /f`, {
@@ -197,7 +268,7 @@ function installWindowsRegistry(browser, extensionId, wrapperPath) {
 
 function parseArgs() {
   const args = process.argv.slice(2);
-  const result = { extensionId: null, browsers: ["chrome"] };
+  const result = { extensionId: null, browsers: ["chrome"], target: "auto" };
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -208,6 +279,8 @@ function parseArgs() {
       } else {
         result.browsers = browserArg.split(",").map((b) => b.trim().toLowerCase());
       }
+    } else if (arg === "--target") {
+      result.target = args[++i];
     } else if (arg === "--help" || arg === "-h") {
       printHelp();
       process.exit(0);
@@ -232,20 +305,23 @@ Options:
   -b, --browser   Browser(s) to install for (default: chrome)
                   Values: chrome, chromium, brave, edge, arc, helium, all
                   Multiple: --browser chrome,brave
+  --target        Install target: auto, linux, windows
+                  On WSL2, auto installs for Windows Chrome. Use linux for WSLg/Linux browsers.
 
 Examples:
   node install-native-host.cjs abcdefghijklmnopabcdefghijklmnop
   node install-native-host.cjs abcdefghijklmnop --browser brave
   node install-native-host.cjs abcdefghijklmnop --browser all
+  node install-native-host.cjs abcdefghijklmnop --target linux
 `);
 }
 
 function main() {
-  const { extensionId, browsers } = parseArgs();
+  const { extensionId, browsers, target } = parseArgs();
 
   if (!extensionId) {
     console.error("Error: Extension ID required");
-    console.error("Usage: install-native-host.cjs <extension-id> [--browser chrome|chromium|brave|edge|arc|helium|all]");
+    console.error("Usage: install-native-host.cjs <extension-id> [--browser chrome|chromium|brave|edge|arc|helium|all] [--target auto|linux|windows]");
     console.error("\nFind your extension ID at chrome://extensions (enable Developer Mode)");
     process.exit(1);
   }
@@ -255,6 +331,24 @@ function main() {
     console.error("Expected 32 lowercase letters (a-p)");
     process.exit(1);
   }
+
+  if (!["auto", "linux", "windows"].includes(target)) {
+    console.error("Error: Invalid --target value. Expected auto, linux, or windows");
+    process.exit(1);
+  }
+
+  const runningInWsl = isWsl();
+  if (target === "windows" && !runningInWsl && process.platform !== "win32") {
+    console.error("Error: --target windows is only supported on Windows or WSL2");
+    process.exit(1);
+  }
+
+  if (target === "linux" && process.platform !== "linux") {
+    console.error("Error: --target linux is only supported on Linux or WSL2");
+    process.exit(1);
+  }
+
+  const effectiveTarget = runningInWsl && target !== "linux" ? "wsl-windows" : process.platform;
 
   const nodePath = findNode();
   if (!nodePath) {
@@ -270,19 +364,20 @@ function main() {
     process.exit(1);
   }
 
-  const wrapperDir = getWrapperDir();
+  const wrapperDir = getWrapperDir(effectiveTarget);
   if (!wrapperDir) {
-    console.error("Error: Unsupported platform");
+    console.error("Error: Unsupported platform or Windows interop unavailable");
     process.exit(1);
   }
 
-  console.log(`Platform: ${process.platform}`);
+  console.log(`Platform: ${process.platform}${runningInWsl ? " (WSL2 detected)" : ""}`);
+  console.log(`Target: ${effectiveTarget === "wsl-windows" ? "Windows browser from WSL2" : effectiveTarget}`);
   console.log(`Node: ${nodePath}`);
   console.log(`Host: ${hostPath}`);
   console.log(`Wrapper dir: ${wrapperDir}`);
   console.log("");
 
-  const wrapperPath = createWrapper(wrapperDir, nodePath, hostPath);
+  const wrapperPath = createWrapper(wrapperDir, nodePath, hostPath, effectiveTarget);
   console.log(`Created wrapper: ${wrapperPath}`);
   console.log("");
 
@@ -295,7 +390,7 @@ function main() {
       continue;
     }
 
-    const result = installManifest(browser, extensionId, wrapperPath);
+    const result = installManifest(browser, extensionId, wrapperPath, effectiveTarget);
     if (result) {
       installed.push({ browser: BROWSERS[browser].name, path: result });
     } else {
@@ -311,10 +406,17 @@ function main() {
   }
 
   if (skipped.length > 0) {
-    console.log(`\nSkipped (not supported on ${process.platform}): ${skipped.join(", ")}`);
+    console.log(`\nSkipped (not supported for ${effectiveTarget}): ${skipped.join(", ")}`);
   }
 
   console.log("\nDone! Restart your browser for changes to take effect.");
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  createWrapper,
+  writeManifest,
+};

--- a/scripts/uninstall-native-host.cjs
+++ b/scripts/uninstall-native-host.cjs
@@ -2,7 +2,7 @@
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
-const { execSync } = require("child_process");
+const { execFileSync, execSync } = require("child_process");
 
 const HOST_NAME = "surf.browser.host";
 
@@ -12,43 +12,80 @@ const BROWSERS = {
     darwin: "Library/Application Support/Google/Chrome/NativeMessagingHosts",
     linux: ".config/google-chrome/NativeMessagingHosts",
     win32: "Google\\Chrome",
+    wsl: "Google/Chrome/User Data/NativeMessagingHosts",
   },
   chromium: {
     name: "Chromium",
     darwin: "Library/Application Support/Chromium/NativeMessagingHosts",
     linux: ".config/chromium/NativeMessagingHosts",
     win32: "Chromium",
+    wsl: "Chromium/User Data/NativeMessagingHosts",
   },
   brave: {
     name: "Brave",
     darwin: "Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts",
     linux: ".config/BraveSoftware/Brave-Browser/NativeMessagingHosts",
     win32: "BraveSoftware\\Brave-Browser",
+    wsl: "BraveSoftware/Brave-Browser/User Data/NativeMessagingHosts",
   },
   edge: {
     name: "Microsoft Edge",
     darwin: "Library/Application Support/Microsoft Edge/NativeMessagingHosts",
     linux: ".config/microsoft-edge/NativeMessagingHosts",
     win32: "Microsoft\\Edge",
+    wsl: "Microsoft/Edge/User Data/NativeMessagingHosts",
   },
   arc: {
     name: "Arc",
     darwin: "Library/Application Support/Arc/User Data/NativeMessagingHosts",
     linux: null,
     win32: null,
+    wsl: null,
   },
   helium: {
     name: "Helium",
     darwin: "Library/Application Support/net.imput.helium/NativeMessagingHosts",
     linux: null,
     win32: null,
+    wsl: null,
   },
 };
 
-function getWrapperDir() {
-  const platform = process.platform;
+function isWsl() {
+  if (process.platform !== "linux") return false;
+  if (process.env.WSL_DISTRO_NAME || process.env.WSL_INTEROP) return true;
+  try {
+    return /microsoft|wsl/i.test(fs.readFileSync("/proc/version", "utf8"));
+  } catch {
+    return false;
+  }
+}
+
+function getWindowsEnv(name) {
+  try {
+    return execFileSync("cmd.exe", ["/c", "echo", `%${name}%`], { encoding: "utf8" })
+      .trim()
+      .replace(/\r/g, "");
+  } catch {
+    return null;
+  }
+}
+
+function windowsPathToWslPath(winPath) {
+  const normalized = winPath.replace(/\\/g, "/");
+  const match = normalized.match(/^([A-Za-z]):\/(.*)$/);
+  if (!match) return normalized;
+  return `/mnt/${match[1].toLowerCase()}/${match[2]}`;
+}
+
+function getWrapperDir(target = process.platform) {
   const home = os.homedir();
-  switch (platform) {
+  if (target === "wsl-windows") {
+    const localAppData = getWindowsEnv("LOCALAPPDATA");
+    if (!localAppData) return null;
+    return path.join(windowsPathToWslPath(localAppData), "surf-cli");
+  }
+  switch (process.platform) {
     case "darwin":
       return path.join(home, "Library/Application Support/surf-cli");
     case "linux":
@@ -60,13 +97,30 @@ function getWrapperDir() {
   }
 }
 
-function removeManifest(browser) {
-  const platform = process.platform;
+function getWslWindowsManifestPath(browserConfig) {
+  const localAppData = getWindowsEnv("LOCALAPPDATA");
+  if (!localAppData || !browserConfig.wsl) return null;
+  return path.join(windowsPathToWslPath(localAppData), browserConfig.wsl, `${HOST_NAME}.json`);
+}
+
+function removeManifest(browser, target) {
   const browserConfig = BROWSERS[browser];
 
-  if (!browserConfig || !browserConfig[platform]) {
-    return null;
+  if (!browserConfig) return null;
+
+  if (target === "wsl-windows") {
+    const manifestPath = getWslWindowsManifestPath(browserConfig);
+    if (!manifestPath) return null;
+    try {
+      fs.unlinkSync(manifestPath);
+      return manifestPath;
+    } catch {
+      return null;
+    }
   }
+
+  const platform = process.platform;
+  if (!browserConfig[platform]) return null;
 
   if (platform === "win32") {
     return removeWindowsRegistry(browser);
@@ -98,8 +152,8 @@ function removeWindowsRegistry(browser) {
   }
 }
 
-function removeWrapperDir() {
-  const wrapperDir = getWrapperDir();
+function removeWrapperDir(target) {
+  const wrapperDir = getWrapperDir(target);
   if (!wrapperDir) return null;
 
   try {
@@ -112,7 +166,7 @@ function removeWrapperDir() {
 
 function parseArgs() {
   const args = process.argv.slice(2);
-  const result = { browsers: ["chrome"], all: false };
+  const result = { browsers: ["chrome"], all: false, target: "auto" };
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -127,6 +181,8 @@ function parseArgs() {
     } else if (arg === "--all" || arg === "-a") {
       result.browsers = Object.keys(BROWSERS);
       result.all = true;
+    } else if (arg === "--target") {
+      result.target = args[++i];
     } else if (arg === "--help" || arg === "-h") {
       printHelp();
       process.exit(0);
@@ -145,18 +201,40 @@ Options:
   -b, --browser   Browser(s) to uninstall from (default: chrome)
                   Values: chrome, chromium, brave, edge, arc, helium, all
   -a, --all       Uninstall from all browsers and remove wrapper
+  --target        Install target to remove: auto, linux, windows
+                  On WSL2, auto removes Windows-browser manifests. Use linux for WSLg/Linux browsers.
 
 Examples:
   node uninstall-native-host.cjs
   node uninstall-native-host.cjs --browser brave
   node uninstall-native-host.cjs --all
+  node uninstall-native-host.cjs --target linux
 `);
 }
 
 function main() {
-  const { browsers, all } = parseArgs();
+  const { browsers, all, target } = parseArgs();
 
-  console.log(`Platform: ${process.platform}`);
+  if (!["auto", "linux", "windows"].includes(target)) {
+    console.error("Error: Invalid --target value. Expected auto, linux, or windows");
+    process.exit(1);
+  }
+
+  const runningInWsl = isWsl();
+  if (target === "windows" && !runningInWsl && process.platform !== "win32") {
+    console.error("Error: --target windows is only supported on Windows or WSL2");
+    process.exit(1);
+  }
+
+  if (target === "linux" && process.platform !== "linux") {
+    console.error("Error: --target linux is only supported on Linux or WSL2");
+    process.exit(1);
+  }
+
+  const effectiveTarget = runningInWsl && target !== "linux" ? "wsl-windows" : process.platform;
+
+  console.log(`Platform: ${process.platform}${runningInWsl ? " (WSL2 detected)" : ""}`);
+  console.log(`Target: ${effectiveTarget === "wsl-windows" ? "Windows browser from WSL2" : effectiveTarget}`);
   console.log("");
 
   const removed = [];
@@ -168,7 +246,7 @@ function main() {
       continue;
     }
 
-    const result = removeManifest(browser);
+    const result = removeManifest(browser, effectiveTarget);
     if (result) {
       removed.push({ browser: BROWSERS[browser].name, path: result });
     } else {
@@ -188,7 +266,7 @@ function main() {
   }
 
   if (all) {
-    const wrapperDir = removeWrapperDir();
+    const wrapperDir = removeWrapperDir(effectiveTarget);
     if (wrapperDir) {
       console.log(`\nRemoved wrapper directory: ${wrapperDir}`);
     }

--- a/skills/surf/SKILL.md
+++ b/skills/surf/SKILL.md
@@ -7,6 +7,12 @@ description: Control Chrome browser via CLI for testing, automation, and debuggi
 
 Control Chrome browser via CLI or Unix socket.
 
+## Native Host / WSL2 Notes
+
+For WSL2 with Windows Chrome, run `surf install <extension-id>` inside WSL2. Surf detects WSL2 and writes the Windows-side native messaging manifest plus a wrapper that launches the WSL host. Use `surf install <extension-id> --target linux` only for Linux browsers running inside WSLg.
+
+If a command reports `Socket connect failed`, check the `Attempted socket:` line. Default sockets are `/tmp/surf.sock` on macOS/Linux/WSL2 and `//./pipe/surf` on Windows. If `SURF_SOCKET` is set, the browser-launched host and the shell running `surf` must use the same value. Restart Chrome after changing native host installs.
+
 ## CLI Quick Reference
 
 ```bash

--- a/test/unit/native-host-installer.test.ts
+++ b/test/unit/native-host-installer.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+declare const process: {
+  execPath: string;
+  platform: string;
+};
+declare const require: (moduleName: string) => any;
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const { createWrapper, writeManifest } = require("../../scripts/install-native-host.cjs");
+
+const extensionA = "abcdefghijklmnopabcdefghijklmnop";
+const extensionB = "bcdefghijklmnopabcdefghijklmnopa";
+
+function makeTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "surf-native-host-test-"));
+}
+
+describe("native host installer", () => {
+  it("merges manifest allowed_origins without dropping existing fields", () => {
+    const tempDir = makeTempDir();
+    const manifestPath = path.join(tempDir, "surf.browser.host.json");
+    fs.writeFileSync(
+      manifestPath,
+      JSON.stringify(
+        {
+          name: "custom.name",
+          description: "Custom description",
+          allowed_origins: [`chrome-extension://${extensionA}/`],
+          extra: "kept",
+        },
+        null,
+        2,
+      ),
+    );
+
+    writeManifest(manifestPath, extensionB, "/tmp/host-wrapper.sh");
+
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+    expect(manifest).toMatchObject({
+      name: "surf.browser.host",
+      description: "Custom description",
+      path: "/tmp/host-wrapper.sh",
+      type: "stdio",
+      extra: "kept",
+    });
+    expect(manifest.allowed_origins).toEqual([
+      `chrome-extension://${extensionA}/`,
+      `chrome-extension://${extensionB}/`,
+    ]);
+  });
+
+  it("forwards wrapper arguments for POSIX and WSL Windows wrappers", () => {
+    const tempDir = makeTempDir();
+    const nodePath = process.execPath;
+    const hostPath = path.join(tempDir, "host.cjs");
+    fs.writeFileSync(hostPath, "");
+
+    const nativeWrapperPath = createWrapper(tempDir, nodePath, hostPath, "linux");
+    const nativeWrapperContent = fs.readFileSync(nativeWrapperPath, "utf8");
+    if (process.platform === "win32") {
+      expect(nativeWrapperContent).toContain(`"${hostPath}" %*`);
+    } else {
+      expect(nativeWrapperContent).toContain(`"${hostPath}" "$@"`);
+    }
+
+    const cmdPath = createWrapper(tempDir, nodePath, hostPath, "wsl-windows");
+    expect(fs.readFileSync(path.join(tempDir, "host-wrapper-wsl.cmd"), "utf8")).toContain(
+      `"${hostPath}" %*`,
+    );
+    expect(cmdPath).toBeTruthy();
+  });
+
+  it.runIf(process.platform !== "linux")(
+    "rejects install --target linux on non-Linux platforms",
+    () => {
+      const result = spawnSync(
+        process.execPath,
+        ["scripts/install-native-host.cjs", extensionA, "--target", "linux"],
+        { encoding: "utf8" },
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("--target linux is only supported on Linux or WSL2");
+    },
+  );
+
+  it.runIf(process.platform !== "linux")(
+    "rejects uninstall --target linux on non-Linux platforms",
+    () => {
+      const result = spawnSync(
+        process.execPath,
+        ["scripts/uninstall-native-host.cjs", "--target", "linux"],
+        { encoding: "utf8" },
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("--target linux is only supported on Linux or WSL2");
+    },
+  );
+});


### PR DESCRIPTION
Addresses #68 and improves the native-host diagnostics side of #42.

This teaches the native-host installer about WSL2 + Windows-browser installs, preserves existing native messaging origins instead of overwriting them, forwards wrapper args, centralizes socket path resolution with `SURF_SOCKET`, and makes missing-socket errors show the attempted path plus useful WSL/setup hints.

Validation:
- `npm ci`
- `npm run lint`
- `npm run check`
- `npm test`
- `npm audit --audit-level=critical`
- `node --check scripts/install-native-host.cjs scripts/uninstall-native-host.cjs native/socket-path.cjs native/cli.cjs native/host.cjs native/do-executor.cjs native/mcp-server.cjs`

Real WSL2 + Windows Chrome validation is still needed before we call #68 fully proven in the wild.
