### PR TITLE
feat: add llm context help flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- **LLM context flag** - Added `surf --llm-context` as a compact, deterministic quick reference for AI agents.
 - **CLI/native socket integration coverage** - Added CI-safe integration tests for Surf CLI request framing, fake native-host responses, host errors, and missing-socket diagnostics.
 - **Scroll shorthand** - `surf scroll` now accepts positional forms like `scroll down 800`, `scroll up 400`, `scroll bottom`, and `scroll top` while keeping existing flag and dot-command forms.
 - **Cookie subcommands** - Added space-separated cookie commands (`surf cookie list`, `get`, `set`, `clear --all`, and `delete`) while keeping existing `cookie.*` commands working.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ npm run build
 ```bash
 surf <command> [args] [options]
 surf --help                    # Basic help
+surf --llm-context             # Compact reference for AI agents
 surf --help-full               # All 50+ commands
 surf <command> --help          # Command details
 surf --find <query>            # Search commands

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -1561,11 +1561,35 @@ Quick Examples:
 
 More Help:
   surf --help-full           All commands
+  surf --llm-context         Compact reference for AI agents
   surf --help-topic <topic>  Topic guide (refs, semantic, frames, devices...)
   surf <command> --help      Command details
   surf --find <query>        Search for commands
   surf --about <topic>       Learn about a topic
 `);
+};
+
+const showLlmContext = () => {
+  console.log(`SURF CLI LLM CONTEXT
+Purpose: control Chrome from shell. Commands are \`surf <command> [args] [options]\`.
+Core loop: navigate -> wait/read -> act -> screenshot/read.
+Navigate: surf navigate "https://example.com"    # alias: surf go "..."
+Wait after navigation: surf wait 2                # or wait.load for load complete
+Read DOM/refs: surf page.read --depth 3 --compact # alias: surf read
+Refs: use e1/e2 refs from page.read; prefer refs over CSS when available.
+Click ref: surf click e5
+Click selector/coords: surf click --selector ".btn" | surf click 100 200
+Type: surf type "text" --submit                  # use --ref e5 to target a field
+Screenshot: surf screenshot /tmp/shot.png         # auto-saves to /tmp if no path
+Full page screenshot: surf screenshot --full-page /tmp/full.png
+JavaScript: surf js "return document.title"
+Scroll: surf scroll down 800 | surf scroll up 400 | surf scroll bottom | surf scroll top
+Find by semantics: surf locate.role button --name "Submit" --action click
+Device/viewport: surf emulate.device "iPhone 14" | surf resize 375 812
+Cookies: surf cookie list | surf cookie get "name" | surf cookie delete "name"
+Window isolation: surf window.new "https://example.com" then pass --window-id <id>
+Workflow: surf do 'go "https://example.com" | wait 2 | read | click e5 | screenshot'
+More help: surf --help-full | surf <command> --help | surf --help-topic refs | surf --find <query>`);
 };
 
 const showFullHelp = () => {
@@ -1758,6 +1782,11 @@ const showAllTools = () => {
   }
   console.log(`\n  Total: ${ALL_SOCKET_TOOLS.length} commands\n`);
 };
+
+if (args[0] === "--llm-context") {
+  showLlmContext();
+  process.exit(0);
+}
 
 if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
   showBasicHelp();

--- a/test/unit/cli-args.test.ts
+++ b/test/unit/cli-args.test.ts
@@ -33,6 +33,32 @@ function cleanupSocket(socketPath: string) {
   }
 }
 
+function runCliWithoutSocket(
+  args: string[],
+): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    let stdout = "";
+    let stderr = "";
+
+    const child = spawn(process.execPath, ["native/cli.cjs", ...args], {
+      cwd: process.cwd(),
+      env: { ...process.env, SURF_SOCKET: undefined, SURF_SOCKET_PATH: undefined },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    child.stdout.on("data", (chunk: { toString(): string }) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk: { toString(): string }) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("close", (code: number | null) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
 function runCli(args: string[]): Promise<{ request: any; stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
     const socketPath = createSocketPath();
@@ -94,6 +120,28 @@ function runCli(args: string[]): Promise<{ request: any; stdout: string; stderr:
 }
 
 describe("CLI argument parsing", () => {
+  it("prints LLM context without requiring a socket", async () => {
+    const { code, stdout, stderr } = await runCliWithoutSocket(["--llm-context"]);
+
+    expect(code).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("SURF CLI LLM CONTEXT");
+    expect(stdout).toContain("surf page.read --depth 3 --compact");
+    expect(stdout).toContain("surf click e5");
+    expect(stdout).toContain("surf screenshot --full-page /tmp/full.png");
+    expect(stdout).toContain("surf scroll down 800");
+    expect(stdout).toContain("surf cookie list");
+    expect(stdout).toContain("surf resize 375 812");
+  });
+
+  it("mentions LLM context in top-level help", async () => {
+    const { code, stdout, stderr } = await runCliWithoutSocket(["--help"]);
+
+    expect(code).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("surf --llm-context");
+  });
+
   it("maps resize positional width and height", async () => {
     const { request } = await runCli(["resize", "375", "812"]);
 


### PR DESCRIPTION
Fixes #57.

Adds `surf --llm-context` as a no-socket, deterministic quick reference for AI agents. The top-level flag exits before native-host parsing, is advertised in normal help, and has focused CLI coverage.

Validation run:
- `npm test -- --reporter=dot` (17 files, 321 tests)
- `npm run lint` (existing warnings only)
- `npm run check`
- `npm audit --audit-level=critical`
- `git diff --check`
- direct smoke: `node native/cli.cjs --llm-context` exits 0 with empty stderr

Fresh read-only reviewer pass found no blockers.