### PR TITLE
fix: support ChatGPT file uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - **Cookie subcommands** - Added space-separated cookie commands (`surf cookie list`, `get`, `set`, `clear --all`, and `delete`) while keeping existing `cookie.*` commands working.
 
 ### Fixed
+- **ChatGPT file upload** - `surf chatgpt --file <path>` now uploads the file through the ChatGPT composer before sending the prompt, with provider-specific upload errors.
+- **Gemini upload menu selector** - Accept Gemini's current `Upload & tools` opener while preserving the legacy upload menu selector.
 - **Screenshot full-page alias** - Treat `surf screenshot --full-page` the same as `--fullpage`, including explicit output paths.
 - **Resize shorthand parsing** - `surf resize 375 812` now maps positional width and height, while `surf resize 375` sets width only.
 - **Grok UI drift** - Updated default model selection for the current Grok menu, broadened send-button validation, and trimmed trailing suggested follow-up chips from extracted responses.

--- a/native/chatgpt-client.cjs
+++ b/native/chatgpt-client.cjs
@@ -1,3 +1,5 @@
+const path = require("path");
+
 const CHATGPT_URL = "https://chatgpt.com/";
 
 const SELECTORS = {
@@ -645,6 +647,7 @@ async function query(options) {
     closeTab,
     cdpEvaluate,
     cdpCommand,
+    uploadFile,
     log = () => {},
   } = options;
   const startTime = Date.now();
@@ -692,7 +695,21 @@ async function query(options) {
       log(`Selected model: ${selectedLabel}`);
     }
     if (file) {
-      throw new Error("File upload not yet implemented");
+      if (!uploadFile) {
+        throw new Error("ChatGPT file upload unavailable: native host did not provide upload callback");
+      }
+      const files = Array.isArray(file) ? file : [file];
+      const absFiles = files.map((filePath) => path.resolve(process.cwd(), filePath));
+      log(`Uploading ${absFiles.length} file(s) to ChatGPT...`);
+      const uploadResult = await uploadFile(tabId, absFiles);
+      if (uploadResult?.error) {
+        throw new Error(`ChatGPT file upload failed: ${uploadResult.error}`);
+      }
+      if (!uploadResult?.success) {
+        throw new Error("ChatGPT file upload failed: upload did not report success");
+      }
+      log("File uploaded, waiting for ChatGPT attachment processing...");
+      await delay(1500);
     }
     await typePrompt(cdp, inputCdp, prompt);
     log("Prompt typed");

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -2755,6 +2755,13 @@ if (tool === "gemini") {
     toolArgs.file = path.resolve(toolArgs.file);
   }
 }
+if (tool === "chatgpt" && toolArgs.file) {
+  if (Array.isArray(toolArgs.file)) {
+    toolArgs.file = toolArgs.file.map((filePath) => path.resolve(filePath));
+  } else if (typeof toolArgs.file === "string") {
+    toolArgs.file = path.resolve(toolArgs.file);
+  }
+}
 
 if (tool === "screenshot" && outputPath) {
   if (typeof outputPath !== "string") {

--- a/native/host-helpers.cjs
+++ b/native/host-helpers.cjs
@@ -2,6 +2,14 @@ const fs = require("fs");
 const networkFormatters = require("./formatters/network.cjs");
 const networkStore = require("./network-store.cjs");
 
+function buildProviderUploadMessage(provider, tabId, filePaths, id) {
+  const normalizedProvider = String(provider || "").toLowerCase();
+  if (!["chatgpt", "gemini"].includes(normalizedProvider)) {
+    throw new Error(`Unsupported upload provider: ${provider}`);
+  }
+  return { type: "AI_UPLOAD_FILE_TO_TAB", provider: normalizedProvider, tabId, filePaths, id };
+}
+
 function normalizeModelString(model) {
   return String(model || "").trim().toLowerCase();
 }
@@ -1146,4 +1154,4 @@ function mapToolToMessage(tool, args, tabId) {
   }
 }
 
-module.exports = { mapToolToMessage, mapComputerAction, formatToolContent };
+module.exports = { mapToolToMessage, mapComputerAction, formatToolContent, buildProviderUploadMessage };

--- a/native/host.cjs
+++ b/native/host.cjs
@@ -12,7 +12,7 @@ const perplexityClient = require("./perplexity-client.cjs");
 const grokClient = require("./grok-client.cjs");
 const aistudioClient = require("./aistudio-client.cjs");
 const aistudioBuild = require("./aistudio-build.cjs");
-const { mapToolToMessage, mapComputerAction, formatToolContent } = require("./host-helpers.cjs");
+const { mapToolToMessage, mapComputerAction, formatToolContent, buildProviderUploadMessage } = require("./host-helpers.cjs");
 
 const IS_WIN = process.platform === "win32";
 const { SOCKET_PATH, SURF_TMP } = require("./socket-path.cjs");
@@ -533,6 +533,16 @@ function handleToolRequest(msg, socket) {
           });
           writeMessage({ type: "CHATGPT_CDP_COMMAND", tabId, method, params, id: cmdId });
         }),
+        uploadFile: (tabId, filePaths) => new Promise((resolve) => {
+          const uploadId = ++requestCounter;
+          pendingToolRequests.set(uploadId, {
+            socket: null,
+            originalId: null,
+            tool: "upload_file",
+            onComplete: (r) => resolve(r)
+          });
+          writeMessage(buildProviderUploadMessage("chatgpt", tabId, filePaths, uploadId));
+        }),
         log: (msg) => log(`[chatgpt] ${msg}`)
       });
       
@@ -735,7 +745,7 @@ function handleToolRequest(msg, socket) {
             tool: "upload_file",
             onComplete: (r) => resolve(r)
           });
-          writeMessage({ type: "UPLOAD_FILE_TO_TAB", tabId, filePaths, id: uploadId });
+          writeMessage(buildProviderUploadMessage("gemini", tabId, filePaths, uploadId));
         }),
         fetchUrl: (url) => new Promise((resolve) => {
           const fetchId = ++requestCounter;

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -35,6 +35,144 @@ function getScreenshot(id: string): { base64: string; width: number; height: num
   return screenshotCache.get(id) || null;
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const providerUploadStrategies = {
+  gemini: {
+    openerSelector: 'button[aria-label="Upload & tools"], button[aria-label="Open upload file menu"]',
+    closeSelector: 'button[aria-label="Close upload file menu"]',
+    uploadItemSelector: '[data-test-id="local-images-files-uploader-button"], [data-testid="local-images-files-uploader-button"], button[aria-label^="Upload files"]',
+  },
+  chatgpt: {
+    directInputSelector: 'form input[type="file"]:not([accept*="image"]), input[type="file"]:not([accept*="image"]), input[type="file"]',
+    openerSelector: 'button[data-testid="composer-plus-btn"], button[aria-label="Add files and more"]',
+  },
+};
+
+async function setFileInputFilesBySelector(
+  tabId: number,
+  filePaths: string[],
+  selector: string,
+): Promise<boolean> {
+  const result = await cdp.sendCommand(tabId, "Runtime.evaluate", {
+    expression: `(() => {
+      const input = document.querySelector(${JSON.stringify(selector)});
+      if (!input || input.tagName !== 'INPUT' || input.type !== 'file') return null;
+      return input;
+    })()`,
+    userGesture: true,
+  });
+  const objectId = result?.result?.objectId;
+  if (!objectId) return false;
+  await cdp.sendCommand(tabId, "DOM.setFileInputFiles", { files: filePaths, objectId });
+  return true;
+}
+
+async function uploadFilesWithChooser(
+  tabId: number,
+  filePaths: string[],
+  provider: "gemini" | "chatgpt",
+): Promise<void> {
+  await cdp.sendCommand(tabId, "Page.setInterceptFileChooserDialog", { enabled: true });
+
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  let handler: ((source: chrome.debugger.Debuggee, method: string, params: any) => void) | null = null;
+  const cleanup = () => {
+    if (timeoutId) { clearTimeout(timeoutId); timeoutId = null; }
+    if (handler) { chrome.debugger.onEvent.removeListener(handler); handler = null; }
+  };
+
+  const attemptFileChooser = (attemptNum: number, timeoutMs: number): Promise<void> => {
+    return new Promise<void>((resolve, reject) => {
+      timeoutId = setTimeout(() => {
+        cleanup();
+        reject(new Error(`${provider} file chooser did not open within ${timeoutMs / 1000}s (attempt ${attemptNum})`));
+      }, timeoutMs);
+      handler = (source: chrome.debugger.Debuggee, method: string, params: any) => {
+        if (source.tabId === tabId && method === "Page.fileChooserOpened") {
+          cleanup();
+          cdp.sendCommand(tabId, "DOM.setFileInputFiles", {
+            files: filePaths,
+            backendNodeId: params.backendNodeId,
+          }).then(() => resolve()).catch(reject);
+        }
+      };
+      chrome.debugger.onEvent.addListener(handler);
+    });
+  };
+
+  const clickUploadSequence = async () => {
+    if (provider === "gemini") {
+      await cdp.sendCommand(tabId, "Runtime.evaluate", {
+        expression: `document.querySelector(${JSON.stringify(providerUploadStrategies.gemini.closeSelector)})?.click()`,
+        userGesture: true,
+      });
+      await sleep(300);
+      await cdp.sendCommand(tabId, "Runtime.evaluate", {
+        expression: `document.querySelector(${JSON.stringify(providerUploadStrategies.gemini.openerSelector)})?.click()`,
+        userGesture: true,
+      });
+      await sleep(500);
+      await cdp.sendCommand(tabId, "Runtime.evaluate", {
+        expression: `document.querySelector(${JSON.stringify(providerUploadStrategies.gemini.uploadItemSelector)})?.click()`,
+        userGesture: true,
+      });
+      return;
+    }
+
+    await cdp.sendCommand(tabId, "Runtime.evaluate", {
+      expression: `document.querySelector(${JSON.stringify(providerUploadStrategies.chatgpt.openerSelector)})?.click()`,
+      userGesture: true,
+    });
+  };
+
+  const maxAttempts = 3;
+  const timeouts = [10000, 15000, 20000];
+  let lastError: Error | null = null;
+
+  try {
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        const fileSetPromise = attemptFileChooser(attempt, timeouts[attempt - 1]);
+        await clickUploadSequence();
+        await fileSetPromise;
+        return;
+      } catch (err) {
+        lastError = err as Error;
+        cleanup();
+        if (attempt < maxAttempts) await sleep(1000);
+      }
+    }
+    throw new Error(`${provider} file upload failed after ${maxAttempts} attempts: ${lastError?.message}`);
+  } finally {
+    cleanup();
+    try { await cdp.sendCommand(tabId, "Page.setInterceptFileChooserDialog", { enabled: false }); } catch {}
+  }
+}
+
+async function uploadFilesToProviderTab(
+  provider: "gemini" | "chatgpt",
+  tabId: number,
+  filePaths: string[],
+): Promise<{ success: true }> {
+  await cdp.attach(tabId);
+  await cdp.sendCommand(tabId, "DOM.enable", {});
+
+  if (provider === "chatgpt") {
+    const directUpload = await setFileInputFilesBySelector(
+      tabId,
+      filePaths,
+      providerUploadStrategies.chatgpt.directInputSelector,
+    );
+    if (directUpload) return { success: true };
+  }
+
+  await uploadFilesWithChooser(tabId, filePaths, provider);
+  return { success: true };
+}
+
 const ELEMENT_COLORS: Record<string, string> = {
   button: '#FF6B6B',
   input: '#4ECDC4',
@@ -2864,87 +3002,17 @@ export async function handleMessage(
       return { success: true };
     }
 
+    case "AI_UPLOAD_FILE_TO_TAB":
     case "UPLOAD_FILE_TO_TAB": {
       const { tabId: uploadTabId, filePaths } = message;
+      const provider = message.type === "UPLOAD_FILE_TO_TAB" ? "gemini" : message.provider;
       if (!uploadTabId || !filePaths?.length) {
-        throw new Error("UPLOAD_FILE_TO_TAB requires tabId and filePaths");
+        throw new Error(`${message.type} requires tabId and filePaths`);
       }
-      await cdp.attach(uploadTabId);
-      await cdp.sendCommand(uploadTabId, "DOM.enable", {});
-      await cdp.sendCommand(uploadTabId, "Page.setInterceptFileChooserDialog", { enabled: true });
-
-      let timeoutId: ReturnType<typeof setTimeout> | null = null;
-      let handler: ((source: chrome.debugger.Debuggee, method: string, params: any) => void) | null = null;
-      const cleanup = () => {
-        if (timeoutId) { clearTimeout(timeoutId); timeoutId = null; }
-        if (handler) { chrome.debugger.onEvent.removeListener(handler); handler = null; }
-      };
-
-      const attemptFileChooser = (attemptNum: number, timeoutMs: number): Promise<void> => {
-        return new Promise<void>((resolve, reject) => {
-          timeoutId = setTimeout(() => {
-            cleanup();
-            reject(new Error(`File chooser did not open within ${timeoutMs / 1000}s (attempt ${attemptNum})`));
-          }, timeoutMs);
-          handler = (source: chrome.debugger.Debuggee, method: string, params: any) => {
-            if (source.tabId === uploadTabId && method === "Page.fileChooserOpened") {
-              cleanup();
-              cdp.sendCommand(uploadTabId, "DOM.setFileInputFiles", {
-                files: filePaths,
-                backendNodeId: params.backendNodeId,
-              }).then(() => resolve()).catch(reject);
-            }
-          };
-          chrome.debugger.onEvent.addListener(handler);
-        });
-      };
-
-      const clickUploadSequence = async () => {
-        // Close menu if already open
-        await cdp.sendCommand(uploadTabId, "Runtime.evaluate", {
-          expression: `document.querySelector('button[aria-label="Close upload file menu"]')?.click()`,
-          userGesture: true,
-        });
-        await new Promise(r => setTimeout(r, 300));
-
-        // Open upload menu
-        await cdp.sendCommand(uploadTabId, "Runtime.evaluate", {
-          expression: `document.querySelector('button[aria-label="Open upload file menu"]')?.click()`,
-          userGesture: true,
-        });
-        await new Promise(r => setTimeout(r, 500));
-
-        // Click "Upload files" button
-        await cdp.sendCommand(uploadTabId, "Runtime.evaluate", {
-          expression: `document.querySelector('[data-test-id="local-images-files-uploader-button"]')?.click()`,
-          userGesture: true,
-        });
-      };
-
-      const maxAttempts = 3;
-      const timeouts = [10000, 15000, 20000];
-      let lastError: Error | null = null;
-
-      try {
-        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-          try {
-            const fileSetPromise = attemptFileChooser(attempt, timeouts[attempt - 1]);
-            await clickUploadSequence();
-            await fileSetPromise;
-            return { success: true };
-          } catch (err) {
-            lastError = err as Error;
-            cleanup();
-            if (attempt < maxAttempts) {
-              await new Promise(r => setTimeout(r, 1000));
-            }
-          }
-        }
-        throw new Error(`File upload failed after ${maxAttempts} attempts: ${lastError?.message}`);
-      } finally {
-        cleanup();
-        try { await cdp.sendCommand(uploadTabId, "Page.setInterceptFileChooserDialog", { enabled: false }); } catch {}
+      if (provider !== "gemini" && provider !== "chatgpt") {
+        throw new Error(`Unsupported upload provider: ${provider}`);
       }
+      return uploadFilesToProviderTab(provider, uploadTabId, filePaths);
     }
 
     case "GEMINI_FETCH_URL": {
@@ -3166,7 +3234,7 @@ const COMMANDS_WITHOUT_TAB = new Set([
   "GET_CHATGPT_COOKIES", "GET_GOOGLE_COOKIES", "GET_TWITTER_COOKIES",
   "PERPLEXITY_NEW_TAB", "PERPLEXITY_CLOSE_TAB", "PERPLEXITY_EVALUATE", "PERPLEXITY_CDP_COMMAND",
   "GROK_NEW_TAB", "GROK_CLOSE_TAB", "GROK_EVALUATE", "GROK_CDP_COMMAND",
-  "GEMINI_NEW_TAB", "GEMINI_CLOSE_TAB", "GEMINI_FETCH_URL", "UPLOAD_FILE_TO_TAB",
+  "GEMINI_NEW_TAB", "GEMINI_CLOSE_TAB", "GEMINI_FETCH_URL", "AI_UPLOAD_FILE_TO_TAB", "UPLOAD_FILE_TO_TAB",
   "AISTUDIO_NEW_TAB", "AISTUDIO_CLOSE_TAB", "AISTUDIO_EVALUATE", "AISTUDIO_CDP_COMMAND",
   "DOWNLOADS_SEARCH",
   "WINDOW_NEW", "WINDOW_LIST", "WINDOW_FOCUS", "WINDOW_CLOSE", "WINDOW_RESIZE",

--- a/test/unit/chatgpt-client.test.ts
+++ b/test/unit/chatgpt-client.test.ts
@@ -1,5 +1,29 @@
+import { vi } from "vitest";
 // @ts-expect-error - CommonJS module without type definitions
 import * as chatgptClient from "../../native/chatgpt-client.cjs";
+
+function createReadyChatGptEvaluate(
+  loginStatus: Record<string, unknown> = { status: 200, hasLoginCta: false },
+) {
+  return async (_tabId: number, expression: string) => {
+    if (expression === "document.readyState") {
+      return { result: { value: "complete" } };
+    }
+    if (expression === "document.title.toLowerCase()") {
+      return { result: { value: "chatgpt" } };
+    }
+    if (expression.includes("challenge-platform")) {
+      return { result: { value: false } };
+    }
+    if (expression.includes("fetch('/backend-api/me'")) {
+      return { result: { value: loginStatus } };
+    }
+    if (expression.includes("const selectors") && expression.includes("prompt-textarea")) {
+      return { result: { value: true } };
+    }
+    throw new Error(`Unexpected expression: ${expression}`);
+  };
+}
 
 describe("chatgpt-client", () => {
   describe("cleanChatGPTResponseText", () => {
@@ -316,6 +340,55 @@ describe("chatgpt-client", () => {
   });
 
   describe("query", () => {
+    it("invokes the upload callback for ChatGPT files and propagates upload errors", async () => {
+      const uploadFile = vi.fn(async () => ({ error: "composer file input not found" }));
+      const closeCalls: number[] = [];
+
+      await expect(
+        chatgptClient.query({
+          prompt: "summarize this",
+          file: "fixtures/report.txt",
+          getCookies: async () => ({
+            cookies: [{ name: "__Secure-next-auth.session-token.0", value: "abc" }],
+          }),
+          createTab: async () => ({ tabId: 123 }),
+          closeTab: async (tabId: number) => {
+            closeCalls.push(tabId);
+          },
+          uploadFile,
+          cdpCommand: async () => {
+            throw new Error("cdpCommand should not be called before upload succeeds");
+          },
+          cdpEvaluate: createReadyChatGptEvaluate(),
+        }),
+      ).rejects.toThrow("ChatGPT file upload failed: composer file input not found");
+
+      expect(uploadFile).toHaveBeenCalledWith(123, [
+        expect.stringContaining("fixtures/report.txt"),
+      ]);
+      expect(closeCalls).toEqual([123]);
+    });
+
+    it("throws a clear error when ChatGPT file upload is requested without a host callback", async () => {
+      await expect(
+        chatgptClient.query({
+          prompt: "summarize this",
+          file: "report.txt",
+          getCookies: async () => ({
+            cookies: [{ name: "__Secure-next-auth.session-token.0", value: "abc" }],
+          }),
+          createTab: async () => ({ tabId: 123 }),
+          closeTab: async () => undefined,
+          cdpCommand: async () => {
+            throw new Error("cdpCommand should not be called");
+          },
+          cdpEvaluate: createReadyChatGptEvaluate(),
+        }),
+      ).rejects.toThrow(
+        "ChatGPT file upload unavailable: native host did not provide upload callback",
+      );
+    });
+
     it("preserves login check failures instead of downgrading them to login required", async () => {
       const closeCalls: number[] = [];
 
@@ -332,29 +405,11 @@ describe("chatgpt-client", () => {
           cdpCommand: async () => {
             throw new Error("cdpCommand should not be called");
           },
-          cdpEvaluate: async (_tabId: number, expression: string) => {
-            if (expression === "document.readyState") {
-              return { result: { value: "complete" } };
-            }
-            if (expression === "document.title.toLowerCase()") {
-              return { result: { value: "chatgpt" } };
-            }
-            if (expression.includes("challenge-platform")) {
-              return { result: { value: false } };
-            }
-            if (expression.includes("fetch('/backend-api/me'")) {
-              return {
-                result: {
-                  value: {
-                    status: 0,
-                    error: "TypeError: Failed to fetch",
-                    url: "https://chatgpt.com/",
-                  },
-                },
-              };
-            }
-            throw new Error(`Unexpected expression: ${expression}`);
-          },
+          cdpEvaluate: createReadyChatGptEvaluate({
+            status: 0,
+            error: "TypeError: Failed to fetch",
+            url: "https://chatgpt.com/",
+          }),
         }),
       ).rejects.toThrow("ChatGPT login check failed: TypeError: Failed to fetch");
 

--- a/test/unit/cli-args.test.ts
+++ b/test/unit/cli-args.test.ts
@@ -123,4 +123,11 @@ describe("CLI argument parsing", () => {
     expect(request.params.args).not.toHaveProperty("width");
     expect(request.params.args).not.toHaveProperty("height");
   });
+
+  it("resolves ChatGPT file paths before sending to the native host", async () => {
+    const { request } = await runCli(["chatgpt", "summarize", "--file", "fixtures/report.txt"]);
+
+    expect(request.params.tool).toBe("chatgpt");
+    expect(request.params.args.file).toBe(path.resolve("fixtures/report.txt"));
+  });
 });

--- a/test/unit/host-helpers.test.ts
+++ b/test/unit/host-helpers.test.ts
@@ -1,6 +1,34 @@
 // @ts-expect-error - CommonJS module without type definitions
 import * as helpers from "../../native/host-helpers.cjs";
 
+describe("buildProviderUploadMessage", () => {
+  it("builds provider-aware ChatGPT upload messages", () => {
+    expect(helpers.buildProviderUploadMessage("chatgpt", 123, ["/tmp/file.txt"], 7)).toEqual({
+      type: "AI_UPLOAD_FILE_TO_TAB",
+      provider: "chatgpt",
+      tabId: 123,
+      filePaths: ["/tmp/file.txt"],
+      id: 7,
+    });
+  });
+
+  it("builds provider-aware Gemini upload messages", () => {
+    expect(helpers.buildProviderUploadMessage("gemini", 456, ["/tmp/image.png"], 8)).toEqual({
+      type: "AI_UPLOAD_FILE_TO_TAB",
+      provider: "gemini",
+      tabId: 456,
+      filePaths: ["/tmp/image.png"],
+      id: 8,
+    });
+  });
+
+  it("rejects unsupported upload providers", () => {
+    expect(() => helpers.buildProviderUploadMessage("perplexity", 1, ["/tmp/file.txt"], 2)).toThrow(
+      "Unsupported upload provider: perplexity",
+    );
+  });
+});
+
 describe("mapToolToMessage", () => {
   describe("window commands", () => {
     it("maps window.new to WINDOW_NEW with url", () => {

--- a/test/unit/service-worker/upload-handlers.test.ts
+++ b/test/unit/service-worker/upload-handlers.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createChromeMock, resetChromeMock } from "../../mocks/chrome";
+
+vi.mock("../../../src/native/port-manager", () => ({
+  initNativeMessaging: vi.fn(),
+  postToNativeHost: vi.fn(),
+}));
+
+async function loadHandleMessage() {
+  vi.resetModules();
+  (globalThis as any).chrome = createChromeMock();
+  const mod = await import("../../../src/service-worker/index");
+  return mod.handleMessage;
+}
+
+describe("provider upload handlers", () => {
+  beforeEach(() => {
+    resetChromeMock();
+  });
+
+  it("sets ChatGPT files on the composer file input when available", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+
+    chrome.debugger.sendCommand.mockImplementation(async (_target: any, method: string) => {
+      if (method === "Runtime.evaluate") {
+        return { result: { objectId: "chatgpt-file-input" } };
+      }
+      return {};
+    });
+
+    const result = await handleMessage(
+      {
+        type: "AI_UPLOAD_FILE_TO_TAB",
+        provider: "chatgpt",
+        tabId: 42,
+        filePaths: ["/tmp/report.txt"],
+      },
+      {},
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(chrome.debugger.attach).toHaveBeenCalledWith({ tabId: 42 }, "1.3");
+    expect(chrome.debugger.sendCommand).toHaveBeenCalledWith(
+      { tabId: 42 },
+      "DOM.setFileInputFiles",
+      { files: ["/tmp/report.txt"], objectId: "chatgpt-file-input" },
+    );
+
+    const evaluateCall = chrome.debugger.sendCommand.mock.calls.find(
+      ([, method]: [unknown, string]) => method === "Runtime.evaluate",
+    );
+    expect(evaluateCall?.[2].expression).toContain("input[type=");
+    expect(evaluateCall?.[2].expression).toContain("not([accept*=");
+  });
+
+  it("keeps legacy UPLOAD_FILE_TO_TAB as Gemini and accepts current Upload & tools opener", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    let chooserHandler: ((source: { tabId: number }, method: string, params: any) => void) | null =
+      null;
+
+    chrome.debugger.onEvent.addListener.mockImplementation((handler: typeof chooserHandler) => {
+      chooserHandler = handler;
+    });
+    chrome.debugger.sendCommand.mockImplementation(async (_target: any, method: string) => {
+      if (method === "Runtime.evaluate" && chooserHandler) {
+        setTimeout(
+          () => chooserHandler?.({ tabId: 42 }, "Page.fileChooserOpened", { backendNodeId: 99 }),
+          0,
+        );
+      }
+      return {};
+    });
+
+    const result = await handleMessage(
+      {
+        type: "UPLOAD_FILE_TO_TAB",
+        tabId: 42,
+        filePaths: ["/tmp/image.png"],
+      },
+      {},
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(chrome.debugger.sendCommand).toHaveBeenCalledWith(
+      { tabId: 42 },
+      "DOM.setFileInputFiles",
+      { files: ["/tmp/image.png"], backendNodeId: 99 },
+    );
+
+    const expressions = chrome.debugger.sendCommand.mock.calls
+      .filter(([, method]: [unknown, string]) => method === "Runtime.evaluate")
+      .map(([, , params]: [unknown, string, { expression: string }]) => params.expression)
+      .join("\n");
+    expect(expressions).toContain("Upload & tools");
+    expect(expressions).toContain("Open upload file menu");
+    expect(expressions).toContain("local-images-files-uploader-button");
+  });
+
+  it("rejects unsupported provider-aware upload providers", async () => {
+    const handleMessage = await loadHandleMessage();
+
+    await expect(
+      handleMessage(
+        {
+          type: "AI_UPLOAD_FILE_TO_TAB",
+          provider: "perplexity",
+          tabId: 42,
+          filePaths: ["/tmp/file.txt"],
+        },
+        {},
+      ),
+    ).rejects.toThrow("Unsupported upload provider: perplexity");
+  });
+});


### PR DESCRIPTION
Fixes #65.

Adds provider-aware file upload plumbing so `surf chatgpt --file <path>` uploads through the ChatGPT composer before sending the prompt. Relative file paths are resolved in the CLI before crossing into the long-lived native host. The Gemini upload path is preserved, and the Gemini opener selector now also accepts the current `Upload & tools` UI for #47.

Validation run:
- focused: `npm test -- --run test/unit/cli-args.test.ts test/unit/chatgpt-client.test.ts test/unit/host-helpers.test.ts test/unit/service-worker/upload-handlers.test.ts` (4 files, 88 tests)
- `npm test -- --reporter=dot` (18 files, 328 tests)
- `npm run lint` (existing warnings only)
- `npm run check`
- `npm audit --audit-level=critical`
- `git diff --check`

Fresh read-only review found and parent fixed a relative-path blocker; re-review found no blockers.

Note: this targets #47's Gemini upload-menu selector drift, but does not close #47 by itself because the original send-button error was not reproduced in non-submitting live DOM validation.