### PR TITLE
fix: support resize positional shorthand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **Cookie subcommands** - Added space-separated cookie commands (`surf cookie list`, `get`, `set`, `clear --all`, and `delete`) while keeping existing `cookie.*` commands working.
 
 ### Fixed
+- **Resize shorthand parsing** - `surf resize 375 812` now maps positional width and height, while `surf resize 375` sets width only.
 - **Grok UI drift** - Updated default model selection for the current Grok menu, broadened send-button validation, and trimmed trailing suggested follow-up chips from extracted responses.
 - **WSL2 native messaging host install** - Install/uninstall now target Windows browser manifests from WSL2 by default, preserve manifest origins, forward wrapper arguments, and include clearer socket diagnostics.
 - **JavaScript expression evaluation** - `surf js` now returns single-expression values while preserving statement-script fallback behavior.

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -1158,9 +1158,12 @@ const TOOLS = {
     commands: {
       "resize": {
         desc: "Resize browser window",
-        args: [],
+        args: ["width", "height"],
         opts: { width: "Window width", height: "Window height" },
-        examples: [{ cmd: "resize --width 1280 --height 720", desc: "Set size" }]
+        examples: [
+          { cmd: "resize 1280 720", desc: "Set size" },
+          { cmd: "resize --width 1280 --height 720", desc: "Set size with flags" },
+        ]
       },
     }
   },
@@ -2614,6 +2617,20 @@ if (tool === "click" && firstArg) {
     toolArgs.y = parseInt(positional[2], 10);
     firstArg = undefined;
   }
+}
+
+if (tool === "resize") {
+  if (firstArg !== undefined && toolArgs.width === undefined) {
+    let val = firstArg;
+    if (/^-?\d+$/.test(val)) val = parseInt(val, 10);
+    toolArgs.width = val;
+  }
+  if (positional[2] !== undefined && toolArgs.height === undefined) {
+    let val = positional[2];
+    if (/^-?\d+$/.test(val)) val = parseInt(val, 10);
+    toolArgs.height = val;
+  }
+  firstArg = undefined;
 }
 
 if (firstArg !== undefined) {

--- a/skills/surf/SKILL.md
+++ b/skills/surf/SKILL.md
@@ -171,6 +171,8 @@ surf tab.groups                # List all tab groups
 
 ```bash
 surf window.list                              # List all windows
+surf resize 1280 720                         # Resize current browser window
+surf resize 1280                             # Set current window width only
 surf window.list --tabs                       # Include tab details
 surf window.new                               # New window
 surf window.new --url "https://example.com"   # New window with URL

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -2063,17 +2063,29 @@ export async function handleMessage(
 
     case "RESIZE_WINDOW": {
       if (!tabId) throw new Error("No tabId provided");
-      if (!message.width || !message.height) throw new Error("width and height required");
+      if (message.width === undefined && message.height === undefined) {
+        throw new Error("width or height required");
+      }
 
       const tab = await chrome.tabs.get(tabId);
       if (!tab.windowId) throw new Error("Tab has no window");
 
+      const currentWindow =
+        message.width === undefined || message.height === undefined
+          ? await chrome.windows.get(tab.windowId)
+          : null;
+      const width = message.width === undefined ? currentWindow?.width : message.width;
+      const height = message.height === undefined ? currentWindow?.height : message.height;
+      if (width === undefined || height === undefined) {
+        throw new Error("current window size unavailable");
+      }
+
       await chrome.windows.update(tab.windowId, {
-        width: Math.floor(message.width),
-        height: Math.floor(message.height),
+        width: Math.floor(width),
+        height: Math.floor(height),
       });
 
-      return { success: true, width: message.width, height: message.height };
+      return { success: true, width, height };
     }
 
     case "TABS_CREATE": {

--- a/test/unit/cli-args.test.ts
+++ b/test/unit/cli-args.test.ts
@@ -1,0 +1,126 @@
+declare const process: {
+  cwd(): string;
+  env: Record<string, string | undefined>;
+  execPath: string;
+  pid: number;
+  platform: string;
+};
+declare const require: (moduleName: string) => any;
+
+const { spawn } = require("node:child_process");
+const fs = require("node:fs");
+const net = require("node:net");
+const os = require("node:os");
+const path = require("node:path");
+
+function createSocketPath() {
+  if (process.platform === "win32") {
+    return `\\\\.\\pipe\\surf-test-${process.pid}-${Date.now()}-${Math.random()}`;
+  }
+
+  return path.join(os.tmpdir(), `surf-test-${process.pid}-${Date.now()}-${Math.random()}.sock`);
+}
+
+function cleanupSocket(socketPath: string) {
+  if (process.platform === "win32") {
+    return;
+  }
+
+  try {
+    fs.unlinkSync(socketPath);
+  } catch {
+    // The socket may already be gone after the server closes.
+  }
+}
+
+function runCli(args: string[]): Promise<{ request: any; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const socketPath = createSocketPath();
+    cleanupSocket(socketPath);
+
+    let stdout = "";
+    let stderr = "";
+    let request: any;
+
+    const server = net.createServer((socket: any) => {
+      let buffer = "";
+      socket.on("data", (chunk: { toString(): string }) => {
+        buffer += chunk.toString();
+        const lineEnd = buffer.indexOf("\n");
+        if (lineEnd === -1) {
+          return;
+        }
+
+        request = JSON.parse(buffer.slice(0, lineEnd));
+        socket.write(
+          `${JSON.stringify({ result: { content: [{ type: "text", text: "OK" }] } })}\n`,
+        );
+        socket.end();
+      });
+    });
+
+    server.on("error", reject);
+    server.listen(socketPath, () => {
+      const child = spawn(process.execPath, ["native/cli.cjs", ...args], {
+        cwd: process.cwd(),
+        env: { ...process.env, SURF_SOCKET: socketPath },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+
+      child.stdout.on("data", (chunk: { toString(): string }) => {
+        stdout += chunk.toString();
+      });
+      child.stderr.on("data", (chunk: { toString(): string }) => {
+        stderr += chunk.toString();
+      });
+      child.on("error", (error: Error) => {
+        server.close();
+        reject(error);
+      });
+      child.on("close", (code: number) => {
+        server.close(() => {
+          cleanupSocket(socketPath);
+
+          if (code !== 0) {
+            reject(new Error(`CLI exited ${code}: ${stderr}`));
+            return;
+          }
+
+          resolve({ request, stdout, stderr });
+        });
+      });
+    });
+  });
+}
+
+describe("CLI argument parsing", () => {
+  it("maps resize positional width and height", async () => {
+    const { request } = await runCli(["resize", "375", "812"]);
+
+    expect(request.params.tool).toBe("resize");
+    expect(request.params.args).toMatchObject({ width: 375, height: 812 });
+  });
+
+  it("maps resize single positional argument to width only", async () => {
+    const { request } = await runCli(["resize", "375"]);
+
+    expect(request.params.tool).toBe("resize");
+    expect(request.params.args.width).toBe(375);
+    expect(request.params.args).not.toHaveProperty("height");
+  });
+
+  it("preserves resize width and height flags", async () => {
+    const { request } = await runCli(["resize", "--width", "375", "--height", "812"]);
+
+    expect(request.params.tool).toBe("resize");
+    expect(request.params.args).toMatchObject({ width: 375, height: 812 });
+  });
+
+  it("does not map emulate.viewport positional values to width and height", async () => {
+    const { request } = await runCli(["emulate.viewport", "375", "812"]);
+
+    expect(request.params.tool).toBe("emulate.viewport");
+    expect(request.params.args).not.toHaveProperty("width");
+    expect(request.params.args).not.toHaveProperty("height");
+  });
+});

--- a/test/unit/service-worker/window-handlers.test.ts
+++ b/test/unit/service-worker/window-handlers.test.ts
@@ -172,6 +172,41 @@ describe("window command handlers", () => {
     });
   });
 
+  describe("RESIZE_WINDOW", () => {
+    it("keeps current height for width-only resize", async () => {
+      const chrome = (globalThis as any).chrome;
+      chrome.tabs.get.mockResolvedValue({ windowId: 123 });
+      chrome.windows.get.mockResolvedValue({ id: 123, width: 1440, height: 900 });
+      chrome.windows.update.mockResolvedValue({ width: 375, height: 900 });
+
+      const result = await handleMessage(
+        {
+          type: "RESIZE_WINDOW",
+          tabId: 456,
+          width: 375,
+        },
+        {},
+      );
+
+      expect(chrome.tabs.get).toHaveBeenCalledWith(456);
+      expect(chrome.windows.get).toHaveBeenCalledWith(123);
+      expect(chrome.windows.update).toHaveBeenCalledWith(123, { width: 375, height: 900 });
+      expect(result).toMatchObject({ success: true, width: 375, height: 900 });
+    });
+
+    it("requires at least one window dimension", async () => {
+      await expect(
+        handleMessage(
+          {
+            type: "RESIZE_WINDOW",
+            tabId: 456,
+          },
+          {},
+        ),
+      ).rejects.toThrow("width or height required");
+    });
+  });
+
   describe("tab commands with windowId", () => {
     describe("LIST_TABS", () => {
       it("filters by windowId when provided", async () => {


### PR DESCRIPTION
Fixes #56.

Adds positional parsing for `surf resize 375 812` and width-only `surf resize 375`, while preserving existing flag behavior. The service-worker resize path now reads the current browser window when one dimension is omitted so the other side is preserved.

Validation run:
- `npm test -- --reporter=dot` (15 files, 299 tests)
- `npm run lint` (existing warnings only)
- `npm run check`
- `npm audit --audit-level=critical`
- `git diff --check`

Fresh read-only reviewer pass found no blockers.