### PR TITLE
fix: return surf js expression values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- **JavaScript expression evaluation** - `surf js` now returns single-expression values while preserving statement-script fallback behavior.
 - **Baseline CI validation** - Restored lint, typecheck, tests, and critical audit checks on current dependencies.
 - **Native messaging host portability** - Generated Unix wrappers now use `#!/usr/bin/env bash` so Chrome can launch the host on NixOS, Guix, and other non-FHS Linux systems. (@ppetru)
 - **Gemini blob-backed generated images** - Detect and extract Gemini-generated `blob:` images from the page while preserving existing `gg-dl` URL downloads. (@goneflyin)

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -133,6 +133,19 @@ function base64ToBlob(base64: string, mimeType = "image/png"): Blob {
   return new Blob([bytes], { type: mimeType });
 }
 
+function codeWithExpressionReturn(code: string): string {
+  return `return (\n${code}\n);`;
+}
+
+function scriptParses(code: string): boolean {
+  try {
+    new Function(code);
+    return true;
+  } catch (err) {
+    return !(err instanceof SyntaxError);
+  }
+}
+
 async function captureFullPage(tabId: number, maxHeight: number): Promise<{ base64: string; width: number; height: number }> {
   const dimensionsResult = await cdp.evaluateScript(tabId, `(() => ({
     viewportHeight: window.innerHeight,
@@ -1772,11 +1785,15 @@ export async function handleMessage(
         const piHelpersCode = `if(!window.piHelpers){const piHelpers={wait(ms){return new Promise(r=>setTimeout(r,ms))},async waitForSelector(sel,opts={}){const{state='visible',timeout=20000}=opts;const isVis=el=>el&&getComputedStyle(el).display!=='none'&&getComputedStyle(el).visibility!=='hidden'&&getComputedStyle(el).opacity!=='0'&&el.offsetWidth>0&&el.offsetHeight>0;const chk=()=>{const el=document.querySelector(sel);switch(state){case'attached':return el;case'detached':return el?null:document.body;case'hidden':return(!el||!isVis(el))?(el||document.body):null;default:return isVis(el)?el:null}};return new Promise((res,rej)=>{const r=chk();if(r){res(state==='detached'||state==='hidden'?null:r);return}const obs=new MutationObserver(()=>{const r=chk();if(r){obs.disconnect();clearTimeout(tid);res(state==='detached'||state==='hidden'?null:r)}});const tid=setTimeout(()=>{obs.disconnect();rej(new Error('Timeout'))},timeout);obs.observe(document.documentElement,{childList:true,subtree:true,attributes:true,attributeFilter:['style','class','hidden']})})},async waitForText(text,opts={}){const{selector,timeout=20000}=opts;const chk=()=>{const root=selector?document.querySelector(selector):document.body;if(!root)return null;const w=document.createTreeWalker(root,NodeFilter.SHOW_TEXT);while(w.nextNode())if(w.currentNode.textContent?.includes(text))return w.currentNode.parentElement;return null};return new Promise((res,rej)=>{const r=chk();if(r){res(r);return}const obs=new MutationObserver(()=>{const r=chk();if(r){obs.disconnect();clearTimeout(tid);res(r)}});const tid=setTimeout(()=>{obs.disconnect();rej(new Error('Timeout'))},timeout);obs.observe(document.documentElement,{childList:true,subtree:true,characterData:true})})},async waitForHidden(sel,t=20000){await piHelpers.waitForSelector(sel,{state:'hidden',timeout:t})},getByRole(role,opts={}){const{name}=opts;const roles={button:['button','input[type=button]','input[type=submit]','input[type=reset]'],link:['a[href]'],textbox:['input:not([type])','input[type=text]','input[type=email]','input[type=password]','textarea'],checkbox:['input[type=checkbox]'],radio:['input[type=radio]'],combobox:['select'],heading:['h1','h2','h3','h4','h5','h6']};const cands=[...document.querySelectorAll('[role='+role+']')];if(roles[role])roles[role].forEach(s=>cands.push(...document.querySelectorAll(s+':not([role])')));if(!name)return cands[0]||null;const n=name.toLowerCase().trim();for(const el of cands){const l=el.getAttribute('aria-label')?.toLowerCase().trim();const t=el.textContent?.toLowerCase().trim();if(l===n||t===n||l?.includes(n)||t?.includes(n))return el}return null}};window.__piHelpers=piHelpers;window.piHelpers=piHelpers}`;
         await cdp.evaluateScript(tabId, piHelpersCode);
         
-        const escaped = message.code.replace(/`/g, "\\`").replace(/\$/g, "\\$");
-        const expression = `(async () => { 'use strict'; ${escaped} })()`;
+        const body = codeWithExpressionReturn(message.code);
+        const expression = `(async () => { 'use strict'; ${body} })()`;
         
-        const result = await cdp.evaluateScript(tabId, expression);
+        let result = await cdp.evaluateScript(tabId, expression);
         
+        if (result.exceptionDetails && !scriptParses(body)) {
+          result = await cdp.evaluateScript(tabId, `(async () => { 'use strict'; ${message.code} })()`);
+        }
+
         if (result.exceptionDetails) {
           const err = result.exceptionDetails.exception?.description || 
                       result.exceptionDetails.text || 

--- a/test/unit/service-worker/javascript-handlers.test.ts
+++ b/test/unit/service-worker/javascript-handlers.test.ts
@@ -1,0 +1,240 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createChromeMock, resetChromeMock } from "../../mocks/chrome";
+
+vi.mock("../../../src/native/port-manager", () => ({
+  initNativeMessaging: vi.fn(),
+  postToNativeHost: vi.fn(),
+}));
+
+async function loadHandleMessage() {
+  vi.resetModules();
+  (globalThis as any).chrome = createChromeMock();
+  const mod = await import("../../../src/service-worker/index");
+  return mod.handleMessage;
+}
+
+function mockRuntimeEvaluate(chrome: ReturnType<typeof createChromeMock>) {
+  chrome.debugger.sendCommand.mockImplementation(
+    async (_target: any, method: string, params?: any) => {
+      if (method !== "Runtime.evaluate") {
+        return {};
+      }
+      if (params.expression.includes("if(!window.piHelpers)")) {
+        return { result: { value: undefined, type: "undefined" } };
+      }
+
+      try {
+        const evaluateExpression = new Function(`return (${params.expression});`);
+        const value = await evaluateExpression();
+        return { result: { value, type: typeof value } };
+      } catch (error) {
+        return {
+          exceptionDetails: {
+            text: error instanceof Error ? error.message : String(error),
+            exception: { description: error instanceof Error ? error.toString() : String(error) },
+          },
+        };
+      }
+    },
+  );
+}
+
+describe("JavaScript command handlers", () => {
+  beforeEach(() => {
+    resetChromeMock();
+  });
+
+  it("returns final expression values", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    mockRuntimeEvaluate(chrome);
+
+    const result = await handleMessage({ type: "EXECUTE_JAVASCRIPT", tabId: 1, code: "1 + 2" }, {});
+
+    expect(result).toEqual({ output: "3" });
+  });
+
+  it("returns multiline member chain expressions", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    mockRuntimeEvaluate(chrome);
+
+    const result = await handleMessage(
+      {
+        type: "EXECUTE_JAVASCRIPT",
+        tabId: 1,
+        code: "({ nested: { value: 42 } })\n  .nested\n  .value",
+      },
+      {},
+    );
+
+    expect(result).toEqual({ output: "42" });
+  });
+
+  it("returns expressions with trailing line comments", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    mockRuntimeEvaluate(chrome);
+
+    const result = await handleMessage(
+      { type: "EXECUTE_JAVASCRIPT", tabId: 1, code: "1 + 2 // trailing comment" },
+      {},
+    );
+
+    expect(result).toEqual({ output: "3" });
+  });
+
+  it("returns regex literal expressions", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    mockRuntimeEvaluate(chrome);
+
+    const result = await handleMessage(
+      { type: "EXECUTE_JAVASCRIPT", tabId: 1, code: "/;/.test(';')" },
+      {},
+    );
+
+    expect(result).toEqual({ output: "true" });
+  });
+
+  it("preserves explicit returns through SyntaxError fallback", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    mockRuntimeEvaluate(chrome);
+
+    const result = await handleMessage(
+      { type: "EXECUTE_JAVASCRIPT", tabId: 1, code: "return Promise.resolve('done')" },
+      {},
+    );
+
+    expect(result).toEqual({ output: '"done"' });
+  });
+
+  it("awaits final expression promises", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    mockRuntimeEvaluate(chrome);
+
+    const result = await handleMessage(
+      { type: "EXECUTE_JAVASCRIPT", tabId: 1, code: "await Promise.resolve({ ok: true })" },
+      {},
+    );
+
+    expect(result).toEqual({ output: '{\n  "ok": true\n}' });
+  });
+
+  it("preserves runtime errors without falling back", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    mockRuntimeEvaluate(chrome);
+
+    const result = await handleMessage(
+      { type: "EXECUTE_JAVASCRIPT", tabId: 1, code: "missingValue.property" },
+      {},
+    );
+
+    const evaluations = chrome.debugger.sendCommand.mock.calls.filter(
+      ([, method]: [unknown, string]) => method === "Runtime.evaluate",
+    );
+
+    expect(result.error).toContain("ReferenceError: missingValue is not defined");
+    expect(evaluations).toHaveLength(2);
+  });
+
+  it("does not fall back for runtime errors whose message mentions SyntaxError", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    mockRuntimeEvaluate(chrome);
+
+    const result = await handleMessage(
+      {
+        type: "EXECUTE_JAVASCRIPT",
+        tabId: 1,
+        code: "(() => { throw new Error('SyntaxError') })()",
+      },
+      {},
+    );
+
+    const evaluations = chrome.debugger.sendCommand.mock.calls.filter(
+      ([, method]: [unknown, string]) => method === "Runtime.evaluate",
+    );
+
+    expect(result.error).toContain("Error: SyntaxError");
+    expect(evaluations).toHaveLength(2);
+  });
+
+  it("does not fall back for runtime SyntaxError objects", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    mockRuntimeEvaluate(chrome);
+
+    const result = await handleMessage(
+      { type: "EXECUTE_JAVASCRIPT", tabId: 1, code: "(() => { throw new SyntaxError('boom') })()" },
+      {},
+    );
+
+    const evaluations = chrome.debugger.sendCommand.mock.calls.filter(
+      ([, method]: [unknown, string]) => method === "Runtime.evaluate",
+    );
+
+    expect(result.error).toContain("SyntaxError: boom");
+    expect(evaluations).toHaveLength(2);
+  });
+
+  it("falls back to original script on expression SyntaxError", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    mockRuntimeEvaluate(chrome);
+
+    const result = await handleMessage(
+      { type: "EXECUTE_JAVASCRIPT", tabId: 1, code: "const value = 42;" },
+      {},
+    );
+
+    const evaluations = chrome.debugger.sendCommand.mock.calls.filter(
+      ([, method]: [unknown, string]) => method === "Runtime.evaluate",
+    );
+
+    expect(result).toEqual({ output: "undefined" });
+    expect(evaluations).toHaveLength(3);
+  });
+
+  it("preserves multi-statement scripts as-is through SyntaxError fallback", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    mockRuntimeEvaluate(chrome);
+
+    const result = await handleMessage(
+      { type: "EXECUTE_JAVASCRIPT", tabId: 1, code: "const value = 40;\nvalue + 2" },
+      {},
+    );
+
+    expect(result).toEqual({ output: "undefined" });
+  });
+
+  it("preserves thrown errors", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    mockRuntimeEvaluate(chrome);
+
+    const result = await handleMessage(
+      { type: "EXECUTE_JAVASCRIPT", tabId: 1, code: "throw new Error('boom')" },
+      {},
+    );
+
+    expect(result.error).toContain("Error: boom");
+  });
+
+  it("preserves restricted-page errors", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    chrome.debugger.attach.mockRejectedValue(new Error("Cannot access a chrome:// URL"));
+
+    const result = await handleMessage({ type: "EXECUTE_JAVASCRIPT", tabId: 1, code: "1 + 2" }, {});
+
+    expect(result).toEqual({
+      error:
+        "Cannot control this page. Chrome restricts automation on chrome://, extensions, and web store pages.",
+    });
+  });
+});


### PR DESCRIPTION
Fixes #51.

`surf js` now returns values for single-expression snippets like `1 + 1`, multiline member chains, regex literal expressions, trailing comments, and awaited expressions. Statement-style snippets still fall back to the existing async-IIFE behavior, so multi-statement scripts keep their old `undefined` result unless they use an explicit `return`.

Validation:
- `npm ci`
- `npm run lint`
- `npm run check`
- `npm test`
- `npm audit --audit-level=critical`
