### PR TITLE
docs: add macOS native host troubleshooting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
 - **Gemini blob-backed generated images** - Detect and extract Gemini-generated `blob:` images from the page while preserving existing `gg-dl` URL downloads. (@goneflyin)
 - **Accessibility tree nested labels** - Include nested text content when naming interactive links, buttons, and summaries so child spans contribute accessible names. (@skyeryg)
 
+### Docs
+- **macOS native host troubleshooting** - Added a focused checklist for Chrome native messaging manifests, extension IDs, service-worker logs, and matching `SURF_SOCKET` values.
+
 ### Dependencies
 - Bump Vitest package group from 4.0.18 to 4.1.9 to clear the critical audit advisory.
 

--- a/README.md
+++ b/README.md
@@ -582,6 +582,15 @@ Common fixes:
 - On WSL2 with Windows Chrome, run `surf install <extension-id>` from WSL2 and restart Windows Chrome. Use `--target linux` only for a Linux browser running inside WSLg.
 - If `SURF_SOCKET` is set, set the same value for both the browser-launched native host and the shell running `surf`.
 
+macOS checklist:
+- Confirm Chrome has a native messaging manifest at `~/Library/Application Support/Google/Chrome/NativeMessagingHosts/surf.browser.host.json`.
+- Confirm the manifest `allowed_origins` entry uses the same extension ID shown on `chrome://extensions` for the Surf extension.
+- Reinstall the manifest with `surf install <extension-id>` after copying a fresh extension build or if the extension ID changed.
+- Fully restart Chrome, then reload the Surf extension on `chrome://extensions`.
+- Open the extension service worker from `chrome://extensions` and check its console for native messaging or socket errors.
+- If `SURF_SOCKET` is set in your shell, make sure Chrome launches the native host with the same value; otherwise both sides should use `/tmp/surf.sock`.
+- Run a simple CLI command such as `surf tab.list`; if it fails, compare its `Attempted socket:` line with the socket expected by the native host.
+
 ## Socket API
 
 For programmatic integration, send JSON to `/tmp/surf.sock` by default, or to `SURF_SOCKET` when set:

--- a/skills/surf/SKILL.md
+++ b/skills/surf/SKILL.md
@@ -7,11 +7,13 @@ description: Control Chrome browser via CLI for testing, automation, and debuggi
 
 Control Chrome browser via CLI or Unix socket.
 
-## Native Host / WSL2 Notes
+## Native Host / Socket Notes
 
 For WSL2 with Windows Chrome, run `surf install <extension-id>` inside WSL2. Surf detects WSL2 and writes the Windows-side native messaging manifest plus a wrapper that launches the WSL host. Use `surf install <extension-id> --target linux` only for Linux browsers running inside WSLg.
 
-If a command reports `Socket connect failed`, check the `Attempted socket:` line. Default sockets are `/tmp/surf.sock` on macOS/Linux/WSL2 and `//./pipe/surf` on Windows. If `SURF_SOCKET` is set, the browser-launched host and the shell running `surf` must use the same value. Restart Chrome after changing native host installs.
+On macOS, Chrome reads the native messaging manifest at `~/Library/Application Support/Google/Chrome/NativeMessagingHosts/surf.browser.host.json`. If native messaging fails, confirm that file exists, its `allowed_origins` extension ID matches `chrome://extensions`, then rerun `surf install <extension-id>`, restart Chrome, reload the extension, and inspect the extension service-worker console.
+
+If a command reports `Socket connect failed`, check the `Attempted socket:` line. Default sockets are `/tmp/surf.sock` on macOS/Linux/WSL2 and `//./pipe/surf` on Windows. If `SURF_SOCKET` is set, the browser-launched host and the shell running `surf` must use the same value.
 
 ## CLI Quick Reference
 


### PR DESCRIPTION
## Summary
- document macOS Chrome native messaging manifest checks
- add extension ID, service-worker log, and `SURF_SOCKET` troubleshooting guidance
- add the same quick checks to the Surf skill

## Validation
- `npm run lint` (existing warnings only)
- `npm run check`
- `git diff --check`
- fresh read-only staged review: no blockers

Refs #42