### PR TITLE
fix: support scroll positional shorthand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- **Scroll shorthand** - `surf scroll` now accepts positional forms like `scroll down 800`, `scroll up 400`, `scroll bottom`, and `scroll top` while keeping existing flag and dot-command forms.
 - **Cookie subcommands** - Added space-separated cookie commands (`surf cookie list`, `get`, `set`, `clear --all`, and `delete`) while keeping existing `cookie.*` commands working.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -197,7 +197,9 @@ surf click 100 200                  # Click by coordinates
 surf type "hello" --submit          # Type and press Enter
 surf type "email@example.com" --ref e12  # Type into specific element
 surf key Escape                     # Press key
-surf scroll.bottom                  # Scroll to bottom
+surf scroll down 800                # Scroll down 800px
+surf scroll bottom                  # Scroll to bottom
+surf scroll.bottom                  # Dot command form also works
 ```
 
 ### Forms

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -563,9 +563,12 @@ const TOOLS = {
     commands: {
       "scroll": {
         desc: "Scroll in direction",
-        args: [],
+        args: ["direction", "pixels"],
         opts: { direction: "up|down|left|right", amount: "Scroll amount (1-10)" },
-        examples: [{ cmd: "scroll --direction down --amount 3", desc: "Scroll down" }]
+        examples: [
+          { cmd: "scroll down 800", desc: "Scroll down 800px" },
+          { cmd: "scroll --direction down --amount 3", desc: "Scroll down" },
+        ]
       },
       "scroll.top": { desc: "Scroll to top of page", args: [], opts: { selector: "Target specific container" } },
       "scroll.bottom": { desc: "Scroll to bottom of page", args: [], opts: { selector: "Target specific container" } },
@@ -2615,6 +2618,19 @@ const PRIMARY_ARG_MAP = {
 };
 
 const toolArgs = { ...options };
+
+if (tool === "scroll" && firstArg) {
+  if (firstArg === "top" || firstArg === "bottom") {
+    tool = `scroll.${firstArg}`;
+    firstArg = undefined;
+  } else if (["up", "down", "left", "right"].includes(firstArg)) {
+    if (toolArgs.direction === undefined) toolArgs.direction = firstArg;
+    if (positional[2] !== undefined && /^-?\d+$/.test(positional[2]) && toolArgs.amount === undefined && toolArgs.scroll_amount === undefined) {
+      toolArgs.scroll_pixels = parseInt(positional[2], 10);
+    }
+    firstArg = undefined;
+  }
+}
 
 if (tool === "click" && firstArg) {
   if (/^e\d+$/.test(firstArg)) {

--- a/native/do-parser.cjs
+++ b/native/do-parser.cjs
@@ -165,6 +165,18 @@ function parseCommandLine(line) {
       } else if (values.length > 1) {
         args.values = values;     // Multiple values as array
       }
+    } else if (cmd === 'scroll') {
+      if (firstArg === 'top' || firstArg === 'bottom') {
+        cmd = `scroll.${firstArg}`;
+        i++;
+      } else if (['up', 'down', 'left', 'right'].includes(firstArg)) {
+        args.direction = firstArg;
+        i++;
+        if (i < tokens.length && /^-?\d+$/.test(tokens[i])) {
+          args.scroll_pixels = parseInt(tokens[i], 10);
+          i++;
+        }
+      }
     } else {
       // Use PRIMARY_ARG_MAP for other commands
       const primaryKey = PRIMARY_ARG_MAP[cmd];

--- a/native/host-helpers.cjs
+++ b/native/host-helpers.cjs
@@ -342,6 +342,19 @@ function formatToolContent(result, log = () => {}) {
     }
     return text(output);
   }
+
+  if (
+    result.scrollTop !== undefined &&
+    result.scrollHeight !== undefined &&
+    result.scrollPercentage === undefined
+  ) {
+    return text(`Scrolled to Y:${result.scrollTop} (page height: ${result.scrollHeight})`);
+  }
+
+  if (result.scrollY !== undefined) {
+    const pageHeight = result.pageHeight !== undefined ? ` (page height: ${result.pageHeight})` : "";
+    return text(`Scrolled to Y:${result.scrollY}${pageHeight}`);
+  }
   
   if (result.success && result.name && result.tabId !== undefined) {
     return text(`Registered tab ${result.tabId} as "${result.name}"`);
@@ -478,14 +491,15 @@ function mapComputerAction(args, tabId) {
       return { type: "FIND_AND_TYPE", text, submit: a.submit ?? false, submitKey: a.submitKey || "Enter", ...baseMsg };
     
     case "scroll": {
-      const amount = (scroll_amount || 3) * 100;
+      const direction = a.direction || scroll_direction;
+      const amount = a.scroll_pixels ?? ((a.amount ?? scroll_amount ?? 3) * 100);
       const deltas = {
         up: { deltaX: 0, deltaY: -amount },
         down: { deltaX: 0, deltaY: amount },
         left: { deltaX: -amount, deltaY: 0 },
         right: { deltaX: amount, deltaY: 0 },
       };
-      const { deltaX, deltaY } = deltas[scroll_direction] || { deltaX: 0, deltaY: 0 };
+      const { deltaX, deltaY } = deltas[direction] || { deltaX: 0, deltaY: 0 };
       return { type: "EXECUTE_SCROLL", deltaX, deltaY, x: coordinate?.[0], y: coordinate?.[1], ...baseMsg };
     }
     

--- a/skills/surf/SKILL.md
+++ b/skills/surf/SKILL.md
@@ -266,11 +266,13 @@ surf element.styles ".card"            # Or by CSS selector
 ## Scrolling
 
 ```bash
-surf scroll.bottom
-surf scroll.top  
-surf scroll.to --y 500         # Scroll to Y position
+surf scroll down 800           # Scroll down 800px
+surf scroll up 400             # Scroll up 400px
+surf scroll bottom             # Scroll to bottom
+surf scroll top                # Scroll to top
+surf scroll.bottom             # Dot command form also works
+surf scroll.top
 surf scroll.to --ref e5        # Scroll element into view
-surf scroll.by --y 200         # Scroll by amount
 surf scroll.info               # Get scroll position
 ```
 

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -752,6 +752,8 @@ export async function handleMessage(
         return { 
           scrollX: after.x, 
           scrollY: after.y,
+          pageHeight: document.documentElement.scrollHeight,
+          viewportHeight: window.innerHeight,
           scrolled: before.x !== after.x || before.y !== after.y
         };
       };

--- a/test/unit/do-parser.test.ts
+++ b/test/unit/do-parser.test.ts
@@ -161,6 +161,20 @@ screenshot --output /tmp/result.png
     expect(steps[0].args.values).toBe("United States"); // Single value as string
     expect(steps[0].args.by).toBe("label");
   });
+
+  it("parses scroll direction shorthand with pixel amount", () => {
+    const steps = parser.parseDoCommands("scroll down 800");
+    expect(steps[0]).toEqual({
+      cmd: "scroll",
+      args: { direction: "down", scroll_pixels: 800 },
+    });
+  });
+
+  it("parses scroll top and bottom shorthand as dot commands", () => {
+    const steps = parser.parseDoCommands("scroll top\nscroll bottom");
+    expect(steps[0]).toEqual({ cmd: "scroll.top", args: {} });
+    expect(steps[1]).toEqual({ cmd: "scroll.bottom", args: {} });
+  });
 });
 
 describe("tokenize", () => {

--- a/test/unit/host-helpers.test.ts
+++ b/test/unit/host-helpers.test.ts
@@ -101,6 +101,44 @@ describe("mapToolToMessage", () => {
     });
   });
 
+  describe("scroll commands", () => {
+    it("maps direction and amount flags to scroll deltas", () => {
+      const msg = helpers.mapToolToMessage("scroll", { direction: "down", amount: 4 }, 123);
+      expect(msg).toMatchObject({ type: "EXECUTE_SCROLL", deltaX: 0, deltaY: 400, tabId: 123 });
+    });
+
+    it("preserves legacy scroll_direction and scroll_amount mapping", () => {
+      const msg = helpers.mapToolToMessage(
+        "scroll",
+        { scroll_direction: "up", scroll_amount: 2 },
+        123,
+      );
+      expect(msg).toMatchObject({ type: "EXECUTE_SCROLL", deltaX: 0, deltaY: -200, tabId: 123 });
+    });
+
+    it("uses shorthand pixel amounts without multiplying by 100", () => {
+      const msg = helpers.mapToolToMessage(
+        "scroll",
+        { direction: "down", scroll_pixels: 800 },
+        123,
+      );
+      expect(msg).toMatchObject({ type: "EXECUTE_SCROLL", deltaX: 0, deltaY: 800, tabId: 123 });
+    });
+
+    it("maps scroll.top and scroll.bottom dot commands", () => {
+      expect(helpers.mapToolToMessage("scroll.top", {}, 123)).toMatchObject({
+        type: "SCROLL_TO_POSITION",
+        position: "top",
+        tabId: 123,
+      });
+      expect(helpers.mapToolToMessage("scroll.bottom", {}, 123)).toMatchObject({
+        type: "SCROLL_TO_POSITION",
+        position: "bottom",
+        tabId: 123,
+      });
+    });
+  });
+
   describe("error cases", () => {
     it("returns null for unknown tool", () => {
       expect(helpers.mapToolToMessage("unknown.command", {})).toBeNull();
@@ -148,6 +186,38 @@ describe("formatToolContent", () => {
         _hint: "hint",
       });
       expect(result[0].text).not.toContain("_resolvedTabId");
+    });
+  });
+
+  describe("scroll responses", () => {
+    it("formats scrollBy position output", () => {
+      const result = helpers.formatToolContent({ scrollY: 800, pageHeight: 3200, scrolled: true });
+      expect(result[0].text).toBe("Scrolled to Y:800 (page height: 3200)");
+    });
+
+    it("formats scroll position output", () => {
+      const result = helpers.formatToolContent({ scrollTop: 0, scrollHeight: 3200, atTop: true });
+      expect(result[0].text).toBe("Scrolled to Y:0 (page height: 3200)");
+    });
+
+    it("preserves detailed scroll info output", () => {
+      const result = helpers.formatToolContent({
+        scrollTop: 800,
+        scrollHeight: 3200,
+        clientHeight: 900,
+        atTop: false,
+        atBottom: false,
+        scrollPercentage: 35,
+      });
+
+      expect(JSON.parse(result[0].text)).toEqual({
+        scrollTop: 800,
+        scrollHeight: 3200,
+        clientHeight: 900,
+        atTop: false,
+        atBottom: false,
+        scrollPercentage: 35,
+      });
     });
   });
 


### PR DESCRIPTION
Fixes #52.

Adds positional forms for `surf scroll down 800`, `surf scroll up 400`, `surf scroll bottom`, and `surf scroll top` in both direct CLI parsing and `surf do` workflows. The formatter was kept narrow so `surf scroll.info` still returns its detailed JSON fields.

Validation run:
- `npm test -- --reporter=dot` (14 files, 302 tests)
- `npm run lint` (existing warnings only)
- `npm run check`
- `npm audit --audit-level=critical`
- `git diff --check`

Fresh read-only reviewer pass found no blockers.