### PR TITLE
docs: clarify multi-agent isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- **Concurrency docs** - Documented the current multi-agent isolation contract: window/tab targeting, named tabs, `SURF_SOCKET` for separate browser/profile instances, and the absence of built-in session IDs or a general serialization lock.
 - **LLM context flag** - Added `surf --llm-context` as a compact, deterministic quick reference for AI agents.
 - **CLI/native socket integration coverage** - Added CI-safe integration tests for Surf CLI request framing, fake native-host responses, host errors, and missing-socket diagnostics.
 - **Scroll shorthand** - `surf scroll` now accepts positional forms like `scroll down 800`, `scroll up 400`, `scroll bottom`, and `scroll top` while keeping existing flag and dot-command forms.

--- a/README.md
+++ b/README.md
@@ -262,14 +262,18 @@ surf tab.group --name "Work" --color blue
 Keep using your browser while the agent works in a separate window:
 
 ```bash
-# Create isolated window for agent
+# Create a separate window for agent work
 surf window.new "https://example.com"
 # Returns: Window 123456 (tab 789)
 
-# All subsequent commands target that window
+# Target that window or its tab from later commands
 surf click e5 --window-id 123456
-surf read --window-id 123456
+surf read --tab-id 789
 surf tab.new "https://other.com" --window-id 123456
+
+# Name tabs when humans or agents need stable aliases
+surf tab.name dashboard --tab-id 789
+surf tab.switch dashboard
 
 # Or manage windows directly
 surf window.list                    # List all windows
@@ -277,6 +281,17 @@ surf window.list --tabs             # Include tab details
 surf window.focus 123456            # Bring window to front
 surf window.close 123456            # Close window
 ```
+
+`window.new`, `--window-id`, `--tab-id`, and named tabs are Surf's supported coordination tools for parallel workflows today. They help agents avoid accidentally driving the same visible tab, but they are not a general concurrency lock. If two processes target the same tab or window at the same time, commands can still interleave.
+
+For hard isolation, run separate browser instances/profiles with separate Surf native hosts and socket paths, then point each shell at the matching socket:
+
+```bash
+SURF_SOCKET=/tmp/surf-agent-a.sock surf tab.list
+SURF_SOCKET=/tmp/surf-agent-b.sock surf tab.list
+```
+
+Surf does not yet provide `session.new`, session IDs, independent per-agent CDP sessions, or a built-in serialization lock for all browser commands. Use an external lock if multiple agents must share one target safely. Issue #55 remains open for the runtime locking/session design.
 
 ### Device Emulation
 
@@ -561,7 +576,7 @@ SURF_EXTENSION_PATH       # Path to extension dist/ directory
 ```
 
 **Use cases:**
-- `SURF_SOCKET`: Advanced socket override. Set it for both the native host and CLI if you need a non-default socket.
+- `SURF_SOCKET`: Advanced socket override. Set it for both the native host and CLI if you need a non-default socket, including separate sockets for separate browser/profile instances in hard-isolated multi-agent workflows.
 - `SURF_NODE_PATH` / `SURF_HOST_PATH`: Package manager installs (e.g., Nix) that store binaries in non-standard locations
 - `SURF_EXTENSION_PATH`: Package managers that create stable symlinks instead of changing paths on reinstall
 

--- a/skills/surf/SKILL.md
+++ b/skills/surf/SKILL.md
@@ -184,14 +184,20 @@ surf window.resize --id 123 --width 1920 --height 1080
 surf window.resize --id 123 --state maximized # States: normal, minimized, maximized, fullscreen
 ```
 
-**Window isolation for agents:**
+**Multi-agent isolation:**
 ```bash
-# Create isolated window for agent work
+# Create a separate window for one agent and keep using its ID
 surf window.new "https://example.com"
-# Returns window ID, use with subsequent commands:
 surf --window-id 123 tab.list
 surf --window-id 123 go "https://other.com"
+
+# Pin work to a specific tab, or name it for easier handoff
+surf read --tab-id 456
+surf tab.name agent-a --tab-id 456
+surf tab.switch agent-a
 ```
+
+Use `window.new`, `--window-id`, `--tab-id`, and named tabs to keep parallel agents on separate targets. This is coordination, not a lock: two agents targeting the same tab/window can still interleave. For hard isolation, run separate browser/profile instances with separate native hosts and `SURF_SOCKET` values. Surf does not yet have `session.new`, session IDs, independent per-agent CDP sessions, or a general serialization lock.
 
 ## Input Methods
 
@@ -574,9 +580,11 @@ surf wait.element ".missing" --auto-capture --timeout 2000
 9. **AI Studio for unrestricted Gemini** - `surf aistudio` gives less filtered responses than `surf gemini` for the same models
 10. **Use `surf do` for multi-step tasks** - Reduces token overhead and improves reliability
 11. **Dry-run workflows first** - `surf do '...' --dry-run` validates without executing
-12. **Window isolation** - Use `window.new` + `--window-id` to keep agent work separate from your browsing
-13. **Semantic locators** - `locate.role`, `locate.text`, `locate.label` for more robust element finding
-14. **Frame context** - Use `frame.switch` before interacting with iframe content
+12. **Window isolation** - Use `window.new` + `--window-id` or `--tab-id` to keep agent work separate from your browsing
+13. **Hard isolation** - Use separate browser/profile instances plus separate `SURF_SOCKET` values when agents must not share a host or target
+14. **No built-in session lock yet** - Surf does not currently provide `session.new`, session IDs, or a general serialization lock
+15. **Semantic locators** - `locate.role`, `locate.text`, `locate.label` for more robust element finding
+16. **Frame context** - Use `frame.switch` before interacting with iframe content
 
 ## Socket API
 


### PR DESCRIPTION
## Summary
- document supported multi-agent coordination with windows, tabs, named tabs, and explicit IDs
- clarify hard isolation requires separate browser/profile/native-host/socket setups via `SURF_SOCKET`
- note that Surf does not yet provide session IDs, per-agent CDP sessions, or a general serialization lock

## Validation
- `npm run lint` (existing warnings only)
- `npm run check`
- `git diff --check`
- fresh read-only staged review: no blockers

Docs-only clarification for #55; keep #55 open for runtime session/locking design.