### PR TITLE
fix: point socket errors at doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - **Cookie subcommands** - Added space-separated cookie commands (`surf cookie list`, `get`, `set`, `clear --all`, and `delete`) while keeping existing `cookie.*` commands working.
 
 ### Fixed
+- **Socket failure guidance** - Socket connection errors now point users to `surf doctor --browser all` for detailed native-host diagnostics.
 - **ChatGPT file upload** - `surf chatgpt --file <path>` now uploads the file through the ChatGPT composer before sending the prompt, with provider-specific upload errors.
 - **Gemini upload menu selector** - Accept Gemini's current `Upload & tools` opener while preserving the legacy upload menu selector.
 - **Screenshot full-page alias** - Treat `surf screenshot --full-page` the same as `--fullpage`, including explicit output paths.

--- a/native/socket-path.cjs
+++ b/native/socket-path.cjs
@@ -10,6 +10,7 @@ function getSocketTroubleshootingHint() {
   const lines = [
     `Attempted socket: ${SOCKET_PATH}`,
     "Make sure the browser is running with the Surf extension enabled, then restart the browser after native host install changes.",
+    "Run `surf doctor --browser all` for detailed native host diagnostics.",
   ];
 
   if (process.env.SURF_SOCKET) {

--- a/test/integration/cli-native-socket.test.ts
+++ b/test/integration/cli-native-socket.test.ts
@@ -292,6 +292,9 @@ describe("CLI native socket integration", () => {
     expect(result.stderr).toContain("Socket connect failed: Socket not found.");
     expect(result.stderr).toContain("Attempted socket:");
     expect(result.stderr).toContain(
+      "Run `surf doctor --browser all` for detailed native host diagnostics.",
+    );
+    expect(result.stderr).toContain(
       "SURF_SOCKET is set; make sure the native host and CLI use the same value.",
     );
     expect(result.stderr).not.toContain("/tmp/surf.sock");


### PR DESCRIPTION
Adds a direct `surf doctor --browser all` breadcrumb to socket connection failures so users who hit the #42 error get pointed at the diagnostics command from the failure path itself.

Validation:
- `npm ci`
- `npm test -- --reporter=dot`
- `npm run lint` (passes with 4 existing unrelated warnings)
- `npm run check`
- `npm audit --audit-level=critical`
- `git diff --check`

Refs #42
