### PR TITLE
feat: add animation audit timeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- **Animation audit** - Added `surf animate-audit --selector ... --duration ... --fps ...` for bounded JSON timelines of element rect/style samples.
 - **Concurrency docs** - Documented the current multi-agent isolation contract: window/tab targeting, named tabs, `SURF_SOCKET` for separate browser/profile instances, and the absence of built-in session IDs or a general serialization lock.
 - **LLM context flag** - Added `surf --llm-context` as a compact, deterministic quick reference for AI agents.
 - **CLI/native socket integration coverage** - Added CI-safe integration tests for Surf CLI request framing, fake native-host responses, host errors, and missing-socket diagnostics.

--- a/README.md
+++ b/README.md
@@ -314,6 +314,16 @@ surf emulate.touch --enabled false            # Disable touch
 
 Available devices: iPhone 12-14 (Pro/Max), iPhone SE, iPad (Pro/Mini), Pixel 5-7 (Pro), Galaxy S21-S23, Galaxy Tab S7, Nest Hub (Max).
 
+### Animation Audit
+
+Sample matching elements over time and return a bounded JSON timeline for agent inspection:
+
+```bash
+surf animate-audit --selector ".thing" --duration 2000 --fps 10
+```
+
+The command captures rect, opacity, transform, visibility, display, and a short text snippet for up to 25 matching elements per sample. `--selector` is required. `--duration` defaults to 2000ms and is capped at 10000ms; `--fps` defaults to 10 and is capped at 30. This command returns JSON only and does not record GIF/video output.
+
 ### Performance Tracing
 
 Capture performance metrics and traces:
@@ -388,6 +398,7 @@ surf wait.url "/dashboard"          # Wait for URL pattern
 
 ```bash
 surf js "return document.title"     # Execute JavaScript
+surf animate-audit --selector ".thing" --duration 2000 --fps 10  # JSON animation timeline
 surf search "login"                 # Find text in page
 surf cookie list                    # List cookies
 surf zoom 1.5                       # Set zoom to 150%

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -555,6 +555,18 @@ const TOOLS = {
           { cmd: "snap", desc: "Alias for screenshot" },
         ]
       },
+      "animate-audit": {
+        desc: "Sample matching elements over time and return a JSON animation timeline",
+        args: [],
+        opts: {
+          selector: "CSS selector to sample (required)",
+          duration: "Capture duration in ms (default: 2000, max: 10000)",
+          fps: "Samples per second (default: 10, max: 30)"
+        },
+        examples: [
+          { cmd: 'animate-audit --selector ".thing" --duration 2000 --fps 10', desc: "Capture a bounded JSON timeline" },
+        ]
+      },
       "snap": { desc: "Alias for screenshot (auto-saves to /tmp)", args: [], alias: "screenshot" },
     }
   },
@@ -1466,7 +1478,7 @@ Exclude text content:
 };
 
 const ALL_SOCKET_TOOLS = [
-  "ai", "screenshot", "navigate",
+  "ai", "screenshot", "animate-audit", "navigate",
   "form_input", "find_and_type", "autocomplete", "set_value", "smart_type",
   "scroll_to_position", "get_scroll_info", "close_dialogs", "page_state",
   "javascript_tool", "health", "smoke",
@@ -1524,6 +1536,7 @@ const SEE_ALSO = {
   "perf.metrics": ["perf.start", "console", "network"],
   "navigate": ["wait.load", "page.read"],
   "screenshot": ["page.read", "scroll.bottom for fullpage"],
+  "animate-audit": ["screenshot", "js", "perf.metrics"],
   "search": ["locate.text", "page.read"],
   "wait.element": ["wait.load", "wait.network"],
   "wait.load": ["wait.element", "wait.network"],
@@ -1543,6 +1556,7 @@ Common Commands:
   click <ref>        Click element by ref or selector
   type <text>        Type text at cursor or into element
   screenshot         Capture screenshot (alias: snap)
+  animate-audit      JSON timeline of element animation/style samples
   page.read          Get page accessibility tree (alias: read)
   locate.role <role> Find element by ARIA role
   search <term>      Search for text in page (alias: find)
@@ -1582,6 +1596,7 @@ Click selector/coords: surf click --selector ".btn" | surf click 100 200
 Type: surf type "text" --submit                  # use --ref e5 to target a field
 Screenshot: surf screenshot /tmp/shot.png         # auto-saves to /tmp if no path
 Full page screenshot: surf screenshot --full-page /tmp/full.png
+Animation audit: surf animate-audit --selector ".thing" --duration 2000 --fps 10
 JavaScript: surf js "return document.title"
 Scroll: surf scroll down 800 | surf scroll up 400 | surf scroll bottom | surf scroll top
 Find by semantics: surf locate.role button --name "Submit" --action click

--- a/native/host-helpers.cjs
+++ b/native/host-helpers.cjs
@@ -605,6 +605,20 @@ function mapToolToMessage(tool, args, tabId) {
       };
     case "javascript_tool":
       return { type: "EXECUTE_JAVASCRIPT", code: a.code, ...baseMsg };
+    case "animate-audit": {
+      if (!a.selector || typeof a.selector !== "string") throw new Error("selector required");
+      if (typeof a.duration === "boolean") throw new Error("duration must be a number");
+      if (typeof a.fps === "boolean") throw new Error("fps must be a number");
+      const durationMs = a.duration !== undefined ? Number(a.duration) : 2000;
+      const fps = a.fps !== undefined ? Number(a.fps) : 10;
+      if (!Number.isFinite(durationMs) || durationMs < 100 || durationMs > 10000) {
+        throw new Error("duration must be between 100 and 10000 ms");
+      }
+      if (!Number.isFinite(fps) || fps < 1 || fps > 30) {
+        throw new Error("fps must be between 1 and 30");
+      }
+      return { type: "ANIMATE_AUDIT", selector: a.selector, durationMs, fps, ...baseMsg };
+    }
     case "wait_for_element":
       return { 
         type: "WAIT_FOR_ELEMENT", 

--- a/skills/surf/SKILL.md
+++ b/skills/surf/SKILL.md
@@ -43,6 +43,9 @@ surf type --text "hello"
 
 # 5. Screenshot
 surf screenshot --output /tmp/shot.png
+
+# Inspect animation/style changes as JSON
+surf animate-audit --selector ".thing" --duration 2000 --fps 10
 ```
 
 ## AI Assistants (No API Keys)
@@ -226,6 +229,7 @@ surf drag --from-x 100 --from-y 100 --to-x 200 --to-y 200
 ```bash
 surf page.read                 # Accessibility tree with refs + page text
 surf page.read --no-text       # Interactive elements only (no text content)
+surf animate-audit --selector ".thing" --duration 2000 --fps 10  # JSON animation timeline
 surf page.read --ref e5        # Get specific element details
 surf page.read --depth 3       # Limit tree depth
 surf page.read --compact       # Minimal output for LLM efficiency

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -1953,6 +1953,99 @@ export async function handleMessage(
       }
     }
 
+    case "ANIMATE_AUDIT": {
+      if (!tabId) throw new Error("No tabId provided");
+      if (!message.selector || typeof message.selector !== "string") throw new Error("selector required");
+
+      if (typeof message.durationMs === "boolean") throw new Error("duration must be a number");
+      if (typeof message.fps === "boolean") throw new Error("fps must be a number");
+      const durationMs = message.durationMs !== undefined ? Number(message.durationMs) : 2000;
+      const fps = message.fps !== undefined ? Number(message.fps) : 10;
+      if (!Number.isFinite(durationMs) || durationMs < 100 || durationMs > 10000) {
+        throw new Error("duration must be between 100 and 10000 ms");
+      }
+      if (!Number.isFinite(fps) || fps < 1 || fps > 30) {
+        throw new Error("fps must be between 1 and 30");
+      }
+
+      try {
+        const expression = `(async () => {
+          const selector = ${JSON.stringify(message.selector)};
+          const durationMs = ${Math.round(durationMs)};
+          const fps = ${Math.round(fps)};
+          const intervalMs = Math.max(1, Math.round(1000 / fps));
+          const maxElements = 25;
+          const maxSamples = Math.min(Math.floor(durationMs / intervalMs) + 1, 301);
+          const startedAt = Date.now();
+          const start = performance.now();
+          const samples = [];
+          const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+          const sample = () => {
+            const now = performance.now();
+            const elements = Array.from(document.querySelectorAll(selector)).slice(0, maxElements).map((el, index) => {
+              const rect = el.getBoundingClientRect();
+              const style = getComputedStyle(el);
+              const text = (el.textContent || "").replace(/\\s+/g, " ").trim().slice(0, 120);
+              return {
+                selector,
+                index,
+                rect: {
+                  x: Math.round(rect.x * 100) / 100,
+                  y: Math.round(rect.y * 100) / 100,
+                  width: Math.round(rect.width * 100) / 100,
+                  height: Math.round(rect.height * 100) / 100,
+                  top: Math.round(rect.top * 100) / 100,
+                  right: Math.round(rect.right * 100) / 100,
+                  bottom: Math.round(rect.bottom * 100) / 100,
+                  left: Math.round(rect.left * 100) / 100,
+                },
+                opacity: style.opacity,
+                transform: style.transform,
+                visibility: style.visibility,
+                display: style.display,
+                text,
+              };
+            });
+            samples.push({ t: Math.round((now - start) * 100) / 100, timestamp: Date.now(), elements });
+          };
+
+          for (let i = 0; i < maxSamples; i++) {
+            sample();
+            const elapsed = performance.now() - start;
+            if (elapsed >= durationMs || i === maxSamples - 1) break;
+            await wait(Math.max(0, Math.min(intervalMs, durationMs - elapsed)));
+          }
+
+          return {
+            selector,
+            durationMs,
+            fps,
+            intervalMs,
+            maxElementsPerSample: maxElements,
+            startedAt,
+            endedAt: Date.now(),
+            sampleCount: samples.length,
+            samples,
+          };
+        })()`;
+
+        const result = await cdp.evaluateScript(tabId, expression);
+        if (result.exceptionDetails) {
+          const err = result.exceptionDetails.exception?.description ||
+            result.exceptionDetails.text ||
+            "Animation audit failed";
+          return { error: err };
+        }
+        return result.result?.value ?? { error: "Animation audit returned no data" };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : "Animation audit failed";
+        if (msg.includes("Cannot access") || msg.includes("Cannot attach")) {
+          return { error: "Cannot execute animation audit on this page (restricted URL)" };
+        }
+        return { error: msg };
+      }
+    }
+
     case "READ_CONSOLE_MESSAGES": {
       if (!tabId) throw new Error("No tabId provided");
 

--- a/test/unit/host-helpers.test.ts
+++ b/test/unit/host-helpers.test.ts
@@ -129,6 +129,48 @@ describe("mapToolToMessage", () => {
     });
   });
 
+  describe("animate-audit command", () => {
+    it("maps animate-audit with bounded defaults", () => {
+      const msg = helpers.mapToolToMessage("animate-audit", { selector: ".thing" }, 123);
+      expect(msg).toMatchObject({
+        type: "ANIMATE_AUDIT",
+        selector: ".thing",
+        durationMs: 2000,
+        fps: 10,
+        tabId: 123,
+      });
+    });
+
+    it("parses animate-audit duration and fps", () => {
+      const msg = helpers.mapToolToMessage(
+        "animate-audit",
+        { selector: ".thing", duration: "1500", fps: "12" },
+        123,
+      );
+      expect(msg.durationMs).toBe(1500);
+      expect(msg.fps).toBe(12);
+    });
+
+    it("requires animate-audit selector", () => {
+      expect(() => helpers.mapToolToMessage("animate-audit", {})).toThrow("selector required");
+    });
+
+    it("rejects malformed animate-audit duration and fps", () => {
+      expect(() =>
+        helpers.mapToolToMessage("animate-audit", { selector: ".thing", duration: true }),
+      ).toThrow("duration must be a number");
+      expect(() =>
+        helpers.mapToolToMessage("animate-audit", { selector: ".thing", fps: true }),
+      ).toThrow("fps must be a number");
+      expect(() =>
+        helpers.mapToolToMessage("animate-audit", { selector: ".thing", duration: "10001" }),
+      ).toThrow("duration must be between 100 and 10000 ms");
+      expect(() =>
+        helpers.mapToolToMessage("animate-audit", { selector: ".thing", fps: "31" }),
+      ).toThrow("fps must be between 1 and 30");
+    });
+  });
+
   describe("scroll commands", () => {
     it("maps direction and amount flags to scroll deltas", () => {
       const msg = helpers.mapToolToMessage("scroll", { direction: "down", amount: 4 }, 123);

--- a/test/unit/service-worker/javascript-handlers.test.ts
+++ b/test/unit/service-worker/javascript-handlers.test.ts
@@ -238,3 +238,111 @@ describe("JavaScript command handlers", () => {
     });
   });
 });
+
+describe("Animation audit handler", () => {
+  beforeEach(() => {
+    resetChromeMock();
+  });
+
+  it("runs a bounded in-page sampler and returns the timeline", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    chrome.debugger.sendCommand.mockImplementation(
+      async (_target: any, method: string, params?: any) => {
+        if (method !== "Runtime.evaluate") {
+          return {};
+        }
+        expect(params.returnByValue).toBe(true);
+        expect(params.awaitPromise).toBe(true);
+        expect(params.expression).toContain('const selector = ".thing"');
+        expect(params.expression).toContain("const durationMs = 500");
+        expect(params.expression).toContain("const fps = 5");
+        expect(params.expression).toContain("const maxElements = 25");
+        return {
+          result: {
+            value: {
+              selector: ".thing",
+              durationMs: 500,
+              fps: 5,
+              sampleCount: 1,
+              samples: [
+                {
+                  t: 0,
+                  timestamp: 123,
+                  elements: [
+                    {
+                      selector: ".thing",
+                      index: 0,
+                      rect: { x: 1, y: 2, width: 3, height: 4 },
+                      opacity: "1",
+                      transform: "none",
+                      visibility: "visible",
+                      display: "block",
+                      text: "Hello",
+                    },
+                  ],
+                },
+              ],
+            },
+            type: "object",
+          },
+        };
+      },
+    );
+
+    const result = await handleMessage(
+      { type: "ANIMATE_AUDIT", tabId: 1, selector: ".thing", durationMs: 500, fps: 5 },
+      {},
+    );
+
+    expect(result).toMatchObject({
+      selector: ".thing",
+      durationMs: 500,
+      fps: 5,
+      sampleCount: 1,
+    });
+    expect(result.samples[0].elements[0]).toMatchObject({
+      rect: { x: 1, y: 2, width: 3, height: 4 },
+      opacity: "1",
+      transform: "none",
+      visibility: "visible",
+      display: "block",
+      text: "Hello",
+    });
+  });
+
+  it("validates animate-audit numeric inputs in the service worker", async () => {
+    const handleMessage = await loadHandleMessage();
+
+    await expect(
+      handleMessage({ type: "ANIMATE_AUDIT", tabId: 1, selector: ".thing", durationMs: true }, {}),
+    ).rejects.toThrow("duration must be a number");
+    await expect(
+      handleMessage({ type: "ANIMATE_AUDIT", tabId: 1, selector: ".thing", fps: true }, {}),
+    ).rejects.toThrow("fps must be a number");
+    await expect(
+      handleMessage({ type: "ANIMATE_AUDIT", tabId: 1, selector: ".thing", durationMs: 10001 }, {}),
+    ).rejects.toThrow("duration must be between 100 and 10000 ms");
+    await expect(
+      handleMessage({ type: "ANIMATE_AUDIT", tabId: 1, selector: ".thing", fps: 31 }, {}),
+    ).rejects.toThrow("fps must be between 1 and 30");
+  });
+
+  it("returns runtime evaluation errors", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    chrome.debugger.sendCommand.mockResolvedValue({
+      exceptionDetails: {
+        text: "SyntaxError",
+        exception: { description: "DOMException: invalid selector" },
+      },
+    });
+
+    const result = await handleMessage(
+      { type: "ANIMATE_AUDIT", tabId: 1, selector: "[", durationMs: 500, fps: 5 },
+      {},
+    );
+
+    expect(result).toEqual({ error: "DOMException: invalid selector" });
+  });
+});


### PR DESCRIPTION
## Summary
- add `surf animate-audit --selector ... --duration ... --fps ...`
- return bounded JSON timelines of element rect/style samples
- document JSON-only scope and add unit coverage for host-helper/service-worker validation

## Validation
- `npm test -- test/unit/host-helpers.test.ts test/unit/service-worker/javascript-handlers.test.ts --reporter=dot`
- `npm test -- --reporter=dot`
- `npm run lint` (existing warnings only)
- `npm run check`
- `npm audit --audit-level=critical`
- `git diff --check`
- fresh read-only staged review: fixed blocker and re-review found no blockers

First JSON-only slice for #66; keep #66 open for GIF/video/trigger/performance-audit work.