### PR TITLE
fix: accept screenshot full-page alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **Cookie subcommands** - Added space-separated cookie commands (`surf cookie list`, `get`, `set`, `clear --all`, and `delete`) while keeping existing `cookie.*` commands working.
 
 ### Fixed
+- **Screenshot full-page alias** - Treat `surf screenshot --full-page` the same as `--fullpage`, including explicit output paths.
 - **Resize shorthand parsing** - `surf resize 375 812` now maps positional width and height, while `surf resize 375` sets width only.
 - **Grok UI drift** - Updated default model selection for the current Grok menu, broadened send-button validation, and trimmed trailing suggested follow-up chips from extracted responses.
 - **WSL2 native messaging host install** - Install/uninstall now target Windows browser manifests from WSL2 by default, preserve manifest origins, forward wrapper arguments, and include clearer socket diagnostics.

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ surf screenshot --output /tmp/shot.png      # Save to specific path
 surf screenshot --full --output /tmp/hd.png # Full resolution (skip resize)
 surf screenshot --annotate                  # With element labels
 surf screenshot --fullpage                  # Entire page
+surf screenshot --full-page /tmp/full.png   # Entire page, save to path
 surf screenshot --no-save                   # Return base64 + ID only (no file)
 surf snap                                   # Alias for screenshot
 ```

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -541,6 +541,7 @@ const TOOLS = {
           selector: "Capture specific element",
           annotate: "Draw element labels",
           fullpage: "Capture full page",
+          "full-page": "Capture full page (alias for --fullpage)",
           "max-height": "Max height for fullpage (default: 4000)",
           full: "Skip resize, save at full resolution",
           "max-size": "Max dimension in px (default: 1200)",
@@ -1319,6 +1320,7 @@ Commands:
   screenshot --output file.png                          Basic screenshot
   screenshot --annotate --output file.png               With element labels
   screenshot --fullpage --output file.png               Full page capture
+  screenshot --full-page --output file.png              Full page capture (alias)
   screenshot --annotate --fullpage --output file.png    Full page with labels
   snap                                                  Auto-save to /tmp
 
@@ -1326,6 +1328,7 @@ Options:
   --output      Save path
   --annotate    Draw element refs
   --fullpage    Capture entire page
+  --full-page   Capture entire page (alias)
   --max-height  Max height for fullpage (default: 4000)`
   },
   automation: {
@@ -1348,7 +1351,7 @@ Wait for dynamic content:
 
 Scroll and capture:
   scroll.bottom
-  screenshot --fullpage --output full.png`
+  screenshot --full-page --output full.png`
   },
   windows: {
     title: "Window Isolation",
@@ -2441,7 +2444,7 @@ if (args[0] === "workflow.validate") {
   }
 }
 
-const BOOLEAN_FLAGS = ["auto-capture", "json", "stream", "dry-run", "stop-on-error", "fail-fast", "clear", "submit", "all", "case-sensitive", "hard", "annotate", "fullpage", "reset", "no-screenshot", "full", "soft-fail", "has-body", "exclude-static", "v", "vv", "request", "by-tab", "har", "jsonl", "no-save", "no-auto-wait"];
+const BOOLEAN_FLAGS = ["auto-capture", "json", "stream", "dry-run", "stop-on-error", "fail-fast", "clear", "submit", "all", "case-sensitive", "hard", "annotate", "fullpage", "full-page", "reset", "no-screenshot", "full", "soft-fail", "has-body", "exclude-static", "v", "vv", "request", "by-tab", "har", "jsonl", "no-save", "no-auto-wait"];
 
 const AUTO_SCREENSHOT_TOOLS = ["click", "type", "key", "smart_type", "form.fill", "form_input", "drag", "hover", "scroll", "scroll.top", "scroll.bottom", "scroll.to", "dialog.accept", "dialog.dismiss", "js", "eval"];
 
@@ -2521,9 +2524,14 @@ tool = ALIASES[tool] || tool;
 // Auto-save screenshots to temp file when no --output specified
 // This ensures agents always get a usable file path, not just an in-memory ID
 // Can be disabled with --no-save flag or autoSaveScreenshots: false in surf.json
+if (options["full-page"] === true) {
+  options.fullpage = true;
+  delete options["full-page"];
+}
+
 const config = loadConfig();
 const autoSaveEnabled = config.autoSaveScreenshots !== false && !options["no-save"];
-if (tool === "screenshot" && !options.output && !options.savePath && autoSaveEnabled) {
+if (tool === "screenshot" && !options.output && !options.savePath && firstArg === undefined && autoSaveEnabled) {
   options.savePath = path.join(SURF_TMP, `surf-snap-${Date.now()}.png`);
 }
 
@@ -2630,6 +2638,11 @@ if (tool === "resize") {
     if (/^-?\d+$/.test(val)) val = parseInt(val, 10);
     toolArgs.height = val;
   }
+  firstArg = undefined;
+}
+
+if (tool === "screenshot" && firstArg !== undefined && toolArgs.output === undefined && toolArgs.savePath === undefined) {
+  toolArgs.savePath = firstArg;
   firstArg = undefined;
 }
 

--- a/native/host-helpers.cjs
+++ b/native/host-helpers.cjs
@@ -575,7 +575,7 @@ function mapToolToMessage(tool, args, tabId) {
         type: "EXECUTE_SCREENSHOT", 
         savePath: a.savePath || a.output,  // Accept both savePath (CLI) and output (MCP)
         annotate: a.annotate || false,
-        fullpage: a.fullpage || false,
+        fullpage: a.fullpage || a["full-page"] || false,
         maxHeight: a["max-height"] || 4000,
         fullRes: a.full || false,
         maxSize: a["max-size"] || 1200,

--- a/skills/surf/SKILL.md
+++ b/skills/surf/SKILL.md
@@ -403,6 +403,7 @@ surf screenshot                           # Auto-saves to /tmp/surf-snap-*.png
 surf screenshot --output /tmp/shot.png    # Save to specific file
 surf screenshot --selector ".card"        # Element only
 surf screenshot --full-page               # Full page scroll capture
+surf screenshot --full-page /tmp/full.png # Full page saved to path
 surf screenshot --no-save                 # Return base64 only, don't save file
 ```
 

--- a/test/unit/cli-screenshot.test.ts
+++ b/test/unit/cli-screenshot.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+declare const process: {
+  cwd(): string;
+  env: Record<string, string | undefined>;
+  execPath: string;
+  platform: string;
+};
+declare const require: (moduleName: string) => any;
+
+const fs = require("node:fs");
+const net = require("node:net");
+const os = require("node:os");
+const path = require("node:path");
+const { spawn } = require("node:child_process");
+
+const tempPaths: string[] = [];
+
+function socketPathForTest() {
+  if (process.platform === "win32") {
+    return `\\\\.\\pipe\\surf-cli-test-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  }
+
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "surf-cli-test-"));
+  tempPaths.push(dir);
+  return path.join(dir, "surf.sock");
+}
+
+async function captureCliRequest(args: string[]) {
+  const socketPath = socketPathForTest();
+  const cliPath = path.join(process.cwd(), "native", "cli.cjs");
+
+  let capturedRequest: any;
+  const server = net.createServer((socket: any) => {
+    let buffer = "";
+    socket.on("data", (chunk: { toString(): string }) => {
+      buffer += chunk.toString();
+      const lines = buffer.split("\n");
+      buffer = lines.pop() || "";
+      for (const line of lines) {
+        if (!line.trim()) {
+          continue;
+        }
+        capturedRequest = JSON.parse(line);
+        socket.write(
+          `${JSON.stringify({
+            id: capturedRequest.id,
+            result: {
+              content: [{ type: "text", text: JSON.stringify({ message: "ok" }) }],
+            },
+          })}\n`,
+        );
+        socket.end();
+      }
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, resolve);
+  });
+
+  const result = await new Promise<{ code: number | null; stdout: string; stderr: string }>(
+    (resolve) => {
+      const child = spawn(process.execPath, [cliPath, ...args], {
+        cwd: process.cwd(),
+        env: { ...process.env, SURF_SOCKET: socketPath },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (chunk: { toString(): string }) => {
+        stdout += chunk.toString();
+      });
+      child.stderr.on("data", (chunk: { toString(): string }) => {
+        stderr += chunk.toString();
+      });
+      child.on("close", (code: number | null) => resolve({ code, stdout, stderr }));
+    },
+  );
+
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+
+  if (result.code !== 0 || result.stderr !== "") {
+    throw new Error(`CLI failed with code ${result.code}: ${result.stderr}`);
+  }
+  if (!capturedRequest) {
+    throw new Error("CLI did not send a request");
+  }
+  return capturedRequest;
+}
+
+afterEach(() => {
+  for (const tempPath of tempPaths.splice(0)) {
+    fs.rmSync(tempPath, { recursive: true, force: true });
+  }
+});
+
+describe("screenshot CLI parsing", () => {
+  it("treats --full-page with a path like fullpage screenshot output", async () => {
+    const request = await captureCliRequest(["screenshot", "--full-page", "/tmp/full.png"]);
+
+    expect(request.params.tool).toBe("screenshot");
+    expect(request.params.args.fullpage).toBe(true);
+    expect(request.params.args.savePath).toBe("/tmp/full.png");
+    expect(request.params.args["full-page"]).toBeUndefined();
+  });
+
+  it("treats --full-page --output like fullpage screenshot output", async () => {
+    const request = await captureCliRequest([
+      "screenshot",
+      "--full-page",
+      "--output",
+      "/tmp/full.png",
+    ]);
+
+    expect(request.params.tool).toBe("screenshot");
+    expect(request.params.args.fullpage).toBe(true);
+    expect(request.params.args.savePath).toBe("/tmp/full.png");
+    expect(request.params.args["full-page"]).toBeUndefined();
+  });
+
+  it("preserves --fullpage auto-save behavior", async () => {
+    const request = await captureCliRequest(["screenshot", "--fullpage"]);
+
+    expect(request.params.args.fullpage).toBe(true);
+    expect(request.params.args.savePath).toMatch(/^\/tmp\/surf-snap-\d+\.png$/);
+  });
+});

--- a/test/unit/host-helpers.test.ts
+++ b/test/unit/host-helpers.test.ts
@@ -88,6 +88,19 @@ describe("mapToolToMessage", () => {
     });
   });
 
+  describe("screenshot commands", () => {
+    it("maps full-page to fullpage", () => {
+      const msg = helpers.mapToolToMessage("screenshot", { "full-page": true });
+      expect(msg.type).toBe("EXECUTE_SCREENSHOT");
+      expect(msg.fullpage).toBe(true);
+    });
+
+    it("preserves fullpage mapping", () => {
+      const msg = helpers.mapToolToMessage("screenshot", { fullpage: true });
+      expect(msg.fullpage).toBe(true);
+    });
+  });
+
   describe("error cases", () => {
     it("returns null for unknown tool", () => {
       expect(helpers.mapToolToMessage("unknown.command", {})).toBeNull();


### PR DESCRIPTION
Fixes #53.

Treats `surf screenshot --full-page` as a complete alias for `--fullpage`, including positional output paths, `--output`, native-host mapping, generated help, topic help, README, skill docs, changelog, and tests.

Validation run:
- `npm test -- --reporter=dot` (15 files, 298 tests)
- `npm run lint` (existing warnings only)
- `npm run check`
- `npm audit --audit-level=critical`
- `git diff --check`

Fresh read-only reviewer pass found no blockers.