### PR TITLE
feat: add performance audit command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- **Performance audit** - Added `surf perf-audit --duration ... --trigger ... --output ...` for bounded PerformanceObserver snapshots of layout shifts, events, long tasks, paints, and long animation frames.
 - **Animation recording** - Added `surf record --duration ... --fps ... --output ...` to capture screenshot bursts and assemble animated GIFs with ImageMagick.
 - **Browser request lock** - Added per-socket CLI request serialization for multi-agent workflows, with `--no-lock` for intentional bypasses.
 - **Animation audit** - Added `surf animate-audit --selector ... --duration ... --fps ...` for bounded JSON timelines of element rect/style samples.

--- a/README.md
+++ b/README.md
@@ -338,6 +338,17 @@ surf animate-audit --selector ".thing" --duration 2000 --fps 10
 
 The command captures rect, opacity, transform, visibility, display, and a short text snippet for up to 25 matching elements per sample. `--selector` is required. `--duration` defaults to 2000ms and is capped at 10000ms; `--fps` defaults to 10 and is capped at 30. This command returns JSON only and does not record GIF/video output.
 
+### Performance Audit
+
+Capture layout shift, long animation frame, event timing, long task, and paint entries during a short window:
+
+```bash
+surf perf-audit --duration 3000 --trigger "click:.cta" --output /tmp/perf.json
+surf perf-audit --duration 1000 --json
+```
+
+`perf-audit` defaults to 3000ms and is capped at 10000ms. `--trigger` supports the same `click:<selector>` and `scroll:<target>` forms as `record`. `--output` writes the JSON snapshot to disk.
+
 ### Performance Tracing
 
 Capture performance metrics and traces:
@@ -414,6 +425,7 @@ surf wait.url "/dashboard"          # Wait for URL pattern
 surf js "return document.title"     # Execute JavaScript
 surf record --duration 2000 --fps 10 --output /tmp/anim.gif      # Animated GIF capture
 surf animate-audit --selector ".thing" --duration 2000 --fps 10  # JSON animation timeline
+surf perf-audit --duration 3000 --output /tmp/perf.json           # PerformanceObserver snapshot
 surf search "login"                 # Find text in page
 surf cookie list                    # List cookies
 surf zoom 1.5                       # Set zoom to 150%

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -625,6 +625,18 @@ const TOOLS = {
           { cmd: 'animate-audit --selector ".thing" --duration 2000 --fps 10', desc: "Capture a bounded JSON timeline" },
         ]
       },
+      "perf-audit": {
+        desc: "Capture layout shift, event, long task, and animation-frame performance entries",
+        args: [],
+        opts: {
+          duration: "Capture duration in ms (default: 3000, max: 10000)",
+          trigger: "Optional action before capture: click:<selector> or scroll:<target>",
+          output: "Save JSON to file"
+        },
+        examples: [
+          { cmd: 'perf-audit --duration 3000 --trigger "click:.cta" --output /tmp/perf.json', desc: "Capture a performance snapshot" },
+        ]
+      },
       "snap": { desc: "Alias for screenshot (auto-saves to /tmp)", args: [], alias: "screenshot" },
     }
   },
@@ -1536,7 +1548,7 @@ Exclude text content:
 };
 
 const ALL_SOCKET_TOOLS = [
-  "ai", "screenshot", "record", "animate-audit", "navigate",
+  "ai", "screenshot", "record", "animate-audit", "perf-audit", "navigate",
   "form_input", "find_and_type", "autocomplete", "set_value", "smart_type",
   "scroll_to_position", "get_scroll_info", "close_dialogs", "page_state",
   "javascript_tool", "health", "smoke",
@@ -1594,8 +1606,9 @@ const SEE_ALSO = {
   "perf.metrics": ["perf.start", "console", "network"],
   "navigate": ["wait.load", "page.read"],
   "screenshot": ["page.read", "scroll.bottom for fullpage"],
-  "record": ["screenshot", "animate-audit", "perf.metrics"],
-  "animate-audit": ["screenshot", "record", "js", "perf.metrics"],
+  "record": ["screenshot", "animate-audit", "perf-audit"],
+  "animate-audit": ["screenshot", "record", "perf-audit", "js"],
+  "perf-audit": ["record", "animate-audit", "perf.metrics", "console"],
   "search": ["locate.text", "page.read"],
   "wait.element": ["wait.load", "wait.network"],
   "wait.load": ["wait.element", "wait.network"],
@@ -1617,6 +1630,7 @@ Common Commands:
   screenshot         Capture screenshot (alias: snap)
   record             Capture screenshot frames into an animated GIF
   animate-audit      JSON timeline of element animation/style samples
+  perf-audit         PerformanceObserver snapshot for motion/jank debugging
   page.read          Get page accessibility tree (alias: read)
   locate.role <role> Find element by ARIA role
   search <term>      Search for text in page (alias: find)
@@ -1658,6 +1672,7 @@ Screenshot: surf screenshot /tmp/shot.png         # auto-saves to /tmp if no pat
 Full page screenshot: surf screenshot --full-page /tmp/full.png
 Record animation: surf record --duration 2000 --fps 10 --output /tmp/anim.gif
 Animation audit: surf animate-audit --selector ".thing" --duration 2000 --fps 10
+Performance audit: surf perf-audit --duration 3000 --trigger "click:.cta" --output /tmp/perf.json
 JavaScript: surf js "return document.title"
 Scroll: surf scroll down 800 | surf scroll up 400 | surf scroll bottom | surf scroll top
 Find by semantics: surf locate.role button --name "Submit" --action click
@@ -2884,7 +2899,7 @@ if (tool === "chatgpt" && toolArgs.file) {
   }
 }
 
-if ((tool === "screenshot" || tool === "record") && outputPath && typeof outputPath !== "string") {
+if ((tool === "screenshot" || tool === "record" || tool === "perf-audit") && outputPath && typeof outputPath !== "string") {
   console.error("Error: --output requires a file path");
   process.exit(1);
 }
@@ -3336,6 +3351,17 @@ async function handleResponse(response) {
 
   if (tool === 'aistudio' && typeof data === 'string') {
     data = { response: data };
+  }
+
+  if (tool === "perf-audit" && outputPath) {
+    const saveTo = path.resolve(outputPath);
+    fs.mkdirSync(path.dirname(saveTo), { recursive: true });
+    fs.writeFileSync(saveTo, JSON.stringify(data ?? null, null, 2));
+    if (!wantJson) {
+      console.log(`Saved perf audit to ${saveTo}`);
+      socket.end();
+      process.exit(0);
+    }
   }
 
   if (wantJson) {

--- a/native/host-helpers.cjs
+++ b/native/host-helpers.cjs
@@ -619,6 +619,17 @@ function mapToolToMessage(tool, args, tabId) {
       }
       return { type: "ANIMATE_AUDIT", selector: a.selector, durationMs, fps, ...baseMsg };
     }
+    case "perf-audit": {
+      if (typeof a.duration === "boolean") throw new Error("duration must be a number");
+      if (a.trigger !== undefined && typeof a.trigger !== "string") {
+        throw new Error("trigger must be action:target");
+      }
+      const durationMs = a.duration !== undefined ? Number(a.duration) : 3000;
+      if (!Number.isFinite(durationMs) || durationMs < 100 || durationMs > 10000) {
+        throw new Error("duration must be between 100 and 10000 ms");
+      }
+      return { type: "PERF_AUDIT", durationMs, trigger: a.trigger, ...baseMsg };
+    }
     case "wait_for_element":
       return { 
         type: "WAIT_FOR_ELEMENT", 

--- a/skills/surf/SKILL.md
+++ b/skills/surf/SKILL.md
@@ -588,7 +588,7 @@ surf wait.element ".missing" --auto-capture --timeout 2000
 11. **Dry-run workflows first** - `surf do '...' --dry-run` validates without executing
 12. **Window isolation** - Use `window.new` + `--window-id` or `--tab-id` to keep agent work separate from your browsing
 13. **Request lock** - Non-streaming browser CLI requests serialize per socket; use `--no-lock` only when you intentionally want to bypass it
-14. **Animation capture** - Use `surf record --duration 2000 --fps 10 --output /tmp/anim.gif` when the agent needs to see motion; use `animate-audit` for numeric timelines
+14. **Animation capture** - Use `surf record --duration 2000 --fps 10 --output /tmp/anim.gif` when the agent needs to see motion; use `animate-audit` for numeric timelines and `perf-audit` for jank/layout-shift snapshots
 15. **Hard isolation** - Use separate browser/profile instances plus separate `SURF_SOCKET` values when agents must not share a host or target
 16. **Semantic locators** - `locate.role`, `locate.text`, `locate.label` for more robust element finding
 17. **Frame context** - Use `frame.switch` before interacting with iframe content

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -2046,6 +2046,218 @@ export async function handleMessage(
       }
     }
 
+    case "PERF_AUDIT": {
+      if (!tabId) throw new Error("No tabId provided");
+      if (typeof message.durationMs === "boolean") throw new Error("duration must be a number");
+      if (message.trigger !== undefined && typeof message.trigger !== "string") {
+        throw new Error("trigger must be action:target");
+      }
+      const durationMs = message.durationMs !== undefined ? Number(message.durationMs) : 3000;
+      if (!Number.isFinite(durationMs) || durationMs < 100 || durationMs > 10000) {
+        throw new Error("duration must be between 100 and 10000 ms");
+      }
+
+      try {
+        const expression = `(async () => {
+          const durationMs = ${Math.round(durationMs)};
+          const trigger = ${JSON.stringify(message.trigger || null)};
+          const startedAt = Date.now();
+          const startedAtPerformance = performance.now();
+          const supportedEntryTypes = typeof PerformanceObserver !== "undefined" && Array.isArray(PerformanceObserver.supportedEntryTypes) ? PerformanceObserver.supportedEntryTypes : [];
+          const requestedTypes = ["layout-shift", "long-animation-frame", "event", "longtask", "paint"];
+          const observedEntryTypes = [];
+          const entries = {
+            layoutShifts: [],
+            longAnimationFrames: [],
+            events: [],
+            longTasks: [],
+            paints: [],
+          };
+          const round = (value) => Math.round(value * 100) / 100;
+          const auditEndsAtPerformance = startedAtPerformance + durationMs;
+          const inAuditWindow = (entry) => entry.startTime >= startedAtPerformance && entry.startTime <= auditEndsAtPerformance;
+          const nodeSummary = (node) => {
+            if (!node || node.nodeType !== Node.ELEMENT_NODE) return null;
+            const el = node;
+            return {
+              tag: el.tagName?.toLowerCase(),
+              id: el.id || undefined,
+              className: typeof el.className === "string" ? el.className.slice(0, 120) : undefined,
+            };
+          };
+          const rectSummary = (rect) => rect ? {
+            x: round(rect.x),
+            y: round(rect.y),
+            width: round(rect.width),
+            height: round(rect.height),
+            top: round(rect.top),
+            right: round(rect.right),
+            bottom: round(rect.bottom),
+            left: round(rect.left),
+          } : null;
+          const pushEntry = (entry) => {
+            if (!inAuditWindow(entry)) return;
+            if (entry.entryType === "layout-shift") {
+              entries.layoutShifts.push({
+                name: entry.name,
+                startTime: round(entry.startTime),
+                duration: round(entry.duration || 0),
+                value: round(entry.value || 0),
+                hadRecentInput: Boolean(entry.hadRecentInput),
+                sources: Array.from(entry.sources || []).slice(0, 10).map((source) => ({
+                  node: nodeSummary(source.node),
+                  previousRect: rectSummary(source.previousRect),
+                  currentRect: rectSummary(source.currentRect),
+                })),
+              });
+              return;
+            }
+            if (entry.entryType === "long-animation-frame") {
+              entries.longAnimationFrames.push({
+                name: entry.name,
+                startTime: round(entry.startTime),
+                duration: round(entry.duration || 0),
+                renderStart: round(entry.renderStart || 0),
+                styleAndLayoutStart: round(entry.styleAndLayoutStart || 0),
+                blockingDuration: round(entry.blockingDuration || 0),
+                firstUIEventTimestamp: round(entry.firstUIEventTimestamp || 0),
+                scripts: Array.from(entry.scripts || []).slice(0, 10).map((script) => ({
+                  name: script.name,
+                  sourceURL: script.sourceURL,
+                  sourceFunctionName: script.sourceFunctionName,
+                  duration: round(script.duration || 0),
+                  invoker: script.invoker,
+                  invokerType: script.invokerType,
+                })),
+              });
+              return;
+            }
+            if (entry.entryType === "event") {
+              entries.events.push({
+                name: entry.name,
+                startTime: round(entry.startTime),
+                duration: round(entry.duration || 0),
+                processingStart: round(entry.processingStart || 0),
+                processingEnd: round(entry.processingEnd || 0),
+                interactionId: entry.interactionId || 0,
+                cancelable: Boolean(entry.cancelable),
+              });
+              return;
+            }
+            if (entry.entryType === "longtask") {
+              entries.longTasks.push({
+                name: entry.name,
+                startTime: round(entry.startTime),
+                duration: round(entry.duration || 0),
+              });
+              return;
+            }
+            if (entry.entryType === "paint") {
+              entries.paints.push({
+                name: entry.name,
+                startTime: round(entry.startTime),
+                duration: round(entry.duration || 0),
+              });
+            }
+          };
+          const observers = [];
+          for (const type of requestedTypes) {
+            if (!supportedEntryTypes.includes(type)) continue;
+            try {
+              const observer = new PerformanceObserver((list) => {
+                for (const entry of list.getEntries()) pushEntry(entry);
+              });
+              const options = type === "event"
+                ? { type, buffered: true, durationThreshold: 16 }
+                : { type, buffered: true };
+              observer.observe(options);
+              observers.push(observer);
+              observedEntryTypes.push(type);
+            } catch {}
+          }
+          const fireTrigger = () => {
+            if (!trigger) return null;
+            const separator = trigger.indexOf(":");
+            if (separator === -1) throw new Error("trigger must be action:target");
+            const action = trigger.slice(0, separator).trim();
+            const target = trigger.slice(separator + 1).trim();
+            if (!action || !target) throw new Error("trigger must be action:target");
+            if (action === "click") {
+              const el = document.querySelector(target);
+              if (!el) return { action, selector: target, fired: false };
+              el.click();
+              return { action, selector: target, fired: true };
+            }
+            if (action === "scroll") {
+              if (["up", "down", "left", "right"].includes(target)) {
+                const deltas = { up: [0, -500], down: [0, 500], left: [-500, 0], right: [500, 0] };
+                const [left, top] = deltas[target];
+                window.scrollBy({ left, top, behavior: "instant" });
+                return { action, target, fired: true };
+              }
+              if (target === "top" || target === "bottom") {
+                window.scrollTo({ top: target === "top" ? 0 : document.documentElement.scrollHeight, behavior: "instant" });
+                return { action, target, fired: true };
+              }
+              const el = document.querySelector(target);
+              if (!el) return { action, selector: target, fired: false };
+              el.scrollTop = el.scrollHeight;
+              el.dispatchEvent(new Event("scroll", { bubbles: true }));
+              return { action, selector: target, fired: true };
+            }
+            throw new Error("trigger action must be click or scroll");
+          };
+          const triggerResult = fireTrigger();
+          await new Promise((resolve) => setTimeout(resolve, durationMs));
+          for (const observer of observers) observer.disconnect();
+          const cls = entries.layoutShifts
+            .filter((entry) => !entry.hadRecentInput)
+            .reduce((sum, entry) => sum + entry.value, 0);
+          const maxDuration = (items) => items.reduce((max, entry) => Math.max(max, entry.duration || 0), 0);
+          const longTaskTotalDuration = entries.longTasks.reduce((sum, entry) => sum + (entry.duration || 0), 0);
+
+          return {
+            durationMs,
+            startedAt,
+            endedAt: Date.now(),
+            elapsedMs: round(performance.now() - startedAtPerformance),
+            supportedEntryTypes,
+            observedEntryTypes,
+            trigger: triggerResult,
+            summary: {
+              cumulativeLayoutShift: round(cls),
+              maxEventDuration: round(maxDuration(entries.events)),
+              maxLongAnimationFrame: round(maxDuration(entries.longAnimationFrames)),
+              longTaskTotalDuration: round(longTaskTotalDuration),
+              counts: {
+                layoutShifts: entries.layoutShifts.length,
+                longAnimationFrames: entries.longAnimationFrames.length,
+                events: entries.events.length,
+                longTasks: entries.longTasks.length,
+                paints: entries.paints.length,
+              },
+            },
+            entries,
+          };
+        })()`;
+
+        const result = await cdp.evaluateScript(tabId, expression);
+        if (result.exceptionDetails) {
+          const err = result.exceptionDetails.exception?.description ||
+            result.exceptionDetails.text ||
+            "Performance audit failed";
+          return { error: err };
+        }
+        return result.result?.value ?? { error: "Performance audit returned no data" };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : "Performance audit failed";
+        if (msg.includes("Cannot access") || msg.includes("Cannot attach")) {
+          return { error: "Cannot execute performance audit on this page (restricted URL)" };
+        }
+        return { error: msg };
+      }
+    }
+
     case "READ_CONSOLE_MESSAGES": {
       if (!tabId) throw new Error("No tabId provided");
 

--- a/test/unit/cli-args.test.ts
+++ b/test/unit/cli-args.test.ts
@@ -187,6 +187,9 @@ describe("CLI argument parsing", () => {
     expect(stdout).toContain("surf click e5");
     expect(stdout).toContain("surf screenshot --full-page /tmp/full.png");
     expect(stdout).toContain("surf record --duration 2000 --fps 10 --output /tmp/anim.gif");
+    expect(stdout).toContain(
+      'surf perf-audit --duration 3000 --trigger "click:.cta" --output /tmp/perf.json',
+    );
     expect(stdout).toContain("surf scroll down 800");
     expect(stdout).toContain("surf cookie list");
     expect(stdout).toContain("surf resize 375 812");
@@ -451,6 +454,72 @@ describe("CLI argument parsing", () => {
       server.close();
       cleanupSocket(socketPath);
       fs.rmSync(magickDir, { recursive: true, force: true });
+      fs.rmSync(outputPath, { force: true });
+    }
+  });
+
+  it("saves perf-audit JSON output", async () => {
+    const socketPath = createSocketPath();
+    cleanupSocket(socketPath);
+    const outputPath = path.join(os.tmpdir(), `surf-perf-${process.pid}-${Date.now()}.json`);
+    let request: any;
+
+    const server = net.createServer((socket: any) => {
+      let buffer = "";
+      socket.on("data", (chunk: { toString(): string }) => {
+        buffer += chunk.toString();
+        const lineEnd = buffer.indexOf("\n");
+        if (lineEnd === -1) {
+          return;
+        }
+
+        request = JSON.parse(buffer.slice(0, lineEnd));
+        socket.write(
+          `${JSON.stringify({
+            result: {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify({
+                    durationMs: 300,
+                    summary: { cumulativeLayoutShift: 0.1 },
+                    entries: { layoutShifts: [] },
+                  }),
+                },
+              ],
+            },
+          })}\n`,
+        );
+        socket.end();
+      });
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.on("error", reject);
+      server.listen(socketPath, resolve);
+    });
+
+    try {
+      const child = spawnCliWithSocket(
+        ["perf-audit", "--duration", "300", "--trigger", "click:.cta", "--output", outputPath],
+        socketPath,
+      );
+      const done = await waitFor(child.done, 3000, "perf-audit command");
+
+      expect(done.code).toBe(0);
+      expect(done.stderr).toBe("");
+      expect(done.stdout).toContain(`Saved perf audit to ${outputPath}`);
+      expect(request.params).toMatchObject({
+        tool: "perf-audit",
+        args: { duration: 300, trigger: "click:.cta" },
+      });
+      expect(JSON.parse(fs.readFileSync(outputPath, "utf8"))).toMatchObject({
+        durationMs: 300,
+        summary: { cumulativeLayoutShift: 0.1 },
+      });
+    } finally {
+      server.close();
+      cleanupSocket(socketPath);
       fs.rmSync(outputPath, { force: true });
     }
   });

--- a/test/unit/host-helpers.test.ts
+++ b/test/unit/host-helpers.test.ts
@@ -171,6 +171,43 @@ describe("mapToolToMessage", () => {
     });
   });
 
+  describe("perf-audit command", () => {
+    it("maps perf-audit with bounded defaults", () => {
+      const msg = helpers.mapToolToMessage("perf-audit", {}, 123);
+      expect(msg).toMatchObject({
+        type: "PERF_AUDIT",
+        durationMs: 3000,
+        tabId: 123,
+      });
+    });
+
+    it("parses perf-audit duration and trigger", () => {
+      const msg = helpers.mapToolToMessage(
+        "perf-audit",
+        { duration: "1500", trigger: "click:.cta" },
+        123,
+      );
+      expect(msg).toMatchObject({
+        type: "PERF_AUDIT",
+        durationMs: 1500,
+        trigger: "click:.cta",
+        tabId: 123,
+      });
+    });
+
+    it("rejects malformed perf-audit options", () => {
+      expect(() => helpers.mapToolToMessage("perf-audit", { duration: true })).toThrow(
+        "duration must be a number",
+      );
+      expect(() => helpers.mapToolToMessage("perf-audit", { duration: "10001" })).toThrow(
+        "duration must be between 100 and 10000 ms",
+      );
+      expect(() => helpers.mapToolToMessage("perf-audit", { trigger: true })).toThrow(
+        "trigger must be action:target",
+      );
+    });
+  });
+
   describe("scroll commands", () => {
     it("maps direction and amount flags to scroll deltas", () => {
       const msg = helpers.mapToolToMessage("scroll", { direction: "down", amount: 4 }, 123);

--- a/test/unit/service-worker/javascript-handlers.test.ts
+++ b/test/unit/service-worker/javascript-handlers.test.ts
@@ -328,6 +328,129 @@ describe("Animation audit handler", () => {
     ).rejects.toThrow("fps must be between 1 and 30");
   });
 
+  it("captures perf-audit snapshots", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    chrome.debugger.sendCommand.mockResolvedValue({
+      result: {
+        value: {
+          durationMs: 500,
+          observedEntryTypes: ["layout-shift", "event"],
+          trigger: { action: "click", selector: ".cta", fired: true },
+          summary: {
+            cumulativeLayoutShift: 0.12,
+            maxEventDuration: 40,
+            counts: { layoutShifts: 1, events: 1 },
+          },
+          entries: {
+            layoutShifts: [{ value: 0.12, hadRecentInput: false }],
+            events: [{ name: "click", duration: 40 }],
+          },
+        },
+        type: "object",
+      },
+    });
+
+    const result = await handleMessage(
+      { type: "PERF_AUDIT", tabId: 1, durationMs: 500, trigger: "click:.cta" },
+      {},
+    );
+
+    expect(result).toMatchObject({
+      durationMs: 500,
+      observedEntryTypes: ["layout-shift", "event"],
+      trigger: { action: "click", selector: ".cta", fired: true },
+      summary: { cumulativeLayoutShift: 0.12, maxEventDuration: 40 },
+    });
+  });
+
+  it("filters buffered perf-audit entries outside the audit window", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    const originalPerformanceObserver = (globalThis as any).PerformanceObserver;
+
+    class FakePerformanceObserver {
+      static supportedEntryTypes = ["layout-shift"];
+      callback: (list: { getEntries(): any[] }) => void;
+
+      constructor(callback: (list: { getEntries(): any[] }) => void) {
+        this.callback = callback;
+      }
+
+      observe() {
+        const now = performance.now();
+        this.callback({
+          getEntries: () => [
+            {
+              entryType: "layout-shift",
+              name: "",
+              startTime: now - 1000,
+              duration: 0,
+              value: 1,
+              hadRecentInput: false,
+              sources: [],
+            },
+            {
+              entryType: "layout-shift",
+              name: "",
+              startTime: now + 1,
+              duration: 0,
+              value: 0.2,
+              hadRecentInput: false,
+              sources: [],
+            },
+          ],
+        });
+      }
+
+      disconnect() {
+        return undefined;
+      }
+    }
+
+    (globalThis as any).PerformanceObserver = FakePerformanceObserver;
+    mockRuntimeEvaluate(chrome);
+
+    try {
+      const result = await handleMessage({ type: "PERF_AUDIT", tabId: 1, durationMs: 100 }, {});
+
+      expect(result.summary.cumulativeLayoutShift).toBe(0.2);
+      expect(result.summary.counts.layoutShifts).toBe(1);
+      expect(result.entries.layoutShifts).toHaveLength(1);
+    } finally {
+      (globalThis as any).PerformanceObserver = originalPerformanceObserver;
+    }
+  });
+
+  it("validates perf-audit numeric and trigger inputs in the service worker", async () => {
+    const handleMessage = await loadHandleMessage();
+
+    await expect(
+      handleMessage({ type: "PERF_AUDIT", tabId: 1, durationMs: true }, {}),
+    ).rejects.toThrow("duration must be a number");
+    await expect(
+      handleMessage({ type: "PERF_AUDIT", tabId: 1, durationMs: 10001 }, {}),
+    ).rejects.toThrow("duration must be between 100 and 10000 ms");
+    await expect(
+      handleMessage({ type: "PERF_AUDIT", tabId: 1, trigger: true }, {}),
+    ).rejects.toThrow("trigger must be action:target");
+  });
+
+  it("returns perf-audit runtime evaluation errors", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    chrome.debugger.sendCommand.mockResolvedValue({
+      exceptionDetails: {
+        text: "PerformanceObserver failed",
+        exception: { description: "Error: PerformanceObserver failed" },
+      },
+    });
+
+    const result = await handleMessage({ type: "PERF_AUDIT", tabId: 1, durationMs: 500 }, {});
+
+    expect(result).toEqual({ error: "Error: PerformanceObserver failed" });
+  });
+
   it("returns runtime evaluation errors", async () => {
     const handleMessage = await loadHandleMessage();
     const chrome = (globalThis as any).chrome;


### PR DESCRIPTION
Closes #66

Adds `surf perf-audit` for bounded PerformanceObserver snapshots covering layout shifts, long animation frames, event timing, long tasks, and paint entries. Supports `--duration`, `--trigger`, `--output`, and `--json`.

This completes the remaining #66 animation tooling scope after `animate-audit` and `record` landed in prior PRs.