### PR TITLE
feat: add per-socket browser request lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## [Unreleased]
 
 ### Added
+- **Browser request lock** - Added per-socket CLI request serialization for multi-agent workflows, with `--no-lock` for intentional bypasses.
 - **Animation audit** - Added `surf animate-audit --selector ... --duration ... --fps ...` for bounded JSON timelines of element rect/style samples.
-- **Concurrency docs** - Documented the current multi-agent isolation contract: window/tab targeting, named tabs, `SURF_SOCKET` for separate browser/profile instances, and the absence of built-in session IDs or a general serialization lock.
+- **Concurrency docs** - Documented the current multi-agent isolation contract: window/tab targeting, named tabs, `SURF_SOCKET` for separate browser/profile instances, and the absence of built-in session IDs or independent per-agent CDP sessions.
 - **LLM context flag** - Added `surf --llm-context` as a compact, deterministic quick reference for AI agents.
 - **CLI/native socket integration coverage** - Added CI-safe integration tests for Surf CLI request framing, fake native-host responses, host errors, and missing-socket diagnostics.
 - **Native host protocol integration coverage** - Added CI-safe tests for `native/host.cjs` native-messaging framing, CLI request forwarding, extension responses, and extension error propagation without real Chrome.

--- a/README.md
+++ b/README.md
@@ -282,16 +282,18 @@ surf window.focus 123456            # Bring window to front
 surf window.close 123456            # Close window
 ```
 
-`window.new`, `--window-id`, `--tab-id`, and named tabs are Surf's supported coordination tools for parallel workflows today. They help agents avoid accidentally driving the same visible tab, but they are not a general concurrency lock. If two processes target the same tab or window at the same time, commands can still interleave.
+`window.new`, `--window-id`, `--tab-id`, and named tabs are Surf's supported coordination tools for parallel workflows. They help agents avoid accidentally driving the same visible tab.
 
-For hard isolation, run separate browser instances/profiles with separate Surf native hosts and socket paths, then point each shell at the matching socket:
+Surf also serializes non-streaming browser CLI requests per socket with a file-based lock, so two agents sharing the same native host wait instead of interleaving browser commands. Use `--no-lock` only when you intentionally want to bypass the guard for a command.
+
+For hard isolation, run separate browser instances/profiles with separate Surf native hosts and socket paths, then point each shell at the matching socket. Each socket has its own independent lock:
 
 ```bash
 SURF_SOCKET=/tmp/surf-agent-a.sock surf tab.list
 SURF_SOCKET=/tmp/surf-agent-b.sock surf tab.list
 ```
 
-Surf does not yet provide `session.new`, session IDs, independent per-agent CDP sessions, or a built-in serialization lock for all browser commands. Use an external lock if multiple agents must share one target safely. Issue #55 remains open for the runtime locking/session design.
+Surf does not yet provide `session.new`, session IDs, or independent per-agent CDP sessions.
 
 ### Device Emulation
 
@@ -571,6 +573,7 @@ surf workflow.validate ./my-workflow.json
 --window-id <id>   # Target specific window (isolate agent from your browsing)
 --json             # Output raw JSON
 --soft-fail        # Warn instead of error (exit 0) on restricted pages
+--no-lock          # Bypass the per-socket browser request lock
 --no-screenshot    # Skip auto-screenshot after actions
 --full             # Full resolution screenshots (skip resize)
 --network-path <path>  # Custom path for network logs (default: /tmp/surf, or SURF_NETWORK_PATH env)
@@ -587,7 +590,7 @@ SURF_EXTENSION_PATH       # Path to extension dist/ directory
 ```
 
 **Use cases:**
-- `SURF_SOCKET`: Advanced socket override. Set it for both the native host and CLI if you need a non-default socket, including separate sockets for separate browser/profile instances in hard-isolated multi-agent workflows.
+- `SURF_SOCKET`: Advanced socket override. Set it for both the native host and CLI if you need a non-default socket, including separate sockets for separate browser/profile instances in hard-isolated multi-agent workflows. Each socket gets an independent request lock.
 - `SURF_NODE_PATH` / `SURF_HOST_PATH`: Package manager installs (e.g., Nix) that store binaries in non-standard locations
 - `SURF_EXTENSION_PATH`: Package managers that create stable symlinks instead of changing paths on reinstall
 

--- a/native/browser-lock.cjs
+++ b/native/browser-lock.cjs
@@ -1,0 +1,169 @@
+const crypto = require("crypto");
+const fs = require("fs");
+const path = require("path");
+
+const DEFAULT_STALE_MS = 30000;
+const DEFAULT_TIMEOUT_MS = 60000;
+const DEFAULT_MIN_WAIT_MS = 50;
+const DEFAULT_MAX_WAIT_MS = 1000;
+
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function getBrowserLockDir(socketPath, tempDir) {
+  const hash = crypto.createHash("sha256").update(socketPath).digest("hex").slice(0, 16);
+  return path.join(tempDir, `surf-lock-${hash}`);
+}
+
+function createToken() {
+  if (typeof crypto.randomUUID === "function") return crypto.randomUUID();
+  return crypto.randomBytes(16).toString("hex");
+}
+
+function readLockOwner(lockDir) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(lockDir, "owner.json"), "utf8"));
+  } catch (error) {
+    if (error && (error.code === "ENOENT" || error instanceof SyntaxError)) return null;
+    throw error;
+  }
+}
+
+function isProcessAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return Boolean(error && error.code === "EPERM");
+  }
+}
+
+function writeLockOwner(lockDir, socketPath, token) {
+  fs.writeFileSync(
+    path.join(lockDir, "owner.json"),
+    JSON.stringify({ pid: process.pid, token, socketPath, createdAt: new Date().toISOString() }),
+  );
+}
+
+function removeLockDir(lockDir) {
+  fs.rmSync(lockDir, { recursive: true, force: true });
+}
+
+function getLockTimestamp(lockDir, owner) {
+  const target = owner ? path.join(lockDir, "owner.json") : lockDir;
+  try {
+    return fs.statSync(target).mtimeMs;
+  } catch (error) {
+    if (error && error.code === "ENOENT") return 0;
+    throw error;
+  }
+}
+
+function ownerMatches(left, right) {
+  if (!left && !right) return true;
+  return Boolean(left && right && left.token && left.token === right.token);
+}
+
+function tryCreateStaleClaim(lockDir, staleMs, now = Date.now()) {
+  const claimDir = path.join(lockDir, "stale-claim");
+  try {
+    fs.mkdirSync(claimDir);
+    return claimDir;
+  } catch (error) {
+    if (!error || error.code !== "EEXIST") throw error;
+    try {
+      if (now - fs.statSync(claimDir).mtimeMs > staleMs) {
+        fs.rmSync(claimDir, { recursive: true, force: true });
+      }
+    } catch (claimError) {
+      if (!claimError || claimError.code !== "ENOENT") throw claimError;
+    }
+    return null;
+  }
+}
+
+function claimAndRemoveStaleLock(lockDir, staleMs, now = Date.now()) {
+  let lockStats;
+  try {
+    lockStats = fs.statSync(lockDir);
+  } catch (error) {
+    if (error && error.code === "ENOENT") return false;
+    throw error;
+  }
+
+  const inspectedOwner = readLockOwner(lockDir);
+  if (inspectedOwner && isProcessAlive(inspectedOwner.pid)) return false;
+  if (now - getLockTimestamp(lockDir, inspectedOwner) <= staleMs) return false;
+
+  const claimDir = tryCreateStaleClaim(lockDir, staleMs, now);
+  if (!claimDir) return false;
+
+  try {
+    const currentOwner = readLockOwner(lockDir);
+    if (!ownerMatches(inspectedOwner, currentOwner)) return false;
+    if (currentOwner && isProcessAlive(currentOwner.pid)) return false;
+    if (!currentOwner && Date.now() - lockStats.mtimeMs <= staleMs) return false;
+
+    removeLockDir(lockDir);
+    return true;
+  } finally {
+    try {
+      fs.rmSync(claimDir, { recursive: true, force: true });
+    } catch {}
+  }
+}
+
+function acquireBrowserLock(socketPath, tempDir, options = {}) {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const staleMs = options.staleMs ?? DEFAULT_STALE_MS;
+  const sleep = options.sleep ?? sleepSync;
+  const lockDir = getBrowserLockDir(socketPath, tempDir);
+  const startedAt = Date.now();
+  let waitMs = options.minWaitMs ?? DEFAULT_MIN_WAIT_MS;
+  const maxWaitMs = options.maxWaitMs ?? DEFAULT_MAX_WAIT_MS;
+
+  while (true) {
+    const token = createToken();
+    try {
+      fs.mkdirSync(lockDir, { recursive: false, mode: 0o700 });
+      try {
+        writeLockOwner(lockDir, socketPath, token);
+      } catch (error) {
+        removeLockDir(lockDir);
+        throw error;
+      }
+      let released = false;
+      return {
+        lockDir,
+        release() {
+          if (released) return;
+          released = true;
+          const owner = readLockOwner(lockDir);
+          if (owner && owner.token === token) removeLockDir(lockDir);
+        },
+      };
+    } catch (error) {
+      if (!error || error.code !== "EEXIST") throw error;
+    }
+
+    if (claimAndRemoveStaleLock(lockDir, staleMs)) continue;
+
+    if (Date.now() - startedAt >= timeoutMs) {
+      throw new Error(
+        `Timed out waiting for browser lock after ${Math.round(timeoutMs / 1000)}s. Use --no-lock to bypass.`,
+      );
+    }
+
+    sleep(waitMs);
+    waitMs = Math.min(Math.round(waitMs * 1.5), maxWaitMs);
+  }
+}
+
+module.exports = {
+  DEFAULT_STALE_MS,
+  DEFAULT_TIMEOUT_MS,
+  acquireBrowserLock,
+  getBrowserLockDir,
+};

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -13,7 +13,50 @@ const { version: VERSION } = require("../package.json");
 
 const IS_WIN = process.platform === "win32";
 const { SOCKET_PATH, SURF_TMP, formatSocketError } = require("./socket-path.cjs");
+const { acquireBrowserLock } = require("./browser-lock.cjs");
 if (IS_WIN) { try { fs.mkdirSync(SURF_TMP, { recursive: true }); } catch {} }
+
+function parseBrowserLockOptions(noLockFlag) {
+  const noLock = noLockFlag || process.env.SURF_NO_LOCK === "1" || process.env.SURF_NO_LOCK === "true";
+  let timeoutMs;
+  if (process.env.SURF_LOCK_TIMEOUT_MS !== undefined) {
+    timeoutMs = Number(process.env.SURF_LOCK_TIMEOUT_MS);
+    if (!Number.isFinite(timeoutMs) || timeoutMs < 0) {
+      console.error("Error: SURF_LOCK_TIMEOUT_MS must be a non-negative number");
+      process.exit(1);
+    }
+  }
+  return { noLock, timeoutMs };
+}
+
+function installBrowserLock({ noLock, timeoutMs }) {
+  let releaseBrowserLock = () => {};
+  if (!noLock) {
+    try {
+      const lock = acquireBrowserLock(SOCKET_PATH, SURF_TMP, { timeoutMs });
+      releaseBrowserLock = lock.release;
+    } catch (error) {
+      console.error("Error:", error && error.message ? error.message : String(error));
+      process.exit(1);
+    }
+  }
+
+  const release = () => {
+    const releaseCurrent = releaseBrowserLock;
+    releaseBrowserLock = () => {};
+    releaseCurrent();
+  };
+
+  process.once("exit", release);
+  process.once("SIGINT", () => {
+    release();
+    process.exit(130);
+  });
+  process.once("SIGTERM", () => {
+    release();
+    process.exit(143);
+  });
+}
 
 // ============================================================================
 // Workflow Resolution and Management
@@ -1603,6 +1646,7 @@ Find by semantics: surf locate.role button --name "Submit" --action click
 Device/viewport: surf emulate.device "iPhone 14" | surf resize 375 812
 Cookies: surf cookie list | surf cookie get "name" | surf cookie delete "name"
 Window isolation: surf window.new "https://example.com" then pass --window-id <id>
+Concurrency: surf serializes commands per socket; use --no-lock only for intentional bypass
 Workflow: surf do 'go "https://example.com" | wait 2 | read | click e5 | screenshot'
 More help: surf --help-full | surf <command> --help | surf --help-topic refs | surf --find <query>`);
 };
@@ -1631,6 +1675,7 @@ Options:
   --json            Output raw JSON
   --auto-capture    On error: capture screenshot + console to /tmp
   --soft-fail       On error: warn and exit 0 (for non-critical commands)
+  --no-lock         Bypass the per-socket browser request lock
 
 Script Mode:
   surf --script <file>     Run workflow from JSON
@@ -2123,6 +2168,10 @@ if (args.includes("--script")) {
     process.exit(failed > 0 ? 1 : 0);
   };
 
+  if (!dryRun) {
+    installBrowserLock(parseBrowserLockOptions(args.includes("--no-lock")));
+  }
+
   runScript();
   return;
 }
@@ -2142,7 +2191,7 @@ if (args[0] === "do") {
   let windowId = undefined;
 
   // Reserved flags that aren't workflow args
-  const reservedFlags = ['file', 'f', 'dry-run', 'on-error', 'no-auto-wait', 'step-delay', 'json', 'tab-id', 'window-id'];
+  const reservedFlags = ['file', 'f', 'dry-run', 'on-error', 'no-auto-wait', 'step-delay', 'json', 'tab-id', 'window-id', 'no-lock'];
 
   // Workflow-specific args (collected for variable substitution)
   const workflowArgs = {};
@@ -2325,6 +2374,8 @@ if (args[0] === "do") {
     process.exit(0);
   }
 
+  installBrowserLock(parseBrowserLockOptions(doArgs.includes("--no-lock")));
+
   if (!wantJson) {
     if (workflowName) {
       console.log(`Running workflow: ${workflowName} (${steps.length} steps)...\n`);
@@ -2491,7 +2542,7 @@ if (args[0] === "workflow.validate") {
   }
 }
 
-const BOOLEAN_FLAGS = ["auto-capture", "json", "stream", "dry-run", "stop-on-error", "fail-fast", "clear", "submit", "all", "case-sensitive", "hard", "annotate", "fullpage", "full-page", "reset", "no-screenshot", "full", "soft-fail", "has-body", "exclude-static", "v", "vv", "request", "by-tab", "har", "jsonl", "no-save", "no-auto-wait"];
+const BOOLEAN_FLAGS = ["auto-capture", "json", "stream", "dry-run", "stop-on-error", "fail-fast", "clear", "submit", "all", "case-sensitive", "hard", "annotate", "fullpage", "full-page", "reset", "no-screenshot", "full", "soft-fail", "has-body", "exclude-static", "v", "vv", "request", "by-tab", "har", "jsonl", "no-save", "no-auto-wait", "no-lock"];
 
 const AUTO_SCREENSHOT_TOOLS = ["click", "type", "key", "smart_type", "form.fill", "form_input", "drag", "hover", "scroll", "scroll.top", "scroll.bottom", "scroll.to", "dialog.accept", "dialog.dismiss", "js", "eval"];
 
@@ -2778,6 +2829,9 @@ delete toolArgs["no-screenshot"];
 const softFail = toolArgs["soft-fail"] === true;
 delete toolArgs["soft-fail"];
 
+const lockOptions = parseBrowserLockOptions(toolArgs["no-lock"] === true);
+delete toolArgs["no-lock"];
+
 if (!noScreenshot && AUTO_SCREENSHOT_TOOLS.includes(tool)) {
   toolArgs.autoScreenshot = true;
 }
@@ -3030,6 +3084,8 @@ const performAutoCapture = async () => {
     console.error(`Auto-capture failed: ${captureErr.message}`);
   }
 };
+
+installBrowserLock(lockOptions);
 
 const socket = net.createConnection(SOCKET_PATH, () => {
   socket.write(JSON.stringify(request) + "\n");

--- a/skills/surf/SKILL.md
+++ b/skills/surf/SKILL.md
@@ -202,7 +202,7 @@ surf tab.name agent-a --tab-id 456
 surf tab.switch agent-a
 ```
 
-Use `window.new`, `--window-id`, `--tab-id`, and named tabs to keep parallel agents on separate targets. This is coordination, not a lock: two agents targeting the same tab/window can still interleave. For hard isolation, run separate browser/profile instances with separate native hosts and `SURF_SOCKET` values. Surf does not yet have `session.new`, session IDs, independent per-agent CDP sessions, or a general serialization lock.
+Use `window.new`, `--window-id`, `--tab-id`, and named tabs to keep parallel agents on separate targets. Surf serializes non-streaming browser CLI requests per socket with a file-based lock, so agents sharing one native host wait instead of interleaving commands. Use `--no-lock` only for intentional bypasses. For hard isolation, run separate browser/profile instances with separate native hosts and `SURF_SOCKET` values; each socket gets its own lock. Surf does not yet have `session.new`, session IDs, or independent per-agent CDP sessions.
 
 ## Input Methods
 
@@ -587,8 +587,8 @@ surf wait.element ".missing" --auto-capture --timeout 2000
 10. **Use `surf do` for multi-step tasks** - Reduces token overhead and improves reliability
 11. **Dry-run workflows first** - `surf do '...' --dry-run` validates without executing
 12. **Window isolation** - Use `window.new` + `--window-id` or `--tab-id` to keep agent work separate from your browsing
-13. **Hard isolation** - Use separate browser/profile instances plus separate `SURF_SOCKET` values when agents must not share a host or target
-14. **No built-in session lock yet** - Surf does not currently provide `session.new`, session IDs, or a general serialization lock
+13. **Request lock** - Non-streaming browser CLI requests serialize per socket; use `--no-lock` only when you intentionally want to bypass it
+14. **Hard isolation** - Use separate browser/profile instances plus separate `SURF_SOCKET` values when agents must not share a host or target
 15. **Semantic locators** - `locate.role`, `locate.text`, `locate.label` for more robust element finding
 16. **Frame context** - Use `frame.switch` before interacting with iframe content
 

--- a/test/unit/browser-lock.test.ts
+++ b/test/unit/browser-lock.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+declare const require: (moduleName: string) => any;
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { acquireBrowserLock, getBrowserLockDir } = require("../../native/browser-lock.cjs");
+
+describe("browser lock", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "surf-browser-lock-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("creates and releases a per-socket lock", () => {
+    const lock = acquireBrowserLock("/tmp/surf.sock", tempDir);
+    const lockDir = getBrowserLockDir("/tmp/surf.sock", tempDir);
+
+    expect(lock.lockDir).toBe(lockDir);
+    expect(fs.existsSync(path.join(lockDir, "owner.json"))).toBe(true);
+
+    lock.release();
+
+    expect(fs.existsSync(lockDir)).toBe(false);
+  });
+
+  it("uses independent lock directories for different sockets", () => {
+    const first = acquireBrowserLock("/tmp/surf-agent-a.sock", tempDir);
+    const second = acquireBrowserLock("/tmp/surf-agent-b.sock", tempDir);
+
+    expect(first.lockDir).not.toBe(second.lockDir);
+
+    first.release();
+    second.release();
+  });
+
+  it("removes stale locks owned by dead processes before acquiring", () => {
+    const lockDir = getBrowserLockDir("/tmp/surf.sock", tempDir);
+    fs.mkdirSync(lockDir);
+    fs.writeFileSync(
+      path.join(lockDir, "owner.json"),
+      JSON.stringify({ pid: -1, token: "dead-owner", socketPath: "/tmp/surf.sock" }),
+    );
+    const staleTime = new Date(Date.now() - 60_000);
+    fs.utimesSync(lockDir, staleTime, staleTime);
+
+    const lock = acquireBrowserLock("/tmp/surf.sock", tempDir, { staleMs: 1 });
+
+    expect(lock.lockDir).toBe(lockDir);
+    expect(JSON.parse(fs.readFileSync(path.join(lockDir, "owner.json"), "utf8")).pid).toBe(
+      process.pid,
+    );
+
+    lock.release();
+  });
+
+  it("does not steal an old lock from a live process", () => {
+    const lockDir = getBrowserLockDir("/tmp/surf.sock", tempDir);
+    fs.mkdirSync(lockDir);
+    fs.writeFileSync(
+      path.join(lockDir, "owner.json"),
+      JSON.stringify({ pid: process.pid, token: "live-owner", socketPath: "/tmp/surf.sock" }),
+    );
+    const staleTime = new Date(Date.now() - 60_000);
+    fs.utimesSync(lockDir, staleTime, staleTime);
+
+    expect(() =>
+      acquireBrowserLock("/tmp/surf.sock", tempDir, {
+        timeoutMs: -1,
+        staleMs: 1,
+        sleep: () => undefined,
+      }),
+    ).toThrow("Timed out waiting for browser lock");
+    expect(fs.existsSync(path.join(lockDir, "owner.json"))).toBe(true);
+  });
+
+  it("does not release a replacement lock owned by another process", () => {
+    const first = acquireBrowserLock("/tmp/surf.sock", tempDir);
+    const lockDir = first.lockDir;
+    fs.rmSync(lockDir, { recursive: true, force: true });
+    fs.mkdirSync(lockDir);
+    fs.writeFileSync(
+      path.join(lockDir, "owner.json"),
+      JSON.stringify({ pid: process.pid, token: "replacement", socketPath: "/tmp/surf.sock" }),
+    );
+
+    first.release();
+
+    expect(fs.existsSync(path.join(lockDir, "owner.json"))).toBe(true);
+  });
+
+  it("times out while a fresh lock is held", () => {
+    const held = acquireBrowserLock("/tmp/surf.sock", tempDir);
+
+    expect(() =>
+      acquireBrowserLock("/tmp/surf.sock", tempDir, {
+        timeoutMs: -1,
+        staleMs: 60_000,
+        sleep: () => undefined,
+      }),
+    ).toThrow("Timed out waiting for browser lock");
+
+    held.release();
+  });
+});

--- a/test/unit/cli-args.test.ts
+++ b/test/unit/cli-args.test.ts
@@ -13,12 +13,15 @@ const net = require("node:net");
 const os = require("node:os");
 const path = require("node:path");
 
+let socketCounter = 0;
+
 function createSocketPath() {
+  socketCounter++;
   if (process.platform === "win32") {
-    return `\\\\.\\pipe\\surf-test-${process.pid}-${Date.now()}-${Math.random()}`;
+    return `\\\\.\\pipe\\surf-test-${process.pid}-${socketCounter}`;
   }
 
-  return path.join(os.tmpdir(), `surf-test-${process.pid}-${Date.now()}-${Math.random()}.sock`);
+  return path.join(os.tmpdir(), `surf-${process.pid}-${socketCounter}.sock`);
 }
 
 function cleanupSocket(socketPath: string) {
@@ -33,6 +36,21 @@ function cleanupSocket(socketPath: string) {
   }
 }
 
+function createCliEnv(socketPath?: string) {
+  const env = { ...process.env };
+  env.SURF_NO_LOCK = undefined;
+  env.SURF_LOCK_TIMEOUT_MS = undefined;
+
+  if (socketPath) {
+    env.SURF_SOCKET = socketPath;
+  } else {
+    env.SURF_SOCKET = undefined;
+    env.SURF_SOCKET_PATH = undefined;
+  }
+
+  return env;
+}
+
 function runCliWithoutSocket(
   args: string[],
 ): Promise<{ code: number | null; stdout: string; stderr: string }> {
@@ -42,7 +60,7 @@ function runCliWithoutSocket(
 
     const child = spawn(process.execPath, ["native/cli.cjs", ...args], {
       cwd: process.cwd(),
-      env: { ...process.env, SURF_SOCKET: undefined, SURF_SOCKET_PATH: undefined },
+      env: createCliEnv(),
       stdio: ["ignore", "pipe", "pipe"],
     });
 
@@ -89,7 +107,7 @@ function runCli(args: string[]): Promise<{ request: any; stdout: string; stderr:
     server.listen(socketPath, () => {
       const child = spawn(process.execPath, ["native/cli.cjs", ...args], {
         cwd: process.cwd(),
-        env: { ...process.env, SURF_SOCKET: socketPath },
+        env: createCliEnv(socketPath),
         stdio: ["ignore", "pipe", "pipe"],
       });
 
@@ -117,6 +135,41 @@ function runCli(args: string[]): Promise<{ request: any; stdout: string; stderr:
       });
     });
   });
+}
+
+function spawnCliWithSocket(args: string[], socketPath: string) {
+  let stdout = "";
+  let stderr = "";
+  const child = spawn(process.execPath, ["native/cli.cjs", ...args], {
+    cwd: process.cwd(),
+    env: createCliEnv(socketPath),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  child.stdout.on("data", (chunk: { toString(): string }) => {
+    stdout += chunk.toString();
+  });
+  child.stderr.on("data", (chunk: { toString(): string }) => {
+    stderr += chunk.toString();
+  });
+
+  return {
+    done: new Promise<{ code: number | null; stdout: string; stderr: string }>(
+      (resolve, reject) => {
+        child.on("error", reject);
+        child.on("close", (code: number | null) => resolve({ code, stdout, stderr }));
+      },
+    ),
+  };
+}
+
+function waitFor<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error(`Timed out waiting for ${label}`)), ms),
+    ),
+  ]);
 }
 
 describe("CLI argument parsing", () => {
@@ -177,5 +230,209 @@ describe("CLI argument parsing", () => {
 
     expect(request.params.tool).toBe("chatgpt");
     expect(request.params.args.file).toBe(path.resolve("fixtures/report.txt"));
+  });
+
+  it("serializes concurrent CLI requests by socket", async () => {
+    const socketPath = createSocketPath();
+    cleanupSocket(socketPath);
+    let requestCount = 0;
+    let firstRequestAt = 0;
+    let secondRequestAt = 0;
+    let resolveFirstRequest!: () => void;
+    const firstRequest = new Promise<void>((resolve) => {
+      resolveFirstRequest = resolve;
+    });
+
+    const server = net.createServer((socket: any) => {
+      let buffer = "";
+      socket.on("data", (chunk: { toString(): string }) => {
+        buffer += chunk.toString();
+        const lineEnd = buffer.indexOf("\n");
+        if (lineEnd === -1) {
+          return;
+        }
+
+        requestCount++;
+        if (requestCount === 1) {
+          firstRequestAt = Date.now();
+          resolveFirstRequest();
+          setTimeout(() => {
+            socket.write(
+              `${JSON.stringify({ result: { content: [{ type: "text", text: "first" }] } })}\n`,
+            );
+            socket.end();
+          }, 250);
+          return;
+        }
+
+        secondRequestAt = Date.now();
+        socket.write(
+          `${JSON.stringify({ result: { content: [{ type: "text", text: "second" }] } })}\n`,
+        );
+        socket.end();
+      });
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.on("error", reject);
+      server.listen(socketPath, resolve);
+    });
+
+    try {
+      const first = spawnCliWithSocket(["page.text"], socketPath);
+      await waitFor(firstRequest, 1000, "first request");
+      const second = spawnCliWithSocket(["page.state"], socketPath);
+      const [firstDone, secondDone] = await Promise.all([first.done, second.done]);
+
+      expect(firstDone.code).toBe(0);
+      expect(secondDone.code).toBe(0);
+      expect(requestCount).toBe(2);
+      expect(secondRequestAt - firstRequestAt).toBeGreaterThanOrEqual(200);
+    } finally {
+      server.close();
+      cleanupSocket(socketPath);
+    }
+  });
+
+  for (const workflowCase of [
+    {
+      name: "--script",
+      args: () => {
+        const scriptPath = path.join(os.tmpdir(), `surf-script-${process.pid}-${Date.now()}.json`);
+        fs.writeFileSync(scriptPath, JSON.stringify({ steps: [{ tool: "page.state" }] }));
+        return { args: ["--script", scriptPath], cleanup: () => fs.unlinkSync(scriptPath) };
+      },
+    },
+    {
+      name: "surf do",
+      args: () => ({ args: ["do", "page.state"], cleanup: () => undefined }),
+    },
+  ]) {
+    it(`serializes ${workflowCase.name} requests by socket`, async () => {
+      const socketPath = createSocketPath();
+      cleanupSocket(socketPath);
+      const workflow = workflowCase.args();
+      let requestCount = 0;
+      let firstRequestAt = 0;
+      let secondRequestAt = 0;
+      let resolveFirstRequest!: () => void;
+      const firstRequest = new Promise<void>((resolve) => {
+        resolveFirstRequest = resolve;
+      });
+
+      const server = net.createServer((socket: any) => {
+        let buffer = "";
+        socket.on("data", (chunk: { toString(): string }) => {
+          buffer += chunk.toString();
+          const lineEnd = buffer.indexOf("\n");
+          if (lineEnd === -1) {
+            return;
+          }
+
+          requestCount++;
+          if (requestCount === 1) {
+            firstRequestAt = Date.now();
+            resolveFirstRequest();
+            setTimeout(() => {
+              socket.write(
+                `${JSON.stringify({ result: { content: [{ type: "text", text: "first" }] } })}\n`,
+              );
+              socket.end();
+            }, 250);
+            return;
+          }
+
+          secondRequestAt = Date.now();
+          socket.write(
+            `${JSON.stringify({ result: { content: [{ type: "text", text: "second" }] } })}\n`,
+          );
+          socket.end();
+        });
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        server.on("error", reject);
+        server.listen(socketPath, resolve);
+      });
+
+      try {
+        const first = spawnCliWithSocket(["page.text"], socketPath);
+        await waitFor(firstRequest, 1000, "first request");
+        const second = spawnCliWithSocket(workflow.args, socketPath);
+        const [firstDone, secondDone] = await Promise.all([first.done, second.done]);
+
+        expect(firstDone.code).toBe(0);
+        expect(secondDone.code).toBe(0);
+        expect(requestCount).toBe(2);
+        expect(secondRequestAt - firstRequestAt).toBeGreaterThanOrEqual(200);
+      } finally {
+        server.close();
+        cleanupSocket(socketPath);
+        workflow.cleanup();
+      }
+    });
+  }
+
+  it("allows --no-lock to bypass a held browser lock", async () => {
+    const socketPath = createSocketPath();
+    cleanupSocket(socketPath);
+    let requestCount = 0;
+    let resolveFirstRequest!: () => void;
+    let resolveSecondRequest!: () => void;
+    const firstRequest = new Promise<void>((resolve) => {
+      resolveFirstRequest = resolve;
+    });
+    const secondRequest = new Promise<void>((resolve) => {
+      resolveSecondRequest = resolve;
+    });
+
+    const server = net.createServer((socket: any) => {
+      let buffer = "";
+      socket.on("data", (chunk: { toString(): string }) => {
+        buffer += chunk.toString();
+        const lineEnd = buffer.indexOf("\n");
+        if (lineEnd === -1) {
+          return;
+        }
+
+        requestCount++;
+        if (requestCount === 1) {
+          resolveFirstRequest();
+          setTimeout(() => {
+            socket.write(
+              `${JSON.stringify({ result: { content: [{ type: "text", text: "first" }] } })}\n`,
+            );
+            socket.end();
+          }, 300);
+          return;
+        }
+
+        resolveSecondRequest();
+        socket.write(
+          `${JSON.stringify({ result: { content: [{ type: "text", text: "second" }] } })}\n`,
+        );
+        socket.end();
+      });
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.on("error", reject);
+      server.listen(socketPath, resolve);
+    });
+
+    try {
+      const first = spawnCliWithSocket(["page.text"], socketPath);
+      await waitFor(firstRequest, 1000, "first request");
+      const second = spawnCliWithSocket(["page.state", "--no-lock"], socketPath);
+      await waitFor(secondRequest, 200, "second no-lock request");
+      const [firstDone, secondDone] = await Promise.all([first.done, second.done]);
+
+      expect(firstDone.code).toBe(0);
+      expect(secondDone.code).toBe(0);
+      expect(requestCount).toBe(2);
+    } finally {
+      server.close();
+      cleanupSocket(socketPath);
+    }
   });
 });


### PR DESCRIPTION
Closes #55

Adds a file-based per-socket lock so concurrent agents sharing one native host serialize instead of interleaving browser commands. Owner tokens prevent cross-owner release. PID liveness checks prevent stealing locks from active long-running commands. Stale-claim directory provides atomic dead-owner recovery. --no-lock bypasses when needed. Stream mode is intentionally not locked.