### PR TITLE
Fix provider extraction and command edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 - **Deep X Research skill** - Added `skills/deep-x-research/`, an agent skill that layers an exhaustive X (Twitter) research procedure on top of `surf grok`: a quota-budgeted multi-angle Grok sweep (keyword + semantic, with DeepSearch), Grok-native video analysis, quota-free URL verification via direct post opens, categorized findings, and a References section where every cited post carries its full post URL. Falls back to the x.com search UI when the Grok quota is exhausted.
+- **Tab movement** - Added `surf tab.move <id> --to-window <id>` with multi-tab and insertion-index support. (@zm2231, #148)
+- **Page text byte limit** - Added `page.read --max-bytes <n>` for UTF-8-safe visible-text truncation without changing the existing default limit. (@zm2231, #148)
+
+### Fixed
+- **Provider response extraction** - Fixed truncated Perplexity answers, trailing Grok suggestion chips, and incomplete Gemini stream/image extraction; refreshed Gemini's selectable web models and unknown-model fallback guidance. (@zm2231, #148)
+- **Browser command edge cases** - Fixed `tab.name` on restricted active pages, `zoom --level` argument loss, and selector-targeted `type --into`; selector typing now follows the active iframe context. (@zm2231, #148)
 
 ### Docs
 - **Skills README** - Documented the two-skill layout (`surf/` reference, `deep-x-research/` procedure) with install steps for Pi, Claude Code, and Codex, and pointed the surf skill's Grok section at `deep-x-research` for exhaustive research tasks.

--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ surf gemini "analyze" --file data.csv                         # Attach file
 surf gemini "a robot surfing" --generate-image /tmp/robot.png # Generate image
 surf gemini "add sunglasses" --edit-image photo.jpg --output out.jpg
 surf gemini "summarize" --youtube "https://youtube.com/..."   # YouTube analysis
-surf gemini "hello" --model gemini-2.5-flash                  # Model selection
+surf gemini "hello" --model gemini-3.5-flash                  # Model selection
 
 # Perplexity
 surf perplexity "what is quantum computing"

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ surf read --no-text                 # Accessibility tree only (no text)
 surf read --depth 3                 # Limit tree depth (smaller output)
 surf read --compact                 # Remove empty structural elements
 surf read --depth 3 --compact       # Both (60% smaller output)
+surf read --max-bytes 2000          # Cap visible text on a UTF-8 byte boundary
 surf page.text                      # Raw text content only
 surf page.state                     # Modals, loading state, scroll position
 ```
@@ -184,6 +185,7 @@ surf frame.switch --selector "#checkout-frame"  # Switch by CSS selector
 # Now all commands target the iframe
 surf read                           # Read iframe content
 surf click e5                       # Click in iframe
+surf type "4242" --into "#card-number"
 surf locate.role button --action click
 
 surf frame.main                     # Return to main page
@@ -195,8 +197,9 @@ surf frame.main                     # Return to main page
 surf click e5                       # Click by element ref
 surf click --selector ".btn"        # Click by CSS selector
 surf click 100 200                  # Click by coordinates
-surf type "hello" --submit          # Type and press Enter
-surf type "email@example.com" --ref e12  # Type into specific element
+surf type "hello" --submit          # Type at the current focus with CDP events
+surf type "email@example.com" --ref e12  # Fill an element from page.read
+surf type "hello" --into "#message"     # Fill a selector in the active frame
 surf key Escape                     # Press key
 surf scroll down 800                # Scroll down 800px
 surf scroll bottom                  # Scroll to bottom
@@ -252,6 +255,7 @@ surf tab.list
 surf tab.new "https://example.com"
 surf tab.switch 123
 surf tab.close 123
+surf tab.move 123 --to-window 456   # Move one tab; use --ids 123,124 for several
 surf tab.name "dashboard"           # Name current tab
 surf tab.switch "dashboard"         # Switch by name
 surf tab.group --name "Work" --color blue

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -2946,7 +2946,9 @@ const streamMode = toolArgs.stream === true;
 delete toolArgs.stream;
 
 const streamLevel = toolArgs.level;
-delete toolArgs.level;
+if (tool === "console" || tool === "network") {
+  delete toolArgs.level;
+}
 
 const streamFilter = toolArgs.filter;
 delete toolArgs.filter;

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -830,7 +830,7 @@ const TOOLS = {
           ref: "Element ref (uses JS DOM method, more reliable for modals)",
           submit: "Press enter after",
           clear: "Clear first",
-          method: "cdp|js (default: cdp, but ref uses JS automatically)"
+          method: "cdp|js (cursor typing uses CDP; selector/ref targets use JS)"
         },
         examples: [
           { cmd: 'type "hello world"', desc: "Type at cursor (CDP events)" },
@@ -2964,11 +2964,15 @@ delete toolArgs.filter;
 let finalTool = tool;
 if (methodFlag === "js") {
   if (tool === "type") {
-    if (!toolArgs.selector) {
-      console.error("Error: --selector or --into required for type with --method js");
-      process.exit(1);
+    if (toolArgs.ref) {
+      finalTool = "type";
+    } else {
+      if (!toolArgs.selector) {
+        console.error("Error: --selector, --into, or --ref required for type with --method js");
+        process.exit(1);
+      }
+      finalTool = "smart_type";
     }
-    finalTool = "smart_type";
   } else if (tool === "click") {
     if (!toolArgs.selector) {
       console.error("Error: --selector required for click with --method js");
@@ -2979,8 +2983,13 @@ if (methodFlag === "js") {
     finalTool = "js";
   }
 } else if (methodFlag === "cdp") {
+  if (tool === "type" && (toolArgs.selector || toolArgs.ref)) {
+    console.error("Error: --method cdp types at the current focus and cannot be combined with --into, --selector, or --ref");
+    process.exit(1);
+  }
   if (tool === "smart_type") {
-    finalTool = "type";
+    console.error("Error: smart_type uses the JS input path and cannot be combined with --method cdp");
+    process.exit(1);
   }
 }
 

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -681,6 +681,7 @@ const TOOLS = {
           "no-text": "Exclude visible text content",
           depth: "Maximum tree depth (default: unlimited)",
           compact: "Remove empty structural elements",
+          "max-bytes": "Maximum visible text bytes",
         },
         examples: [
           { cmd: "page.read", desc: "Interactive elements + text content" },
@@ -688,7 +689,7 @@ const TOOLS = {
           { cmd: "page.read --no-text", desc: "Interactive elements only (no text)" },
           { cmd: "page.read --depth 3", desc: "Limit to 3 levels deep" },
           { cmd: "page.read --compact", desc: "Skip empty containers" },
-          { cmd: "page.read --depth 3 --compact", desc: "Shallow + compact (60% smaller)" },
+          { cmd: "page.read --depth 3 --compact --max-bytes 2000", desc: "Shallow + compact output" },
           { cmd: "read", desc: "Alias" },
         ]
       },

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -405,7 +405,7 @@ const TOOLS = {
         args: ["query"],
         opts: {
           "with-page": "Include current page context",
-          model: "Model: gemini-3-pro (default), gemini-2.5-pro, gemini-2.5-flash",
+          model: "Model: gemini-3.1-pro (default), gemini-3.5-flash, gemini-3.1-flash-lite",
           file: "Attach file to analyze",
           "generate-image": "Generate image and save to path",
           "edit-image": "Edit existing image (use with --output)",
@@ -2907,6 +2907,14 @@ if (tool === "gemini") {
   }
   if (toolArgs.file && typeof toolArgs.file === "string") {
     toolArgs.file = path.resolve(toolArgs.file);
+  }
+  if (toolArgs.model) {
+    const known = ["gemini-3.1-pro", "gemini-3.5-flash", "gemini-3.1-flash-lite"];
+    if (!known.includes(toolArgs.model)) {
+      process.stderr.write(
+        `warning: unknown Gemini model "${toolArgs.model}"; using "gemini-3.1-pro". Available: ${known.join(", ")}\n`,
+      );
+    }
   }
 }
 if (tool === "chatgpt" && toolArgs.file) {

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -528,6 +528,12 @@ const TOOLS = {
         opts: { ids: "Close multiple tabs" },
         examples: [{ cmd: "tab.close 123", desc: "Close tab" }]
       },
+      "tab.move": {
+        desc: "Move tab to another window",
+        args: ["id"],
+        opts: { ids: "Move multiple tabs", "to-window": "Destination window ID", index: "Destination index" },
+        examples: [{ cmd: "tab.move 123 --to-window 456", desc: "Move tab to window" }]
+      },
       "tab.name": {
         desc: "Register current tab with a name",
         args: ["name"],
@@ -1567,7 +1573,7 @@ const ALL_SOCKET_TOOLS = [
   "computer",
   "page.read", "page.text", "page.state",
   "locate.role", "locate.text", "locate.label",
-  "tab.list", "tab.new", "tab.switch", "tab.close", "tab.name", "tab.unname", "tab.named",
+  "tab.list", "tab.new", "tab.switch", "tab.close", "tab.move", "tab.name", "tab.unname", "tab.named",
   "tab.group", "tab.ungroup", "tab.groups", "tab.reload",
   "scroll.top", "scroll.bottom", "scroll.to", "scroll.info",
   "wait.element", "wait.network", "wait.url", "wait.dom", "wait.load",
@@ -2732,6 +2738,7 @@ const PRIMARY_ARG_MAP = {
   "tab.switch": "id",
   close_tab: "tab_id",
   "tab.close": "id",
+  "tab.move": "id",
   "tab.name": "name",
   "tab.unname": "name",
   scroll_to_position: "position",

--- a/native/gemini-client.cjs
+++ b/native/gemini-client.cjs
@@ -22,9 +22,9 @@ const USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
 
 const MODEL_HEADER_NAME = "x-goog-ext-525001261-jspb";
 const MODEL_HEADERS = {
-  "gemini-3-pro": '[1,null,null,null,"9d8ca3786ebdfbea",null,null,0,[4]]',
-  "gemini-2.5-pro": '[1,null,null,null,"4af6c7f5da75d65d",null,null,0,[4]]',
-  "gemini-2.5-flash": '[1,null,null,null,"9ec249fc9ad08861",null,null,0,[4]]',
+  "gemini-3.1-pro": '[1,null,null,null,"e6fa609c3fa255c0",null,null,0,[4]]',
+  "gemini-3.5-flash": '[1,null,null,null,"56fdd199312815e2",null,null,0,[4]]',
+  "gemini-3.1-flash-lite": '[1,null,null,null,"8c46e95b1a07cecc",null,null,0,[4]]',
 };
 
 const REQUIRED_COOKIES = ["__Secure-1PSID", "__Secure-1PSIDTS"];
@@ -543,7 +543,7 @@ async function runGeminiWebOnce(input) {
     "referer": "https://gemini.google.com/",
     "x-same-domain": "1",
     "cookie": cookieHeader,
-    [MODEL_HEADER_NAME]: MODEL_HEADERS[model] || MODEL_HEADERS["gemini-3-pro"],
+    [MODEL_HEADER_NAME]: MODEL_HEADERS[model] || MODEL_HEADERS["gemini-3.1-pro"],
   }, params.toString(), { timeoutMs, log, label: "geminiStreamGenerate" });
 
   const rawResponseText = res.text;
@@ -594,9 +594,9 @@ async function runGeminiWebWithFallback(input) {
   const attempt = await runGeminiWebOnce(input);
   
   // Auto-fallback to flash if model unavailable
-  if (isModelUnavailable(attempt.errorCode) && input.model !== "gemini-2.5-flash") {
-    const fallback = await runGeminiWebOnce({ ...input, model: "gemini-2.5-flash" });
-    return { ...fallback, effectiveModel: "gemini-2.5-flash" };
+  if (isModelUnavailable(attempt.errorCode) && input.model !== "gemini-3.5-flash") {
+    const fallback = await runGeminiWebOnce({ ...input, model: "gemini-3.5-flash" });
+    return { ...fallback, effectiveModel: "gemini-3.5-flash" };
   }
   
   return { ...attempt, effectiveModel: input.model };
@@ -846,7 +846,13 @@ async function query(options) {
   log(`Got ${Object.keys(cookieMap).length} Gemini cookies`);
 
   // 2. Resolve model
-  const resolvedModel = MODEL_HEADERS[model] ? model : "gemini-3-pro";
+  let resolvedModel;
+  if (MODEL_HEADERS[model]) {
+    resolvedModel = model;
+  } else {
+    resolvedModel = "gemini-3.1-pro";
+    log(`Unknown Gemini model "${model}"; using "${resolvedModel}"`);
+  }
 
   // 3. Build prompt
   let fullPrompt = prompt || "";

--- a/native/gemini-client.cjs
+++ b/native/gemini-client.cjs
@@ -292,14 +292,49 @@ function ensureFullSizeImageUrl(url) {
   return `${url}=s2048`;
 }
 
+function getFirstStringAtPaths(value, paths) {
+  for (const pathParts of paths) {
+    const found = getNestedValue(value, pathParts, "");
+    if (typeof found === "string" && found.trim()) return found;
+  }
+  return "";
+}
+
+const GEMINI_TEXT_PATHS = [
+  [1, 0],
+  [1, 0, 0],
+  [1, 0, 1],
+  [1, 1, 0],
+  [2, 0],
+  [22, 0],
+];
+
+const GEMINI_CARD_CONTENT_RE = /^http:\/\/googleusercontent\.com\/card_content\/\d+/;
+const GEMINI_CARD_ALT_PATHS = [[22, 0], [1, 1, 0], [2, 0]];
+
+function resolveCandidateText(candidate) {
+  const textRaw = getFirstStringAtPaths(candidate, GEMINI_TEXT_PATHS);
+  if (GEMINI_CARD_CONTENT_RE.test(textRaw)) {
+    return getFirstStringAtPaths(candidate, GEMINI_CARD_ALT_PATHS) || textRaw;
+  }
+  return textRaw;
+}
+
+// An unresolved card_content placeholder URL is not answer text; score it zero.
+function candidateTextScore(candidate) {
+  const resolved = resolveCandidateText(candidate);
+  return GEMINI_CARD_CONTENT_RE.test(resolved) ? 0 : resolved.length;
+}
+
 function parseGeminiStreamGenerateResponse(rawText) {
   const responseJson = JSON.parse(trimGeminiJsonEnvelope(rawText));
   const errorCode = extractErrorCode(responseJson);
 
   const parts = Array.isArray(responseJson) ? responseJson : [];
-  let bodyIndex = 0;
   let body = null;
-  
+  let bestTextLength = -1;
+
+  // Stream chunks are cumulative; the longest text is the most complete answer.
   for (let i = 0; i < parts.length; i++) {
     const partBody = getNestedValue(parts[i], [2], null);
     if (!partBody) continue;
@@ -307,9 +342,14 @@ function parseGeminiStreamGenerateResponse(rawText) {
       const parsed = JSON.parse(partBody);
       const candidateList = getNestedValue(parsed, [4], []);
       if (Array.isArray(candidateList) && candidateList.length > 0) {
-        bodyIndex = i;
-        body = parsed;
-        break;
+        if (!body) {
+          body = parsed;
+        }
+        const score = candidateTextScore(candidateList[0]);
+        if (score > bestTextLength) {
+          bestTextLength = score;
+          body = parsed;
+        }
       }
     } catch {
       // ignore
@@ -318,11 +358,7 @@ function parseGeminiStreamGenerateResponse(rawText) {
 
   const candidateList = getNestedValue(body, [4], []);
   const firstCandidate = candidateList[0];
-  const textRaw = getNestedValue(firstCandidate, [1, 0], "");
-  const cardContent = /^http:\/\/googleusercontent\.com\/card_content\/\d+/.test(textRaw);
-  const text = cardContent
-    ? (getNestedValue(firstCandidate, [22, 0], null) ?? textRaw)
-    : textRaw;
+  const text = resolveCandidateText(firstCandidate);
   const thoughts = getNestedValue(firstCandidate, [37, 0, 0], null);
   const metadata = getNestedValue(body, [1], []);
 
@@ -341,27 +377,23 @@ function parseGeminiStreamGenerateResponse(rawText) {
     });
   }
 
-  // Generated images
-  const hasGenerated = Boolean(getNestedValue(firstCandidate, [12, 7, 0], null));
-  if (hasGenerated) {
-    let imgBody = null;
-    for (let i = bodyIndex; i < parts.length; i++) {
-      const partBody = getNestedValue(parts[i], [2], null);
-      if (!partBody) continue;
-      try {
-        const parsed = JSON.parse(partBody);
-        const candidateImages = getNestedValue(parsed, [4, 0, 12, 7, 0], null);
-        if (candidateImages != null) {
-          imgBody = parsed;
-          break;
-        }
-      } catch {
-        // ignore
+  // Keep the last chunk with a non-empty image list; a trailing empty must not erase it.
+  let imgBody = null;
+  for (let i = 0; i < parts.length; i++) {
+    const partBody = getNestedValue(parts[i], [2], null);
+    if (!partBody) continue;
+    try {
+      const parsed = JSON.parse(partBody);
+      const imgs = getNestedValue(parsed, [4, 0, 12, 7, 0], null);
+      if (Array.isArray(imgs) && imgs.length > 0) {
+        imgBody = parsed;
       }
+    } catch {
+      // ignore
     }
-
-    const imgCandidate = getNestedValue(imgBody ?? body, [4, 0], null);
-    const generated = getNestedValue(imgCandidate, [12, 7, 0], []);
+  }
+  if (imgBody) {
+    const generated = getNestedValue(imgBody, [4, 0, 12, 7, 0], []);
     for (const genImage of generated) {
       const url = getNestedValue(genImage, [0, 3, 3], null);
       if (!url) continue;
@@ -638,20 +670,20 @@ async function runGeminiWebViaPage(input) {
     };
 
     // Type prompt
-    const fullPrompt = prompt.replace(/\\/g, "\\\\").replace(/'/g, "\\'").replace(/\n/g, "\\n").replace(/\r/g, "\\r");
+    const promptJson = JSON.stringify(prompt);
     if (log) log("Typing prompt...");
-    const typeResult = await jsEval(tabId, `
+    const typeResult = await jsEval(tabId, `(() => {
       const editor = document.querySelector('.ql-editor[contenteditable=true]');
       if (!editor) return JSON.stringify({ error: "No editor found on page" });
       editor.focus();
       document.execCommand('selectAll', false, null);
-      document.execCommand('insertText', false, '${fullPrompt}');
+      document.execCommand('insertText', false, ${promptJson});
       return JSON.stringify({ ok: true, len: editor.textContent.length });
-    `);
+    })()`);
     const typed = JSON.parse(JSON.parse(checkJsResult(typeResult, "Type prompt")));
     if (typed.error) throw new Error(typed.error);
 
-    const beforeResult = await jsEval(tabId, `
+    const beforeResult = await jsEval(tabId, `(() => {
       const imageKey = (img) => {
         const url = img.currentSrc || img.src || "";
         return url + "|" + img.naturalWidth + "x" + img.naturalHeight;
@@ -665,16 +697,16 @@ async function runGeminiWebViaPage(input) {
         })
         .map(imageKey);
       return JSON.stringify(baselineKeys);
-    `);
+    })()`);
     const baselineImageKeys = JSON.parse(JSON.parse(checkJsResult(beforeResult, "Count images")) || "[]");
 
     if (log) log("Submitting...");
-    const sendResult = await jsEval(tabId, `
+    const sendResult = await jsEval(tabId, `(() => {
       const btn = document.querySelector('button[aria-label="Send message"]');
       if (!btn) return 'no-btn';
       btn.click();
       return 'sent';
-    `);
+    })()`);
     const sendVal = JSON.parse(checkJsResult(sendResult, "Click send"));
     if (sendVal === "no-btn") throw new Error("Send button not found on Gemini page");
 
@@ -686,7 +718,7 @@ async function runGeminiWebViaPage(input) {
 
     while (Date.now() < deadline) {
       await new Promise(r => setTimeout(r, 2000));
-      const pollResult = await jsEval(tabId, `
+      const pollResult = await jsEval(tabId, `(async () => {
         const baselineKeys = new Set(${JSON.stringify(baselineImageKeys)});
         const imageKey = (img) => {
           const url = img.currentSrc || img.src || "";
@@ -729,7 +761,7 @@ async function runGeminiWebViaPage(input) {
         const lastTurn = turns.length ? turns[turns.length - 1] : null;
         const text = lastTurn ? lastTurn.textContent?.trim() : "";
         return JSON.stringify({ images, loading, text, turns: turns.length });
-      `);
+      })()`);
       const poll = JSON.parse(JSON.parse(checkJsResult(pollResult, "Poll response")));
       const newImgs = poll.images || [];
 
@@ -758,7 +790,7 @@ async function runGeminiWebViaPage(input) {
         const chunkSize = 40000;
         let type = img.type || "image/png";
         while (true) {
-          const chunkResult = await jsEval(tabId, `
+          const chunkResult = await jsEval(tabId, `(() => {
             const item = window.__surfGeminiBlobImages?.[${img.blobIndex}];
             if (!item) return JSON.stringify({ error: "Blob image not found" });
             return JSON.stringify({
@@ -767,7 +799,7 @@ async function runGeminiWebViaPage(input) {
               type: item.type || "image/png",
               url: item.url,
             });
-          `);
+          })()`);
           const chunk = JSON.parse(JSON.parse(checkJsResult(chunkResult, "Read blob image chunk")));
           if (chunk.error) throw new Error(chunk.error);
           b64 += chunk.chunk || "";
@@ -810,7 +842,7 @@ async function runGeminiWebViaPage(input) {
 async function query(options) {
   const {
     prompt,
-    model = "gemini-3-pro",
+    model = "gemini-3.1-pro",
     file,
     generateImage,
     editImage,

--- a/native/grok-client.cjs
+++ b/native/grok-client.cjs
@@ -556,17 +556,6 @@ async function waitForResponse(cdp, timeoutMs = 300000, userPrompt = '') {
       // Check for stop/cancel button (indicates still generating)
       const hasStopBtn = !!document.querySelector('button[aria-label*="Stop"], button[aria-label*="stop"], button[aria-label*="Cancel"]');
 
-      // Check for "Thought for Xs" which indicates thinking model completed thinking
-      const thinkMatch = bodyText.match(/Thought for (\\d+)s/i);
-      const thinkingDone = !!thinkMatch;
-      const thinkingSecs = thinkMatch ? parseInt(thinkMatch[1], 10) : null;
-
-      // Check if actively showing "thinking..." or similar loading state
-      const isThinking = /\\bthinking\\.\\.\\./i.test(bodyText) ||
-                         /\\bSearching\\.\\.\\./i.test(bodyText) ||
-                         bodyText.includes('Grok is thinking') ||
-                         bodyText.includes('is thinking...');
-
       // Try to find the actual Grok response in the DOM
       // Look for the main content area - Grok responses appear in the conversation area
       let responseText = '';
@@ -599,6 +588,16 @@ async function waitForResponse(cdp, timeoutMs = 300000, userPrompt = '') {
         responseText = responseRoot.innerText || bodyText;
         preciseRoot = false;
       }
+
+      // Completion state must come from the current response container. Page-wide markers can belong to an earlier turn and would make a new short response finish prematurely.
+      const currentStateText = preciseRoot && responseRoot ? (responseRoot.innerText || '') : '';
+      const thinkMatch = currentStateText.match(/Thought for (\\d+)s/i);
+      const thinkingDone = !!thinkMatch;
+      const thinkingSecs = thinkMatch ? parseInt(thinkMatch[1], 10) : null;
+      const isThinking = /\\bthinking\\.\\.\\./i.test(currentStateText) ||
+                         /\\bSearching\\.\\.\\./i.test(currentStateText) ||
+                         currentStateText.includes('Grok is thinking') ||
+                         currentStateText.includes('is thinking...');
 
       // Suggestion chips are the no-testid/no-aria-label buttons inside the response container. Only collect them from a precise container: a broad main/body fallback holds unrelated buttons that could erase a matching answer line.
       const chipTexts = (preciseRoot && responseRoot ? Array.from(responseRoot.querySelectorAll('button')) : [])
@@ -669,7 +668,7 @@ async function waitForResponse(cdp, timeoutMs = 300000, userPrompt = '') {
     }
 
     const stableMs = Date.now() - lastChangeAt;
-    const noStopButton = !snapshot.hasStopBtn;
+    const noStopButton = !snapshot.hasStopBtn && !snapshot.isThinking;
 
     // Response is stable if the extracted response text hasn't changed
     // Use shorter thresholds since we're checking actual content, not noisy body text

--- a/native/grok-client.cjs
+++ b/native/grok-client.cjs
@@ -450,52 +450,16 @@ async function submitPrompt(cdp, inputCdp) {
 // Response Handling
 // ============================================================================
 
-function looksLikeTrailingSuggestion(line) {
-  if (!line || line.length < 4 || line.length > 90) return false;
-  if (/[.!:;)]$/.test(line)) return false;
-  const words = line.split(/\s+/).filter(Boolean);
-  if (words.length < 2 || words.length > 9) return false;
-  if (/^[-*•\d]/.test(line)) return false;
-  if (/\b(https?:\/\/|www\.)\b/i.test(line)) return false;
-  return true;
-}
-
-function trimTrailingSuggestionLines(lines) {
-  let end = lines.length;
-  while (end > 0 && looksLikeTrailingSuggestion(lines[end - 1])) {
-    end--;
-  }
-
-  const trimmedCount = lines.length - end;
-  if (trimmedCount >= 2 && end > 0) {
-    return lines.slice(0, end);
-  }
-
-  const last = lines[lines.length - 1];
-  if (
-    trimmedCount === 1 &&
-    lines.length > 1 &&
-    /^(explain|tell|share|compare|derive|make|show|summari[sz]e|expand|rewrite)\b/i.test(last)
-  ) {
-    return lines.slice(0, -1);
-  }
-
-  const previous = lines[lines.length - 2];
-  if (
-    last &&
-    previous &&
-    /^[A-Z][a-z]{3,}$/.test(last) &&
-    /(?:[.!?)]|^\d+(?:\.\d+)?$)/.test(previous)
-  ) {
-    return lines.slice(0, -1);
-  }
-
-  return lines;
-}
-
 // Extract Grok's response from the full page body text
-function extractGrokResponse(bodyText, userPrompt = '') {
+function extractGrokResponse(bodyText, userPrompt = '', chipTexts = []) {
   if (!bodyText) return null;
+
+  // Suggestion chips are captured from the DOM as button texts; count occurrences.
+  const chipCounts = new Map();
+  for (const t of chipTexts || []) {
+    const key = String(t).trim();
+    if (key) chipCounts.set(key, (chipCounts.get(key) || 0) + 1);
+  }
 
   // Split into lines and filter out navigation/UI elements
   const lines = bodyText.split('\n').map(l => l.trim()).filter(l => l);
@@ -543,7 +507,15 @@ function extractGrokResponse(bodyText, userPrompt = '') {
     contentLines.push(line);
   }
 
-  const responseLines = trimTrailingSuggestionLines(contentLines);
+  // Chips follow the answer; strip trailing chip lines but never the first line.
+  let contentEnd = contentLines.length;
+  while (contentEnd > 1) {
+    const remaining = chipCounts.get(contentLines[contentEnd - 1]) || 0;
+    if (remaining <= 0) break;
+    chipCounts.set(contentLines[contentEnd - 1], remaining - 1);
+    contentEnd--;
+  }
+  const responseLines = contentLines.slice(0, contentEnd);
 
   // If we found content after the question, return the response
   if (responseLines.length > 0) {
@@ -569,6 +541,7 @@ async function waitForResponse(cdp, timeoutMs = 300000, userPrompt = '') {
   const deadline = Date.now() + timeoutMs;
   let previousText = '';
   let previousLength = 0;
+  let lastChipTexts = [];
   let lastChangeAt = Date.now();
   let thinkingTime = null;
   let thinkingComplete = false;
@@ -597,29 +570,41 @@ async function waitForResponse(cdp, timeoutMs = 300000, userPrompt = '') {
       // Try to find the actual Grok response in the DOM
       // Look for the main content area - Grok responses appear in the conversation area
       let responseText = '';
+      let responseRoot = null;
+      let preciseRoot = false;
 
       // Strategy 1: Look for article elements or main content containers
       const articles = document.querySelectorAll('article');
       if (articles.length > 0) {
         // Get the last article which should be the response
-        const lastArticle = articles[articles.length - 1];
-        responseText = lastArticle.innerText || '';
+        responseRoot = articles[articles.length - 1];
+        responseText = responseRoot.innerText || '';
+        preciseRoot = true;
       }
 
       // Strategy 2: If no articles, look for the conversation container
       if (!responseText) {
         const convArea = document.querySelector('[data-testid="conversation"], [role="main"] > div > div');
         if (convArea) {
+          responseRoot = convArea;
           responseText = convArea.innerText || '';
+          preciseRoot = true;
         }
       }
 
       // Strategy 3: Fallback to looking for text after common Grok UI patterns
       if (!responseText || responseText.length < 10) {
         // Find content between user question and follow-up suggestions
-        const mainArea = document.querySelector('main') || document.body;
-        responseText = mainArea.innerText || bodyText;
+        responseRoot = document.querySelector('main') || document.body;
+        responseText = responseRoot.innerText || bodyText;
+        preciseRoot = false;
       }
+
+      // Suggestion chips are the no-testid/no-aria-label buttons inside the response container. Only collect them from a precise container: a broad main/body fallback holds unrelated buttons that could erase a matching answer line.
+      const chipTexts = (preciseRoot && responseRoot ? Array.from(responseRoot.querySelectorAll('button')) : [])
+        .filter(function(b){ return !b.getAttribute('data-testid') && !b.getAttribute('aria-label'); })
+        .map(function(b){ return (b.innerText || '').trim(); })
+        .filter(function(t){ return t && !t.includes('\\n') && t.length <= 120; });
 
       return {
         bodyText: bodyText,
@@ -629,6 +614,7 @@ async function waitForResponse(cdp, timeoutMs = 300000, userPrompt = '') {
         thinkingDone: thinkingDone,
         thinkingSecs: thinkingSecs,
         isThinking: isThinking,
+        chipTexts: chipTexts,
         url: location.href
       };
     })()`);
@@ -657,12 +643,14 @@ async function waitForResponse(cdp, timeoutMs = 300000, userPrompt = '') {
     }
 
     // Extract the actual response text - try DOM-extracted first, fall back to body parsing
+    const chipTexts = snapshot.chipTexts || [];
+    lastChipTexts = chipTexts;
     let currentResponseText = '';
     if (snapshot.responseText && snapshot.responseText.length > 10) {
-      currentResponseText = extractGrokResponse(snapshot.responseText, userPrompt) || '';
+      currentResponseText = extractGrokResponse(snapshot.responseText, userPrompt, chipTexts) || '';
     }
     if (!currentResponseText || currentResponseText.length < 5) {
-      currentResponseText = extractGrokResponse(bodyText, userPrompt) || '';
+      currentResponseText = extractGrokResponse(bodyText, userPrompt, chipTexts) || '';
     }
 
     // Track RESPONSE text stability (more reliable than body text)
@@ -686,19 +674,19 @@ async function waitForResponse(cdp, timeoutMs = 300000, userPrompt = '') {
     // Response is stable if the extracted response text hasn't changed
     // Use shorter thresholds since we're checking actual content, not noisy body text
     // 4 cycles (1.2s) + 1.5s minimum is enough for response stability
-    const responseIsStable = responseStableCycles >= 4 && stableMs >= 1500 && currentResponseText.length > 10;
+    const responseIsStable = responseStableCycles >= 4 && stableMs >= 1500 && currentResponseText.trim().length > 0;
 
     // "Thought for Xs" is the strongest completion signal - response is definitely done
     const thinkingModelDone = snapshot.thinkingDone && noStopButton;
 
     // SIMPLE CHECK: If we have response content, no stop button, and stable for 3+ cycles
-    const hasResponseNoStop = currentResponseText.length > 5 && noStopButton && responseStableCycles >= 3;
+    const hasResponseNoStop = currentResponseText.trim().length > 0 && noStopButton && responseStableCycles >= 3;
 
     // Response is complete when:
-    // 1. Has meaningful response content (> 5 chars)
+    // 1. Has any non-empty extracted text
     // 2. No stop button
     // 3. Either: thinking done, response stable for 3+ cycles, OR stable for 4+ cycles with 1.5s
-    const isDone = currentResponseText.length > 5 && noStopButton &&
+    const isDone = currentResponseText.trim().length > 0 && noStopButton &&
                    (thinkingModelDone || hasResponseNoStop || responseIsStable);
 
     if (isDone) {
@@ -713,8 +701,8 @@ async function waitForResponse(cdp, timeoutMs = 300000, userPrompt = '') {
   }
 
   // Timeout - return whatever we have (partial response is better than nothing)
-  const finalText = extractGrokResponse(previousText, userPrompt);
-  if (finalText && finalText.length > 10) {
+  const finalText = extractGrokResponse(previousText, userPrompt, lastChipTexts);
+  if (finalText && finalText.trim().length > 0) {
     return {
       text: finalText,
       thinkingTime: thinkingTime,
@@ -1067,6 +1055,7 @@ module.exports = {
   normalizeGrokModelLabel,
   getGrokModelMatchLabels,
   grokModelLabelsMatch,
+  waitForResponse,
   GROK_URL,
   GROK_MODELS,
   DEFAULT_GROK_MODELS,

--- a/native/host-helpers.cjs
+++ b/native/host-helpers.cjs
@@ -896,18 +896,32 @@ function mapToolToMessage(tool, args, tabId) {
     case "upload":
       const files = a.files ? (typeof a.files === "string" ? a.files.split(",").map(f => f.trim()) : a.files) : [];
       return { type: "UPLOAD_FILE", ref: a.ref, files, ...baseMsg };
-    case "page.read":
-      return { 
-        type: "READ_PAGE", 
-        options: { 
-          filter: a.filter || "interactive", 
-          refId: a.ref, 
+    case "page.read": {
+      let maxBytes;
+      if (a["max-bytes"] !== undefined) {
+        const raw = String(a["max-bytes"]).trim();
+        if (!/^\d+$/.test(raw) || raw === "0") {
+          throw new Error("max-bytes must be a positive integer");
+        }
+        maxBytes = parseInt(raw, 10);
+        if (!Number.isFinite(maxBytes) || maxBytes <= 0) {
+          throw new Error("max-bytes must be a positive integer");
+        }
+      }
+      return {
+        type: "READ_PAGE",
+        options: {
+          filter: a.filter || "interactive",
+          refId: a.ref,
           includeText: a["no-text"] !== true,
           depth: a.depth !== undefined ? parseInt(a.depth, 10) : undefined,
           compact: a.compact || false,
-        }, 
-        ...baseMsg 
+          maxBytes,
+          forceFullSnapshot: a.compact === true || maxBytes !== undefined,
+        },
+        ...baseMsg
       };
+    }
     case "page.text":
       return { type: "GET_PAGE_TEXT", ...baseMsg };
     case "page.state":

--- a/native/host-helpers.cjs
+++ b/native/host-helpers.cjs
@@ -471,11 +471,16 @@ function mapComputerAction(args, tabId) {
       if (ref) return { type: "CLICK_REF", ref, button: "triple", ...baseMsg };
       return { type: "EXECUTE_TRIPLE_CLICK", x: coordinate?.[0], y: coordinate?.[1], modifiers, ...baseMsg };
     
-    case "type":
+    case "type": {
       if (ref) {
         return { type: "FORM_FILL", data: [{ ref, value: text }], ...baseMsg };
       }
+      const typeSelector = a.selector || a.into;
+      if (typeSelector) {
+        return { type: "SMART_TYPE", selector: typeSelector, text, clear: a.clear ?? true, submit: a.submit ?? false, ...baseMsg };
+      }
       return { type: "EXECUTE_TYPE", text, ...baseMsg };
+    }
     
     case "key": {
       const keyValue = a.key || text;

--- a/native/host-helpers.cjs
+++ b/native/host-helpers.cjs
@@ -1081,7 +1081,7 @@ function mapToolToMessage(tool, args, tabId) {
       return {
         type: "GEMINI_QUERY",
         query: a.query,
-        model: a.model || "gemini-3-pro",
+        model: a.model || "gemini-3.1-pro",
         withPage: a["with-page"],
         file: a.file,
         generateImage: a["generate-image"],

--- a/native/host-helpers.cjs
+++ b/native/host-helpers.cjs
@@ -798,6 +798,12 @@ function mapToolToMessage(tool, args, tabId) {
       }
       return { type: "CLOSE_TAB", tabId: id, tabIds: ids };
     }
+    case "tab.move": {
+      const id = a.id || a.tab_id || a.tabId;
+      const ids = a.ids || a.tab_ids || a.tabIds;
+      const windowId = a["to-window"] || a.toWindow || a.window_id || a.windowId;
+      return { type: "TAB_MOVE", tabId: id, tabIds: ids, windowId, index: a.index };
+    }
     case "tab.name":
       return { type: "TABS_REGISTER", name: a.name, ...baseMsg };
     case "tab.unname":

--- a/native/host.cjs
+++ b/native/host.cjs
@@ -688,7 +688,7 @@ function handleToolRequest(msg, socket) {
       // 3. Call Gemini client
       const result = await geminiClient.query({
         prompt: fullPrompt,
-        model: model || "gemini-3-pro",
+        model: model || "gemini-3.1-pro",
         file,
         generateImage,
         editImage,

--- a/native/perplexity-client.cjs
+++ b/native/perplexity-client.cjs
@@ -371,6 +371,25 @@ async function submitPrompt(cdp, inputCdp) {
 // Response Handling
 // ============================================================================
 
+function extractPerplexityResponseText() {
+  const selectors = [
+    '[id^="markdown-content"]',
+    '[data-testid="answer"]',
+    'article',
+    '.prose',
+  ];
+
+  for (const selector of selectors) {
+    const elements = Array.from(document.querySelectorAll(selector));
+    for (let i = elements.length - 1; i >= 0; i--) {
+      const text = elements[i].innerText?.trim() || '';
+      if (text) return text;
+    }
+  }
+
+  return '';
+}
+
 async function waitForResponse(cdp, timeoutMs = 120000) {
   const deadline = Date.now() + timeoutMs;
   let previousText = '';
@@ -395,8 +414,7 @@ async function waitForResponse(cdp, timeoutMs = 120000) {
   // Now poll for response completion
   while (Date.now() < deadline) {
     const snapshot = await evaluate(cdp, `(function() {
-      const prose = document.querySelector('.prose');
-      const text = prose ? prose.innerText : '';
+      const text = (${extractPerplexityResponseText.toString()})();
       const hasStop = !!document.querySelector('button[aria-label*=stop], button[aria-label*=Stop]');
       const hasCopy = !!document.querySelector('button[aria-label*=copy], button[aria-label*=Copy]');
       const hasRelated = document.body.innerText.indexOf('Related') > -1;
@@ -437,7 +455,7 @@ async function waitForResponse(cdp, timeoutMs = 120000) {
     const hasCompletionIndicators = snapshot.hasActions || snapshot.hasRelated || snapshot.hasFollowUp;
     const isDone = !snapshot.generating && (hasCompletionIndicators || isStable);
     
-    if (isDone && currentText.length > 20) {
+    if (isDone && currentText.trim().length > 0) {
       // Clean up the response text
       let cleanText = currentText;
       
@@ -458,7 +476,7 @@ async function waitForResponse(cdp, timeoutMs = 120000) {
   }
   
   // Timeout - return whatever we have
-  if (previousText.length > 20) {
+  if (previousText.trim().length > 0) {
     return {
       text: previousText,
       sources: 0,
@@ -562,4 +580,4 @@ async function query(options) {
   }
 }
 
-module.exports = { query, PERPLEXITY_URL };
+module.exports = { query, PERPLEXITY_URL, waitForResponse, extractPerplexityResponseText };

--- a/skills/surf/SKILL.md
+++ b/skills/surf/SKILL.md
@@ -68,7 +68,7 @@ surf gemini "analyze" --file data.csv             # Attach file
 surf gemini "a robot surfing" --generate-image /tmp/robot.png
 surf gemini "add sunglasses" --edit-image photo.jpg --output out.jpg
 surf gemini "summarize" --youtube "https://youtube.com/..."
-surf gemini "hello" --model gemini-2.5-flash      # Models: gemini-3-pro (default), gemini-2.5-pro, gemini-2.5-flash
+surf gemini "hello" --model gemini-3.5-flash      # Models: gemini-3.1-pro (default), gemini-3.5-flash, gemini-3.1-flash-lite
 surf gemini "wide banner" --generate-image /tmp/banner.png --aspect-ratio 16:9
 ```
 

--- a/skills/surf/SKILL.md
+++ b/skills/surf/SKILL.md
@@ -160,6 +160,7 @@ surf tab.list
 surf tab.new "https://google.com"
 surf tab.switch 12345
 surf tab.close 12345
+surf tab.move 12345 --to-window 67890
 surf tab.reload                # Reload current tab
 
 # Named tabs (aliases)
@@ -209,12 +210,13 @@ Use `window.new`, `--window-id`, `--tab-id`, and named tabs to keep parallel age
 ## Input Methods
 
 ```bash
-# CDP method (real events) - default
+# CDP method (real events) types at the current focus
 surf type --text "hello"
 surf click --x 100 --y 200
 
-# JS method (DOM manipulation) - for contenteditable
-surf type --text "hello" --selector "#input" --method js
+# Selector/ref targets use frame-aware DOM input
+surf type "hello" --into "#input"
+surf type "hello" --ref e5
 
 # Keys
 surf key Enter
@@ -235,6 +237,7 @@ surf animate-audit --selector ".thing" --duration 2000 --fps 10  # JSON animatio
 surf page.read --ref e5        # Get specific element details
 surf page.read --depth 3       # Limit tree depth
 surf page.read --compact       # Minimal output for LLM efficiency
+surf page.read --max-bytes 2000 # Cap visible text at a UTF-8 byte boundary
 surf page.text                 # Plain text content only
 surf page.state                # Modals, loading state, scroll info
 ```

--- a/src/content/accessibility-tree.ts
+++ b/src/content/accessibility-tree.ts
@@ -1258,6 +1258,42 @@ function setFormValue(ref: string, value: string | boolean | number): { success:
   }
 }
 
+function smartType(selector: string, text: string, clear = true, submit = false): { success: boolean; contentEditable?: boolean; error?: string } {
+  try {
+    const element = document.querySelector(selector) as HTMLElement | null;
+    if (!element) return { success: false, error: `Element not found: ${selector}` };
+
+    const contentEditableChild = element.querySelector<HTMLElement>('[contenteditable="true"]');
+    const target = contentEditableChild || element;
+    const contentEditable = element.isContentEditable || !!contentEditableChild;
+    target.focus();
+
+    if (clear) {
+      if (contentEditable) target.textContent = "";
+      else (target as HTMLInputElement | HTMLTextAreaElement).value = "";
+    }
+
+    if (contentEditable) target.textContent = text;
+    else (target as HTMLInputElement | HTMLTextAreaElement).value = text;
+
+    target.dispatchEvent(new Event("input", { bubbles: true }));
+    target.dispatchEvent(new Event("change", { bubbles: true }));
+
+    if (submit) {
+      const form = element.closest("form");
+      const submitButton = form?.querySelector<HTMLElement>('button[type="submit"], input[type="submit"]')
+        || document.querySelector<HTMLElement>('button[type="submit"], button[data-testid*="send"], button[aria-label*="Send"]');
+      if (submitButton) submitButton.click();
+      else if (form) form.dispatchEvent(new Event("submit", { bubbles: true }));
+      else target.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", code: "Enter", keyCode: 13, bubbles: true }));
+    }
+
+    return { success: true, contentEditable };
+  } catch (err) {
+    return { success: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
 function truncateToUtf8Bytes(input: string, maxBytes: number): string {
   const encoder = new TextEncoder();
   const encoded = encoder.encode(input);
@@ -1267,19 +1303,18 @@ function truncateToUtf8Bytes(input: string, maxBytes: number): string {
   return new TextDecoder("utf-8", { fatal: false }).decode(encoded.subarray(0, end));
 }
 
-function getPageText(options: { compact?: boolean; maxBytes?: number } = {}): { text: string; title: string; url: string; error?: string } {
+function getPageText(options: { maxBytes?: number } = {}): { text: string; title: string; url: string; error?: string } {
   try {
     const article = document.querySelector("article");
     const main = document.querySelector("main");
     const content = article || main || document.body;
-    const maxBytes = Number.isFinite(options.maxBytes) && options.maxBytes! > 0
-      ? options.maxBytes!
-      : 50000;
 
     const normalized = content.textContent
       ?.replace(/\s+/g, " ")
       .trim() || "";
-    const text = truncateToUtf8Bytes(normalized, maxBytes);
+    const text = Number.isFinite(options.maxBytes) && options.maxBytes! > 0
+      ? truncateToUtf8Bytes(normalized, options.maxBytes!)
+      : normalized.substring(0, 50000);
 
     return {
       text,
@@ -1481,6 +1516,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     case "GET_PAGE_TEXT": {
       const result = getPageText(message.options || {});
       sendResponse(result);
+      break;
+    }
+    case "SMART_TYPE": {
+      sendResponse(smartType(message.selector, message.text, message.clear, message.submit));
       break;
     }
     case "GET_FRAME_BY_SELECTOR": {

--- a/src/content/accessibility-tree.ts
+++ b/src/content/accessibility-tree.ts
@@ -1258,16 +1258,28 @@ function setFormValue(ref: string, value: string | boolean | number): { success:
   }
 }
 
-function getPageText(): { text: string; title: string; url: string; error?: string } {
+function truncateToUtf8Bytes(input: string, maxBytes: number): string {
+  const encoder = new TextEncoder();
+  const encoded = encoder.encode(input);
+  if (encoded.length <= maxBytes) return input;
+  let end = maxBytes;
+  while (end > 0 && (encoded[end] & 0xc0) === 0x80) end--;
+  return new TextDecoder("utf-8", { fatal: false }).decode(encoded.subarray(0, end));
+}
+
+function getPageText(options: { compact?: boolean; maxBytes?: number } = {}): { text: string; title: string; url: string; error?: string } {
   try {
     const article = document.querySelector("article");
     const main = document.querySelector("main");
     const content = article || main || document.body;
+    const maxBytes = Number.isFinite(options.maxBytes) && options.maxBytes! > 0
+      ? options.maxBytes!
+      : 50000;
 
-    const text = content.textContent
+    const normalized = content.textContent
       ?.replace(/\s+/g, " ")
-      .trim()
-      .substring(0, 50000) || "";
+      .trim() || "";
+    const text = truncateToUtf8Bytes(normalized, maxBytes);
 
     return {
       text,
@@ -1467,7 +1479,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       break;
     }
     case "GET_PAGE_TEXT": {
-      const result = getPageText();
+      const result = getPageText(message.options || {});
       sendResponse(result);
       break;
     }

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -983,7 +983,13 @@ export async function handleMessage(
       // Include visible text content if requested
       if (message.options?.includeText) {
         try {
-          const textResult = await chrome.tabs.sendMessage(tabId, { type: "GET_PAGE_TEXT" }, { frameId: readFrameId });
+          const textResult = await chrome.tabs.sendMessage(tabId, {
+            type: "GET_PAGE_TEXT",
+            options: {
+              compact: message.options?.compact === true,
+              maxBytes: message.options?.maxBytes,
+            },
+          }, { frameId: readFrameId });
           if (textResult?.text) {
             result.text = textResult.text;
           }

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -2644,10 +2644,26 @@ export async function handleMessage(
     }
 
     case "TABS_REGISTER": {
-      if (!tabId) throw new Error("No tabId provided");
+      let targetTabId = tabId;
+      if (!targetTabId) {
+        const isRestricted = (url?: string) =>
+          !url || url.startsWith('chrome://') || url.startsWith('chrome-extension://') || url === 'about:blank';
+        const queryOptions: chrome.tabs.QueryInfo = message.windowId
+          ? { active: true, windowId: message.windowId }
+          : { active: true, lastFocusedWindow: true };
+        const [activeTab] = await chrome.tabs.query(queryOptions);
+        if (activeTab && !isRestricted(activeTab.url)) {
+          targetTabId = activeTab.id;
+        } else {
+          throw new Error(
+            "Cannot register a chrome:// or extension tab. Focus a regular web page, or pass an explicit tabId."
+          );
+        }
+      }
+      if (!targetTabId) throw new Error("No active tab found");
       if (!message.name) throw new Error("No name provided");
-      tabNameRegistry.set(message.name, tabId);
-      return { success: true, name: message.name, tabId };
+      tabNameRegistry.set(message.name, targetTabId);
+      return { success: true, name: message.name, tabId: targetTabId };
     }
 
     case "TABS_GET_BY_NAME": {

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -2643,6 +2643,37 @@ export async function handleMessage(
       return { success: true, closed: tabIds };
     }
 
+    case "TAB_MOVE": {
+      const rawTabIds = message.tabIds || (message.tabId ? [message.tabId] : []);
+      const tabIds = (Array.isArray(rawTabIds) ? rawTabIds : String(rawTabIds).split(","))
+        .map((id) => Number(id));
+      if (tabIds.length === 0) throw new Error("No tabId(s) provided");
+      if (tabIds.some((id) => !Number.isInteger(id) || id <= 0)) {
+        throw new Error("Invalid tabId(s)");
+      }
+
+      const windowId = Number(message.windowId);
+      if (!Number.isInteger(windowId) || windowId <= 0) {
+        throw new Error("No destination windowId provided");
+      }
+
+      const index = message.index !== undefined ? Number(message.index) : -1;
+      if (!Number.isInteger(index) || index < -1) throw new Error("Invalid tab index");
+
+      const moveProperties = { windowId, index };
+      const movedTabs = tabIds.length === 1
+        ? await chrome.tabs.move(tabIds[0], moveProperties)
+        : await chrome.tabs.move(tabIds, moveProperties);
+
+      return {
+        success: true,
+        moved: tabIds,
+        destinationWindowId: windowId,
+        index,
+        tabs: Array.isArray(movedTabs) ? movedTabs : [movedTabs],
+      };
+    }
+
     case "TABS_REGISTER": {
       let targetTabId = tabId;
       if (!targetTabId) {
@@ -3546,7 +3577,7 @@ chrome.runtime.onInstalled.addListener((details) => {
 });
 
 const COMMANDS_WITHOUT_TAB = new Set([
-  "LIST_TABS", "NEW_TAB", "TABS_NEW", "CLOSE_TABS", "SWITCH_TAB", "TABS_SWITCH",
+  "LIST_TABS", "NEW_TAB", "TABS_NEW", "CLOSE_TABS", "TAB_MOVE", "SWITCH_TAB", "TABS_SWITCH",
   "TABS_REGISTER", "TABS_UNREGISTER", "TABS_LIST_NAMED", "TABS_GET_BY_NAME",
   "CREATE_TAB_GROUP", "UNGROUP_TABS", "LIST_TAB_GROUPS", "GET_HISTORY", "SEARCH_HISTORY",
   "GET_COOKIES", "SET_COOKIE", "DELETE_COOKIES", "GET_BOOKMARKS", "ADD_BOOKMARK", 

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -16,6 +16,11 @@ function getFrameIdForTab(tabId: number): number {
   return frameContexts.get(tabId) ?? 0;
 }
 
+function isRestrictedTabUrl(url?: string): boolean {
+  if (!url) return true;
+  return /^(?:about|arc|brave|chrome|chrome-extension|devtools|edge|extension|helium|moz-extension):/i.test(url);
+}
+
 const screenshotCache = new Map<string, { base64: string; width: number; height: number }>();
 let screenshotCounter = 0;
 
@@ -778,54 +783,18 @@ export async function handleMessage(
       const { selector, text, clear = true, submit = false } = message;
       if (!selector) throw new Error("selector required");
       if (text === undefined) throw new Error("text required");
-      
-      const script = `(() => {
-        const el = document.querySelector(${JSON.stringify(selector)});
-        if (!el) return { error: 'Element not found: ' + ${JSON.stringify(selector)} };
-        
-        const isContentEditable = el.isContentEditable || 
-                                   el.getAttribute('contenteditable') === 'true';
-        const hasContentEditableChild = el.querySelector('[contenteditable="true"]');
-        
-        const target = hasContentEditableChild || el;
-        const useContentEditable = isContentEditable || !!hasContentEditableChild;
-        
-        target.focus();
-        
-        if (${clear}) {
-          if (useContentEditable) {
-            target.textContent = '';
-          } else {
-            target.value = '';
-          }
-        }
-        
-        if (useContentEditable) {
-          target.textContent = ${JSON.stringify(text)};
-        } else {
-          target.value = ${JSON.stringify(text)};
-        }
-        
-        target.dispatchEvent(new Event('input', { bubbles: true }));
-        target.dispatchEvent(new Event('change', { bubbles: true }));
-        
-        if (${submit}) {
-          const form = el.closest('form');
-          const submitBtn = document.querySelector('button[type="submit"], button[data-testid*="send"], button[aria-label*="Send"]');
-          if (submitBtn) {
-            submitBtn.click();
-          } else if (form) {
-            form.dispatchEvent(new Event('submit', { bubbles: true }));
-          } else {
-            target.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }));
-          }
-        }
-        
-        return { success: true, contentEditable: useContentEditable };
-      })()`;
-      
-      const result = await cdp.evaluateScript(tabId, script);
-      return result.result?.value || { error: "Script failed" };
+
+      try {
+        return await chrome.tabs.sendMessage(tabId, {
+          type: "SMART_TYPE",
+          selector,
+          text,
+          clear,
+          submit,
+        }, { frameId: getFrameIdForTab(tabId) });
+      } catch (err) {
+        throw new Error(`Could not type into selector: ${err instanceof Error ? err.message : String(err)}`);
+      }
     }
 
     case "CLOSE_DIALOGS": {
@@ -2683,17 +2652,15 @@ export async function handleMessage(
     case "TABS_REGISTER": {
       let targetTabId = tabId;
       if (!targetTabId) {
-        const isRestricted = (url?: string) =>
-          !url || url.startsWith('chrome://') || url.startsWith('chrome-extension://') || url === 'about:blank';
         const queryOptions: chrome.tabs.QueryInfo = message.windowId
           ? { active: true, windowId: message.windowId }
           : { active: true, lastFocusedWindow: true };
         const [activeTab] = await chrome.tabs.query(queryOptions);
-        if (activeTab && !isRestricted(activeTab.url)) {
+        if (activeTab && !isRestrictedTabUrl(activeTab.url)) {
           targetTabId = activeTab.id;
         } else {
           throw new Error(
-            "Cannot register a chrome:// or extension tab. Focus a regular web page, or pass an explicit tabId."
+            "Cannot register a restricted browser or extension page. Focus a regular web page, or pass an explicit tabId."
           );
         }
       }
@@ -3622,13 +3589,10 @@ initNativeMessaging(async (msg) => {
       tab = tabs[0];
       
       // Check if active tab is usable (not a restricted URL)
-      const isRestricted = (url?: string) => 
-        !url || url.startsWith('chrome://') || url.startsWith('chrome-extension://') || url === 'about:blank';
-      
-      if (!tab || isRestricted(tab.url)) {
+      if (!tab || isRestrictedTabUrl(tab.url)) {
         // Active tab is restricted, find any usable tab in the window
         tabs = await chrome.tabs.query({ windowId });
-        tab = tabs.find(t => !isRestricted(t.url));
+        tab = tabs.find(t => !isRestrictedTabUrl(t.url));
       }
       
       if (!tab?.id) {
@@ -3650,13 +3614,13 @@ initNativeMessaging(async (msg) => {
       // Default behavior: find active tab across windows
       tabs = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
       tab = tabs[0];
-      if (!tab || tab.url?.startsWith('chrome-extension://')) {
+      if (!tab || isRestrictedTabUrl(tab.url)) {
         tabs = await chrome.tabs.query({ active: true, currentWindow: true });
         tab = tabs[0];
       }
-      if (!tab || tab.url?.startsWith('chrome-extension://') || tab.url?.startsWith('chrome://')) {
+      if (!tab || isRestrictedTabUrl(tab.url)) {
         tabs = await chrome.tabs.query({ active: true });
-        tab = tabs.find(t => !t.url?.startsWith('chrome-extension://') && !t.url?.startsWith('chrome://'));
+        tab = tabs.find(t => !isRestrictedTabUrl(t.url));
       }
       if (!tab?.id) {
         throw new Error("No active tab found. Use 'surf tab.new <url>' to create one, or 'surf tab.list' to see available tabs.");

--- a/test/mocks/chrome.ts
+++ b/test/mocks/chrome.ts
@@ -21,6 +21,7 @@ type ChromeMock = {
     get: ReturnType<typeof vi.fn>;
     create: ReturnType<typeof vi.fn>;
     update: ReturnType<typeof vi.fn>;
+    move: ReturnType<typeof vi.fn>;
     remove: ReturnType<typeof vi.fn>;
     sendMessage: ReturnType<typeof vi.fn>;
     onUpdated: {
@@ -119,6 +120,7 @@ export function createChromeMock(): ChromeMock {
       get: vi.fn().mockResolvedValue(null),
       create: vi.fn().mockResolvedValue({ id: 1 }),
       update: vi.fn().mockResolvedValue({}),
+      move: vi.fn().mockResolvedValue({}),
       remove: vi.fn().mockResolvedValue(undefined),
       sendMessage: vi.fn().mockResolvedValue(undefined),
       onUpdated: {

--- a/test/mocks/chrome.ts
+++ b/test/mocks/chrome.ts
@@ -47,6 +47,7 @@ type ChromeMock = {
     };
   };
   webNavigation: {
+    getAllFrames: ReturnType<typeof vi.fn>;
     onCompleted: {
       addListener: ReturnType<typeof vi.fn>;
       removeListener: ReturnType<typeof vi.fn>;
@@ -146,6 +147,7 @@ export function createChromeMock(): ChromeMock {
       },
     },
     webNavigation: {
+      getAllFrames: vi.fn().mockResolvedValue([]),
       onCompleted: {
         addListener: vi.fn(),
         removeListener: vi.fn(),

--- a/test/unit/accessibility-tree.test.ts
+++ b/test/unit/accessibility-tree.test.ts
@@ -23,6 +23,9 @@ class FakeElement extends FakeNode {
   disabled = false;
   indeterminate = false;
   checked = false;
+  focused = false;
+  clicked = false;
+  isContentEditable = false;
 
   private attrs = new Map<string, string>();
 
@@ -78,6 +81,18 @@ class FakeElement extends FakeNode {
 
   querySelector(): FakeElement | null {
     return null;
+  }
+
+  focus(): void {
+    this.focused = true;
+  }
+
+  click(): void {
+    this.clicked = true;
+  }
+
+  dispatchEvent(): boolean {
+    return true;
   }
 
   getBoundingClientRect(): { top: number; bottom: number; left: number; right: number } {
@@ -198,8 +213,8 @@ describe("accessibility tree", () => {
     });
   });
 
-  it("does not truncate compact text when max-bytes is not given", () => {
-    const long = "a".repeat(5000);
+  it("preserves the existing 50000-character default when max-bytes is not given", () => {
+    const long = "😀".repeat(30000);
     (document.body as unknown as FakeElement).append(text(long));
 
     let response: any;
@@ -207,7 +222,26 @@ describe("accessibility tree", () => {
       response = result;
     });
 
-    expect(response.text.length).toBe(5000);
+    expect(response.text.length).toBe(50000);
+    expect(new TextEncoder().encode(response.text).length).toBe(100000);
+  });
+
+  it("types into a selector in the content-script frame", () => {
+    const input = new FakeInputElement("input");
+    (document as any).querySelector = (selector: string) => (selector === "#target" ? input : null);
+
+    let response: any;
+    messageHandler?.(
+      { type: "SMART_TYPE", selector: "#target", text: "hello", clear: true, submit: false },
+      {},
+      (result) => {
+        response = result;
+      },
+    );
+
+    expect(input.focused).toBe(true);
+    expect(input.value).toBe("hello");
+    expect(response).toEqual({ success: true, contentEditable: false });
   });
 
   it("truncates multi-byte utf-8 text on a byte boundary, not a surrogate", () => {

--- a/test/unit/accessibility-tree.test.ts
+++ b/test/unit/accessibility-tree.test.ts
@@ -122,6 +122,7 @@ describe("accessibility tree", () => {
     (globalThis as any).window = {
       innerWidth: 1024,
       innerHeight: 768,
+      location: { href: "https://example.test/page" },
       getComputedStyle: () => ({
         display: "block",
         visibility: "visible",
@@ -132,6 +133,7 @@ describe("accessibility tree", () => {
 
     (globalThis as any).document = {
       body: new FakeElement("body"),
+      title: "Example",
       getElementById: () => null,
       querySelector: () => null,
       querySelectorAll: () => [],
@@ -175,5 +177,55 @@ describe("accessibility tree", () => {
     expect(response.error).toBeUndefined();
     expect(response.pageContent).toContain('link "Read docs"');
     expect(response.pageContent).toContain('button "Save changes"');
+  });
+
+  it("caps visible text in compact mode", () => {
+    (document.body as unknown as FakeElement).append(text("abcdef"));
+
+    let response: any;
+    messageHandler?.(
+      { type: "GET_PAGE_TEXT", options: { compact: true, maxBytes: 3 } },
+      {},
+      (result) => {
+        response = result;
+      },
+    );
+
+    expect(response).toMatchObject({
+      text: "abc",
+      title: "Example",
+      url: "https://example.test/page",
+    });
+  });
+
+  it("does not truncate compact text when max-bytes is not given", () => {
+    const long = "a".repeat(5000);
+    (document.body as unknown as FakeElement).append(text(long));
+
+    let response: any;
+    messageHandler?.({ type: "GET_PAGE_TEXT", options: { compact: true } }, {}, (result) => {
+      response = result;
+    });
+
+    expect(response.text.length).toBe(5000);
+  });
+
+  it("truncates multi-byte utf-8 text on a byte boundary, not a surrogate", () => {
+    (document.body as unknown as FakeElement).append(text("😀😀"));
+
+    let response: any;
+    messageHandler?.(
+      { type: "GET_PAGE_TEXT", options: { compact: true, maxBytes: 3 } },
+      {},
+      (result) => {
+        response = result;
+      },
+    );
+
+    expect(response.text).not.toContain("\uD83D");
+    expect(response.text).not.toContain("\uDE00");
+    const byteLen = new TextEncoder().encode(response.text).length;
+    expect(byteLen).toBeLessThanOrEqual(3);
+    expect(response.text).toBe("");
   });
 });

--- a/test/unit/cli-args.test.ts
+++ b/test/unit/cli-args.test.ts
@@ -239,6 +239,13 @@ describe("CLI argument parsing", () => {
     expect(request.params.args).toMatchObject({ id: 123, "to-window": 456, index: 0 });
   });
 
+  it("preserves page.read max-bytes", async () => {
+    const { request } = await runCli(["page.read", "--compact", "--max-bytes", "1200"]);
+
+    expect(request.params.tool).toBe("page.read");
+    expect(request.params.args).toMatchObject({ compact: true, "max-bytes": 1200 });
+  });
+
   it("does not map emulate.viewport positional values to width and height", async () => {
     const { request } = await runCli(["emulate.viewport", "375", "812"]);
 

--- a/test/unit/cli-args.test.ts
+++ b/test/unit/cli-args.test.ts
@@ -232,6 +232,13 @@ describe("CLI argument parsing", () => {
     expect(request.params.args.level).toBe(1.5);
   });
 
+  it("maps tab.move positional tab id and destination window", async () => {
+    const { request } = await runCli(["tab.move", "123", "--to-window", "456", "--index", "0"]);
+
+    expect(request.params.tool).toBe("tab.move");
+    expect(request.params.args).toMatchObject({ id: 123, "to-window": 456, index: 0 });
+  });
+
   it("does not map emulate.viewport positional values to width and height", async () => {
     const { request } = await runCli(["emulate.viewport", "375", "812"]);
 

--- a/test/unit/cli-args.test.ts
+++ b/test/unit/cli-args.test.ts
@@ -246,6 +246,42 @@ describe("CLI argument parsing", () => {
     expect(request.params.args).toMatchObject({ compact: true, "max-bytes": 1200 });
   });
 
+  it("rejects explicit CDP typing with selector targets", async () => {
+    const { code, stderr } = await runCliWithoutSocket([
+      "type",
+      "hello",
+      "--into",
+      "#target",
+      "--method",
+      "cdp",
+    ]);
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("--method cdp types at the current focus");
+  });
+
+  it("rejects explicit CDP method on smart_type", async () => {
+    const { code, stderr } = await runCliWithoutSocket([
+      "smart_type",
+      "--selector",
+      "#target",
+      "--text",
+      "hello",
+      "--method",
+      "cdp",
+    ]);
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("smart_type uses the JS input path");
+  });
+
+  it("keeps ref typing on the frame-aware form path with --method js", async () => {
+    const { request } = await runCli(["type", "hello", "--ref", "e1", "--method", "js"]);
+
+    expect(request.params.tool).toBe("type");
+    expect(request.params.args).toMatchObject({ text: "hello", ref: "e1" });
+  });
+
   it("does not map emulate.viewport positional values to width and height", async () => {
     const { request } = await runCli(["emulate.viewport", "375", "812"]);
 

--- a/test/unit/cli-args.test.ts
+++ b/test/unit/cli-args.test.ts
@@ -225,6 +225,13 @@ describe("CLI argument parsing", () => {
     expect(request.params.args).toMatchObject({ width: 375, height: 812 });
   });
 
+  it("preserves zoom level flags", async () => {
+    const { request } = await runCli(["zoom", "--level", "1.5"]);
+
+    expect(request.params.tool).toBe("zoom");
+    expect(request.params.args.level).toBe(1.5);
+  });
+
   it("does not map emulate.viewport positional values to width and height", async () => {
     const { request } = await runCli(["emulate.viewport", "375", "812"]);
 

--- a/test/unit/gemini-client.test.ts
+++ b/test/unit/gemini-client.test.ts
@@ -22,7 +22,7 @@ describe("gemini-client", () => {
 
       const run = geminiClient.runGeminiWebViaPage({
         prompt: "generate a test image",
-        model: "gemini-3-pro",
+        model: "gemini-3.1-pro",
         timeoutMs: 10_000,
         log: (msg: string) => logs.push(msg),
         createTab: async () => ({ tabId: 123 }),
@@ -102,7 +102,7 @@ describe("gemini-client", () => {
 
       const run = geminiClient.runGeminiWebViaPage({
         prompt: "generate a new image",
-        model: "gemini-3-pro",
+        model: "gemini-3.1-pro",
         timeoutMs: 10_000,
         createTab: async () => ({ tabId: 123 }),
         closeTab: async () => ({ ok: true }),
@@ -155,7 +155,7 @@ describe("gemini-client", () => {
 
       const run = geminiClient.runGeminiWebViaPage({
         prompt: "generate a test image",
-        model: "gemini-3-pro",
+        model: "gemini-3.1-pro",
         timeoutMs: 10_000,
         createTab: async () => ({ tabId: 123 }),
         closeTab: async () => ({ ok: true }),

--- a/test/unit/gemini-client.test.ts
+++ b/test/unit/gemini-client.test.ts
@@ -8,13 +8,212 @@ const promptTyped = (code: string) => code.includes("document.execCommand('inser
 const baselineCollected = (code: string) => code.includes("return JSON.stringify(baselineKeys)");
 const sendClicked = (code: string) => code.includes('button[aria-label="Send message"]');
 const imagesPolled = (code: string) => code.includes("window.__surfGeminiBlobImageIndexes");
+const blobExtracted = (code: string) => code.includes("window.__surfGeminiBlobImages?.[0]");
+
+type ScriptHandler = (code: string) => unknown;
+type ScriptMatcher = (code: string) => boolean;
+
+const routeJsEval = (
+  code: string,
+  handlers: {
+    type?: ScriptHandler;
+    baseline?: ScriptHandler;
+    send?: ScriptHandler;
+    poll?: ScriptHandler;
+    blob?: ScriptHandler;
+  },
+) => {
+  const matchers: Array<[ScriptMatcher, ScriptHandler | undefined]> = [
+    [promptTyped, handlers.type],
+    [baselineCollected, handlers.baseline],
+    [sendClicked, handlers.send],
+    [imagesPolled, handlers.poll],
+    [blobExtracted, handlers.blob],
+  ];
+  const handler = matchers.find(([match]) => match(code))?.[1];
+  if (!handler) {
+    throw new Error(`Unexpected script: ${code}`);
+  }
+  return handler(code);
+};
 
 describe("gemini-client", () => {
   afterEach(() => {
     vi.useRealTimers();
   });
 
+  describe("parseGeminiStreamGenerateResponse", () => {
+    it("uses a later stream body when the first candidate body has empty text", () => {
+      const emptyBody = [null, [], null, null, [["rc_123", [""]]]];
+      const answerBody = [null, [], null, null, [["rc_123", ["pong"]]]];
+      const raw = JSON.stringify([
+        [null, null, JSON.stringify(emptyBody)],
+        [null, null, JSON.stringify(answerBody)],
+      ]);
+
+      expect(geminiClient.parseGeminiStreamGenerateResponse(raw).text).toBe("pong");
+    });
+
+    it("extracts text when Gemini shifts the candidate text one slot deeper", () => {
+      const body = [null, [], null, null, [[null, [[null, "pong"]]]]];
+      const raw = JSON.stringify([[null, null, JSON.stringify(body)]]);
+
+      expect(geminiClient.parseGeminiStreamGenerateResponse(raw).text).toBe("pong");
+    });
+
+    it("uses alternate text when the primary slot is only card content", () => {
+      const body = [
+        null,
+        [],
+        null,
+        null,
+        [[null, ["http://googleusercontent.com/card_content/123"], ["pong"]]],
+      ];
+      const raw = JSON.stringify([[null, null, JSON.stringify(body)]]);
+
+      expect(geminiClient.parseGeminiStreamGenerateResponse(raw).text).toBe("pong");
+    });
+
+    it("returns the most complete cumulative body, not an earlier truncated prefix", () => {
+      const partialBody = [null, [], null, null, [["rc_1", ["alpha bravo"]]]];
+      const fullBody = [null, [], null, null, [["rc_1", ["alpha bravo charlie delta echo"]]]];
+      const raw = JSON.stringify([
+        [null, null, JSON.stringify(partialBody)],
+        [null, null, JSON.stringify(fullBody)],
+      ]);
+
+      expect(geminiClient.parseGeminiStreamGenerateResponse(raw).text).toBe(
+        "alpha bravo charlie delta echo",
+      );
+    });
+
+    it("keeps the longest body when a trailing chunk carries shorter text", () => {
+      const fullBody = [null, [], null, null, [["rc_1", ["alpha bravo charlie delta echo"]]]];
+      const trailingBody = [null, [], null, null, [["rc_1", ["related"]]]];
+      const raw = JSON.stringify([
+        [null, null, JSON.stringify(fullBody)],
+        [null, null, JSON.stringify(trailingBody)],
+      ]);
+
+      expect(geminiClient.parseGeminiStreamGenerateResponse(raw).text).toBe(
+        "alpha bravo charlie delta echo",
+      );
+    });
+
+    it("preserves a generated image that arrives in a later equal-text chunk", () => {
+      const url = "http://img/gen.png";
+      const genImage = [[null, null, null, [null, null, null, url]]];
+      const imgCand: any[] = ["rc", ["cat"]];
+      imgCand[12] = [];
+      imgCand[12][7] = [[genImage]];
+      const raw = JSON.stringify([
+        [null, null, JSON.stringify([null, [], null, null, [["rc", ["cat"]]]])],
+        [null, null, JSON.stringify([null, [], null, null, [imgCand]])],
+      ]);
+
+      const result = geminiClient.parseGeminiStreamGenerateResponse(raw);
+      expect(result.text).toBe("cat");
+      expect(result.images).toEqual([
+        { kind: "generated", url, title: "[Generated Image]", alt: "" },
+      ]);
+    });
+
+    it("returns every generated image from the cumulative final chunk", () => {
+      const mk = (url: string) => [[null, null, null, [null, null, null, url]]];
+      const cand1: any[] = ["rc", ["pic"]];
+      cand1[12] = [];
+      cand1[12][7] = [[mk("http://one")]];
+      const cand2: any[] = ["rc", ["pic"]];
+      cand2[12] = [];
+      cand2[12][7] = [[mk("http://one"), mk("http://two")]];
+      const raw = JSON.stringify([
+        [null, null, JSON.stringify([null, [], null, null, [cand1]])],
+        [null, null, JSON.stringify([null, [], null, null, [cand2]])],
+      ]);
+
+      const result = geminiClient.parseGeminiStreamGenerateResponse(raw);
+      expect(result.images.map((i: { url: string }) => i.url)).toEqual([
+        "http://one",
+        "http://two",
+      ]);
+    });
+
+    it("does not let a trailing empty image list erase an earlier image", () => {
+      const mk = (url: string) => [[null, null, null, [null, null, null, url]]];
+      const cand1: any[] = ["rc", ["pic"]];
+      cand1[12] = [];
+      cand1[12][7] = [[mk("http://one")]];
+      const cand2: any[] = ["rc", ["pic"]];
+      cand2[12] = [];
+      cand2[12][7] = [[]];
+      const raw = JSON.stringify([
+        [null, null, JSON.stringify([null, [], null, null, [cand1]])],
+        [null, null, JSON.stringify([null, [], null, null, [cand2]])],
+      ]);
+
+      const result = geminiClient.parseGeminiStreamGenerateResponse(raw);
+      expect(result.images.map((i: { url: string }) => i.url)).toEqual(["http://one"]);
+    });
+
+    it("ranks a real answer over an earlier unresolved card-content placeholder", () => {
+      const cardOnlyBody = [
+        null,
+        [],
+        null,
+        null,
+        [[null, ["http://googleusercontent.com/card_content/123"]]],
+      ];
+      const answerBody = [null, [], null, null, [["rc_1", ["pong"]]]];
+      const raw = JSON.stringify([
+        [null, null, JSON.stringify(cardOnlyBody)],
+        [null, null, JSON.stringify(answerBody)],
+      ]);
+
+      expect(geminiClient.parseGeminiStreamGenerateResponse(raw).text).toBe("pong");
+    });
+  });
+
   describe("runGeminiWebViaPage", () => {
+    it("sends expression-safe page scripts through jsEval", async () => {
+      vi.useFakeTimers();
+      const seenScripts: string[] = [];
+
+      const run = geminiClient.runGeminiWebViaPage({
+        prompt: "quote ' and newline\nsafe",
+        model: "gemini-3.1-pro",
+        timeoutMs: 10_000,
+        createTab: async () => ({ tabId: 123 }),
+        closeTab: async () => ({ ok: true }),
+        jsEval: async (_tabId: number, code: string) => {
+          seenScripts.push(code);
+          return routeJsEval(code, {
+            type: (c) => {
+              expect(c.trim()).toMatch(/^\(\(\) => \{/);
+              expect(c).toContain(
+                "document.execCommand('insertText', false, \"quote ' and newline\\nsafe\")",
+              );
+              return asChromeOutput(JSON.stringify({ ok: true, len: 24 }));
+            },
+            baseline: () => asChromeOutput(JSON.stringify([])),
+            send: (c) => {
+              expect(c.trim()).toMatch(/^\(\(\) => \{/);
+              return asChromeOutput("sent");
+            },
+            poll: (c) => {
+              expect(c.trim()).toMatch(/^\(async \(\) => \{/);
+              return asChromeOutput(
+                JSON.stringify({ images: [], loading: false, text: "done", turns: 1 }),
+              );
+            },
+          });
+        },
+      });
+
+      await vi.runAllTimersAsync();
+      await expect(run).resolves.toMatchObject({ text: "done" });
+      expect(seenScripts.length).toBeGreaterThanOrEqual(4);
+    });
+
     it("detects and extracts large blob-backed generated images without alt or class markers", async () => {
       vi.useFakeTimers();
       const seenScripts: string[] = [];
@@ -29,56 +228,46 @@ describe("gemini-client", () => {
         closeTab: async () => ({ ok: true }),
         jsEval: async (_tabId: number, code: string) => {
           seenScripts.push(code);
-
-          if (promptTyped(code)) {
-            return asChromeOutput(JSON.stringify({ ok: true, len: 21 }));
-          }
-
-          if (baselineCollected(code)) {
-            expect(code).toContain('url.startsWith("blob:")');
-            expect(code).toContain('url.includes("gg-dl")');
-            expect(code).not.toContain("alt");
-            expect(code).not.toContain("className");
-            return asChromeOutput(JSON.stringify([]));
-          }
-
-          if (sendClicked(code)) {
-            return asChromeOutput("sent");
-          }
-
-          if (imagesPolled(code)) {
-            expect(code).toContain('url.startsWith("blob:")');
-            expect(code).toContain("canvas.toDataURL");
-            expect(code).not.toContain("alt");
-            expect(code).not.toContain("className");
-            return asChromeOutput(
-              JSON.stringify({
-                images: [
-                  {
-                    url: "blob:https://gemini.google.com/generated-image",
-                    blobIndex: 0,
-                    type: "image/png",
-                  },
-                ],
-                loading: false,
-                text: "",
-                turns: 1,
-              }),
-            );
-          }
-
-          if (code.includes("window.__surfGeminiBlobImages?.[0]")) {
-            return asChromeOutput(
-              JSON.stringify({
-                chunk: "ZmFrZS1wbmc=",
-                done: true,
-                type: "image/png",
-                url: "blob:https://gemini.google.com/generated-image",
-              }),
-            );
-          }
-
-          throw new Error(`Unexpected script: ${code}`);
+          return routeJsEval(code, {
+            type: () => asChromeOutput(JSON.stringify({ ok: true, len: 21 })),
+            baseline: (c) => {
+              expect(c).toContain('url.startsWith("blob:")');
+              expect(c).toContain('url.includes("gg-dl")');
+              expect(c).not.toContain("alt");
+              expect(c).not.toContain("className");
+              return asChromeOutput(JSON.stringify([]));
+            },
+            send: () => asChromeOutput("sent"),
+            poll: (c) => {
+              expect(c).toContain('url.startsWith("blob:")');
+              expect(c).toContain("canvas.toDataURL");
+              expect(c).not.toContain("alt");
+              expect(c).not.toContain("className");
+              return asChromeOutput(
+                JSON.stringify({
+                  images: [
+                    {
+                      url: "blob:https://gemini.google.com/generated-image",
+                      blobIndex: 0,
+                      type: "image/png",
+                    },
+                  ],
+                  loading: false,
+                  text: "",
+                  turns: 1,
+                }),
+              );
+            },
+            blob: () =>
+              asChromeOutput(
+                JSON.stringify({
+                  chunk: "ZmFrZS1wbmc=",
+                  done: true,
+                  type: "image/png",
+                  url: "blob:https://gemini.google.com/generated-image",
+                }),
+              ),
+          });
         },
       });
 
@@ -106,37 +295,27 @@ describe("gemini-client", () => {
         timeoutMs: 10_000,
         createTab: async () => ({ tabId: 123 }),
         closeTab: async () => ({ ok: true }),
-        jsEval: async (_tabId: number, code: string) => {
-          if (promptTyped(code)) {
-            return asChromeOutput(JSON.stringify({ ok: true, len: 20 }));
-          }
-
-          if (baselineCollected(code)) {
-            return asChromeOutput(JSON.stringify([baselineKey]));
-          }
-
-          if (sendClicked(code)) {
-            return asChromeOutput("sent");
-          }
-
-          if (imagesPolled(code)) {
-            expect(code).toContain(`const baselineKeys = new Set(["${baselineKey}"])`);
-            expect(code).toContain(".filter((img) => !baselineKeys.has(imageKey(img)))");
-            expect(code.indexOf("!baselineKeys.has(imageKey(img))")).toBeLessThan(
-              code.indexOf("canvas.toDataURL"),
-            );
-            return asChromeOutput(
-              JSON.stringify({
-                images: [],
-                loading: false,
-                text: "No new image was generated.",
-                turns: 1,
-              }),
-            );
-          }
-
-          throw new Error(`Unexpected script: ${code}`);
-        },
+        jsEval: async (_tabId: number, code: string) =>
+          routeJsEval(code, {
+            type: () => asChromeOutput(JSON.stringify({ ok: true, len: 20 })),
+            baseline: () => asChromeOutput(JSON.stringify([baselineKey])),
+            send: () => asChromeOutput("sent"),
+            poll: (c) => {
+              expect(c).toContain(`const baselineKeys = new Set(["${baselineKey}"])`);
+              expect(c).toContain(".filter((img) => !baselineKeys.has(imageKey(img)))");
+              expect(c.indexOf("!baselineKeys.has(imageKey(img))")).toBeLessThan(
+                c.indexOf("canvas.toDataURL"),
+              );
+              return asChromeOutput(
+                JSON.stringify({
+                  images: [],
+                  loading: false,
+                  text: "No new image was generated.",
+                  turns: 1,
+                }),
+              );
+            },
+          }),
       });
 
       await vi.runAllTimersAsync();
@@ -160,32 +339,21 @@ describe("gemini-client", () => {
         createTab: async () => ({ tabId: 123 }),
         closeTab: async () => ({ ok: true }),
         fetchUrl,
-        jsEval: async (_tabId: number, code: string) => {
-          if (promptTyped(code)) {
-            return asChromeOutput(JSON.stringify({ ok: true, len: 21 }));
-          }
-
-          if (baselineCollected(code)) {
-            return asChromeOutput(JSON.stringify([]));
-          }
-
-          if (sendClicked(code)) {
-            return asChromeOutput("sent");
-          }
-
-          if (imagesPolled(code)) {
-            return asChromeOutput(
-              JSON.stringify({
-                images: [{ url: "https://lh3.googleusercontent.com/gg-dl/generated" }],
-                loading: false,
-                text: "",
-                turns: 1,
-              }),
-            );
-          }
-
-          throw new Error(`Unexpected script: ${code}`);
-        },
+        jsEval: async (_tabId: number, code: string) =>
+          routeJsEval(code, {
+            type: () => asChromeOutput(JSON.stringify({ ok: true, len: 21 })),
+            baseline: () => asChromeOutput(JSON.stringify([])),
+            send: () => asChromeOutput("sent"),
+            poll: () =>
+              asChromeOutput(
+                JSON.stringify({
+                  images: [{ url: "https://lh3.googleusercontent.com/gg-dl/generated" }],
+                  loading: false,
+                  text: "",
+                  turns: 1,
+                }),
+              ),
+          }),
       });
 
       await vi.runAllTimersAsync();

--- a/test/unit/grok-client.test.ts
+++ b/test/unit/grok-client.test.ts
@@ -309,6 +309,35 @@ pong`,
         ),
       ).resolves.toMatchObject({ text: "pong" });
     });
+
+    it("does not complete from a stale thinking marker while the current response is still changing", async () => {
+      let calls = 0;
+      const result = await grokClient.waitForResponse(
+        async () => {
+          calls++;
+          const currentText = calls < 3 ? "p" : "pong";
+          return {
+            result: {
+              value: {
+                bodyText: `Thought for 4s\nreply with one word\n${currentText}`,
+                responseText: `reply with one word\n${currentText}`,
+                bodyLength: 50 + currentText.length,
+                hasStopBtn: false,
+                thinkingDone: true,
+                thinkingSecs: 4,
+                isThinking: calls < 3,
+                url: "https://x.com/i/grok",
+              },
+            },
+          };
+        },
+        5000,
+        "reply with one word",
+      );
+
+      expect(result.text).toBe("pong");
+      expect(calls).toBe(3);
+    });
   });
 
   describe("getGrokModels", () => {

--- a/test/unit/grok-client.test.ts
+++ b/test/unit/grok-client.test.ts
@@ -5,6 +5,16 @@ const { extractGrokResponse, normalizeGrokModelLabel } = grokClient;
 
 describe("grok-client", () => {
   describe("extractGrokResponse", () => {
+    it("extracts a short non-numeric answer", () => {
+      const bodyText = `Grok
+reply with the word pong. nothing else.
+pong
+Think Harder`;
+
+      const result = extractGrokResponse(bodyText, "reply with the word pong. nothing else.");
+      expect(result).toBe("pong");
+    });
+
     it("extracts simple numeric answer", () => {
       const bodyText = `Home
 Explore
@@ -15,7 +25,9 @@ What is 2+2? Reply with just the number.
 Explain basic arithmetic
 Think Harder`;
 
-      const result = extractGrokResponse(bodyText, "What is 2+2? Reply with just the number.");
+      const result = extractGrokResponse(bodyText, "What is 2+2? Reply with just the number.", [
+        "Explain basic arithmetic",
+      ]);
       expect(result).toBe("4");
     });
 
@@ -30,7 +42,7 @@ Green
 Tell me more
 Think Harder`;
 
-      const result = extractGrokResponse(bodyText, "Name 3 colors");
+      const result = extractGrokResponse(bodyText, "Name 3 colors", ["Tell me more"]);
       expect(result).toBe("Here are 3 colors:\nBlue\nRed\nGreen");
     });
 
@@ -42,7 +54,7 @@ What is 7*8?
 Explain multiplication
 Think Harder`;
 
-      const result = extractGrokResponse(bodyText, "What is 7*8?");
+      const result = extractGrokResponse(bodyText, "What is 7*8?", ["Explain multiplication"]);
       expect(result).toBe("7 × 8 = 56");
     });
 
@@ -57,7 +69,10 @@ What is 5*5?
 Explain multiplication
 Think Harder`;
 
-      const result = extractGrokResponse(bodyText, "What is 5*5?");
+      const result = extractGrokResponse(bodyText, "What is 5*5?", [
+        "Explain basic arithmetic",
+        "Explain multiplication",
+      ]);
       expect(result).toBe("25");
     });
 
@@ -93,8 +108,26 @@ Share greetings in other languages
 Fun icebreaker questions
 Make it more playful`;
 
-      const result = extractGrokResponse(bodyText, "say hello in 3 words");
+      const result = extractGrokResponse(bodyText, "say hello in 3 words", [
+        "Share greetings in other languages",
+        "Fun icebreaker questions",
+        "Make it more playful",
+      ]);
       expect(result).toBe("Hello there, friend!");
+    });
+
+    it("keeps an answer line that coincidentally matches a chip when the real chips still trail it", () => {
+      const bodyText = `Grok
+name a fruit
+Exotic tropical fruits list
+Nutritional benefits of apples
+Exotic tropical fruits list`;
+
+      const result = extractGrokResponse(bodyText, "name a fruit", [
+        "Nutritional benefits of apples",
+        "Exotic tropical fruits list",
+      ]);
+      expect(result).toBe("Exotic tropical fruits list");
     });
 
     it("trims suggested follow-ups without depending on fixed prefixes", () => {
@@ -105,7 +138,10 @@ It's the ratio of a circle's circumference to its diameter
 Compare circle constants
 Derive it geometrically`;
 
-      const result = extractGrokResponse(bodyText, "What is pi?");
+      const result = extractGrokResponse(bodyText, "What is pi?", [
+        "Compare circle constants",
+        "Derive it geometrically",
+      ]);
       expect(result).toBe(
         "Pi is approximately 3.14159\nIt's the ratio of a circle's circumference to its diameter",
       );
@@ -128,6 +164,52 @@ Hello there`;
 
       const result = extractGrokResponse(bodyText, "Give a two-line casual answer");
       expect(result).toBe("Sure thing.\nHello there");
+    });
+
+    it("drops suggestion chips captured as DOM buttons even when the answer is chip-shaped", () => {
+      const bodyText = `Grok
+Reply with exactly this and nothing else: alpha bravo charlie delta echo foxtrot
+alpha bravo charlie delta echo foxtrot
+Explore NATO phonetic alphabet origins
+Learn about military radio procedures`;
+
+      const result = extractGrokResponse(
+        bodyText,
+        "Reply with exactly this and nothing else: alpha bravo charlie delta echo foxtrot",
+        ["Explore NATO phonetic alphabet origins", "Learn about military radio procedures"],
+      );
+      expect(result).toBe("alpha bravo charlie delta echo foxtrot");
+    });
+
+    it("keeps a lone lowercase punctuation-free answer", () => {
+      const bodyText = `Grok
+say the code
+pong ping`;
+
+      const result = extractGrokResponse(bodyText, "say the code");
+      expect(result).toBe("pong ping");
+    });
+
+    it("keeps an answer that matches a chip label, dropping only the trailing chip", () => {
+      const bodyText = `Grok
+Give one action item
+Explore the repository
+Explore the repository`;
+
+      const result = extractGrokResponse(bodyText, "Give one action item", [
+        "Explore the repository",
+      ]);
+      expect(result).toBe("Explore the repository");
+    });
+
+    it("keeps verb-led answer lines that are not DOM chip buttons", () => {
+      const bodyText = `Grok
+Give two action items
+Explore the repository
+Learn the deployment steps`;
+
+      const result = extractGrokResponse(bodyText, "Give two action items", []);
+      expect(result).toBe("Explore the repository\nLearn the deployment steps");
     });
 
     it("returns null for empty body", () => {
@@ -154,7 +236,7 @@ What's 2+2?
 4
 Explain`;
 
-      const result = extractGrokResponse(bodyText, "What's 2+2?");
+      const result = extractGrokResponse(bodyText, "What's 2+2?", ["Explain"]);
       expect(result).toBe("4");
     });
 
@@ -198,6 +280,34 @@ Think Harder`;
 
     it("returns false for non-array", () => {
       expect(grokClient.hasRequiredCookies({} as unknown as [])).toBe(false);
+    });
+  });
+
+  describe("waitForResponse", () => {
+    it("completes when a short extracted answer is stable and generation stopped", async () => {
+      await expect(
+        grokClient.waitForResponse(
+          async () => ({
+            result: {
+              value: {
+                bodyText: `Grok
+reply with the word pong. nothing else.
+pong`,
+                responseText: `reply with the word pong. nothing else.
+pong`,
+                bodyLength: 50,
+                hasStopBtn: false,
+                thinkingDone: false,
+                thinkingSecs: null,
+                isThinking: false,
+                url: "https://x.com/i/grok",
+              },
+            },
+          }),
+          5000,
+          "reply with the word pong. nothing else.",
+        ),
+      ).resolves.toMatchObject({ text: "pong" });
     });
   });
 

--- a/test/unit/host-helpers.test.ts
+++ b/test/unit/host-helpers.test.ts
@@ -130,6 +130,39 @@ describe("mapToolToMessage", () => {
     });
   });
 
+  describe("page.read command", () => {
+    it("maps compact max-bytes to READ_PAGE options", () => {
+      const msg = helpers.mapToolToMessage("page.read", {
+        compact: true,
+        "max-bytes": "1200",
+        depth: "2",
+      });
+      expect(msg).toMatchObject({
+        type: "READ_PAGE",
+        options: {
+          compact: true,
+          maxBytes: 1200,
+          depth: 2,
+          forceFullSnapshot: true,
+        },
+      });
+    });
+
+    it("throws when max-bytes is not a positive integer", () => {
+      for (const bad of ["abc", "0", "-5", "12abc", "1.5", " ", ""]) {
+        expect(() => helpers.mapToolToMessage("page.read", { "max-bytes": bad })).toThrow(
+          /max-bytes must be a positive integer/,
+        );
+      }
+    });
+
+    it("accepts a valid positive integer max-bytes", () => {
+      const msg = helpers.mapToolToMessage("page.read", { "max-bytes": "1200" });
+      expect(msg.options.maxBytes).toBe(1200);
+      expect(msg.options.forceFullSnapshot).toBe(true);
+    });
+  });
+
   describe("screenshot commands", () => {
     it("maps full-page to fullpage", () => {
       const msg = helpers.mapToolToMessage("screenshot", { "full-page": true });

--- a/test/unit/host-helpers.test.ts
+++ b/test/unit/host-helpers.test.ts
@@ -208,6 +208,13 @@ describe("mapToolToMessage", () => {
     });
   });
 
+  describe("zoom command", () => {
+    it("maps zoom level to ZOOM_SET", () => {
+      const msg = helpers.mapToolToMessage("zoom", { level: "1.5" }, 123);
+      expect(msg).toMatchObject({ type: "ZOOM_SET", level: 1.5, tabId: 123 });
+    });
+  });
+
   describe("scroll commands", () => {
     it("maps direction and amount flags to scroll deltas", () => {
       const msg = helpers.mapToolToMessage("scroll", { direction: "down", amount: 4 }, 123);

--- a/test/unit/host-helpers.test.ts
+++ b/test/unit/host-helpers.test.ts
@@ -90,6 +90,20 @@ describe("mapToolToMessage", () => {
       expect(msg.type).toBe("NEW_TAB");
       expect(msg.url).toBe("https://example.com");
     });
+
+    it("maps tab.move to TAB_MOVE", () => {
+      const msg = helpers.mapToolToMessage("tab.move", {
+        id: "123",
+        "to-window": "456",
+        index: "0",
+      });
+      expect(msg).toMatchObject({
+        type: "TAB_MOVE",
+        tabId: "123",
+        windowId: "456",
+        index: "0",
+      });
+    });
   });
 
   describe("aistudio commands", () => {

--- a/test/unit/host-helpers.test.ts
+++ b/test/unit/host-helpers.test.ts
@@ -163,6 +163,47 @@ describe("mapToolToMessage", () => {
     });
   });
 
+  describe("type command", () => {
+    it("routes a selector target to SMART_TYPE", () => {
+      const msg = helpers.mapToolToMessage("type", { text: "hello", selector: "#i" });
+      expect(msg.type).toBe("SMART_TYPE");
+      expect(msg.selector).toBe("#i");
+      expect(msg.text).toBe("hello");
+      expect(msg.clear).toBe(true);
+      expect(msg.submit).toBe(false);
+    });
+
+    it("routes an --into target to SMART_TYPE without CLI normalization", () => {
+      const msg = helpers.mapToolToMessage("type", { text: "hello", into: "#target" });
+      expect(msg.type).toBe("SMART_TYPE");
+      expect(msg.selector).toBe("#target");
+    });
+
+    it("honors submit and clear flags on a selector target", () => {
+      const msg = helpers.mapToolToMessage("type", {
+        text: "hello",
+        selector: "#i",
+        clear: false,
+        submit: true,
+      });
+      expect(msg.type).toBe("SMART_TYPE");
+      expect(msg.clear).toBe(false);
+      expect(msg.submit).toBe(true);
+    });
+
+    it("uses FORM_FILL for a ref target", () => {
+      const msg = helpers.mapToolToMessage("type", { text: "hello", ref: "e1" });
+      expect(msg.type).toBe("FORM_FILL");
+      expect(msg.data).toEqual([{ ref: "e1", value: "hello" }]);
+    });
+
+    it("falls back to cursor typing with no target", () => {
+      const msg = helpers.mapToolToMessage("type", { text: "hello" });
+      expect(msg.type).toBe("EXECUTE_TYPE");
+      expect(msg.text).toBe("hello");
+    });
+  });
+
   describe("screenshot commands", () => {
     it("maps full-page to fullpage", () => {
       const msg = helpers.mapToolToMessage("screenshot", { "full-page": true });

--- a/test/unit/perplexity-client.test.ts
+++ b/test/unit/perplexity-client.test.ts
@@ -1,0 +1,79 @@
+// @ts-expect-error - CommonJS module without type definitions
+import * as perplexityClient from "../../native/perplexity-client.cjs";
+
+type FakeEl = { innerText: string };
+
+function withFakeDom(matches: Record<string, string[]>, run: () => void): void {
+  const doc = {
+    querySelectorAll(selector: string): FakeEl[] {
+      return (matches[selector] || []).map((innerText) => ({ innerText }));
+    },
+  };
+  const prev = (globalThis as { document?: unknown }).document;
+  (globalThis as { document?: unknown }).document = doc;
+  try {
+    run();
+  } finally {
+    (globalThis as { document?: unknown }).document = prev;
+  }
+}
+
+describe("perplexity-client", () => {
+  describe("extractPerplexityResponseText", () => {
+    it("prefers the answer container over individual prose sub-blocks", () => {
+      withFakeDom(
+        {
+          '[id^="markdown-content"]': [
+            "Ganymede is largest.\nCallisto is cratered.\nIo is volcanic.",
+          ],
+          ".prose": ["Ganymede is largest.", "Callisto is cratered.", "Io is volcanic."],
+        },
+        () => {
+          expect(perplexityClient.extractPerplexityResponseText()).toBe(
+            "Ganymede is largest.\nCallisto is cratered.\nIo is volcanic.",
+          );
+        },
+      );
+    });
+
+    it("returns the most recent answer when multiple containers exist", () => {
+      withFakeDom({ '[id^="markdown-content"]': ["first answer", "second answer"] }, () => {
+        expect(perplexityClient.extractPerplexityResponseText()).toBe("second answer");
+      });
+    });
+
+    it("falls back to prose when no answer container is present", () => {
+      withFakeDom({ ".prose": ["only prose block"] }, () => {
+        expect(perplexityClient.extractPerplexityResponseText()).toBe("only prose block");
+      });
+    });
+  });
+
+  describe("waitForResponse", () => {
+    it("completes when a short response is no longer generating", async () => {
+      await expect(
+        perplexityClient.waitForResponse(async (expr: string) => {
+          if (expr === "location.href") {
+            return { result: { value: "https://www.perplexity.ai/search/test" } };
+          }
+          return {
+            result: {
+              value: {
+                text: "pong",
+                generating: false,
+                hasActions: true,
+                hasRelated: false,
+                hasFollowUp: false,
+                sourcesCount: 0,
+                url: "https://www.perplexity.ai/search/test",
+              },
+            },
+          };
+        }, 5000),
+      ).resolves.toMatchObject({
+        text: "pong",
+        sources: 0,
+      });
+    });
+  });
+});

--- a/test/unit/service-worker/tab-handlers.test.ts
+++ b/test/unit/service-worker/tab-handlers.test.ts
@@ -31,16 +31,59 @@ describe("tab handlers", () => {
     expect(result).toEqual({ success: true, name: "work", tabId: 123 });
   });
 
-  it("rejects registration when the active tab is chrome:// or extension URL", async () => {
+  it.each([
+    "chrome://settings/",
+    "edge://settings/",
+    "brave://settings/",
+    "arc://settings/",
+    "helium://settings/",
+    "chrome-extension://abc/page.html",
+    "about:blank",
+  ])("rejects registration for restricted URL %s", async (url) => {
     const handleMessage = await loadHandleMessage();
     const chrome = (globalThis as any).chrome;
-    chrome.tabs.query.mockResolvedValue([
-      { id: 999, url: "chrome://settings/", active: true, windowId: 1 },
-    ]);
+    chrome.tabs.query.mockResolvedValue([{ id: 999, url, active: true, windowId: 1 }]);
 
     await expect(handleMessage({ type: "TABS_REGISTER", name: "settings" }, {})).rejects.toThrow(
-      /chrome:\/\/ or extension tab/,
+      /restricted browser or extension page/,
     );
+  });
+
+  it("routes selector typing to the selected iframe", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    chrome.webNavigation.getAllFrames.mockResolvedValue([
+      { frameId: 0, parentFrameId: -1, url: "https://example.com/" },
+      { frameId: 7, parentFrameId: 0, url: "https://example.com/frame" },
+    ]);
+
+    await handleMessage({ type: "FRAME_SWITCH", tabId: 123, index: 0 }, {});
+    chrome.tabs.sendMessage.mockResolvedValue({ success: true, contentEditable: false });
+
+    const result = await handleMessage(
+      {
+        type: "SMART_TYPE",
+        tabId: 123,
+        selector: "#card-number",
+        text: "4242",
+        clear: true,
+        submit: false,
+      },
+      {},
+    );
+
+    expect(chrome.tabs.sendMessage).toHaveBeenLastCalledWith(
+      123,
+      {
+        type: "SMART_TYPE",
+        selector: "#card-number",
+        text: "4242",
+        clear: true,
+        submit: false,
+      },
+      { frameId: 7 },
+    );
+    expect(result).toEqual({ success: true, contentEditable: false });
   });
 
   it("moves tabs to the destination window", async () => {

--- a/test/unit/service-worker/tab-handlers.test.ts
+++ b/test/unit/service-worker/tab-handlers.test.ts
@@ -42,4 +42,23 @@ describe("tab handlers", () => {
       /chrome:\/\/ or extension tab/,
     );
   });
+
+  it("moves tabs to the destination window", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    chrome.tabs.move.mockResolvedValue([{ id: 123, windowId: 456, index: 0 }]);
+
+    const result = await handleMessage(
+      { type: "TAB_MOVE", tabIds: "123,124", windowId: "456", index: "0" },
+      {},
+    );
+
+    expect(chrome.tabs.move).toHaveBeenCalledWith([123, 124], { windowId: 456, index: 0 });
+    expect(result).toMatchObject({
+      success: true,
+      moved: [123, 124],
+      destinationWindowId: 456,
+      index: 0,
+    });
+  });
 });

--- a/test/unit/service-worker/tab-handlers.test.ts
+++ b/test/unit/service-worker/tab-handlers.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createChromeMock, resetChromeMock } from "../../mocks/chrome";
+
+vi.mock("../../../src/native/port-manager", () => ({
+  initNativeMessaging: vi.fn(),
+  postToNativeHost: vi.fn(),
+}));
+
+async function loadHandleMessage() {
+  vi.resetModules();
+  (globalThis as any).chrome = createChromeMock();
+  const mod = await import("../../../src/service-worker/index");
+  return mod.handleMessage;
+}
+
+describe("tab handlers", () => {
+  beforeEach(() => {
+    resetChromeMock();
+  });
+
+  it("registers the active tab when tabId is omitted", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    chrome.tabs.query.mockResolvedValue([
+      { id: 123, url: "https://example.com/", active: true, windowId: 1 },
+    ]);
+
+    const result = await handleMessage({ type: "TABS_REGISTER", name: "work" }, {});
+
+    expect(chrome.tabs.query).toHaveBeenCalledWith({ active: true, lastFocusedWindow: true });
+    expect(result).toEqual({ success: true, name: "work", tabId: 123 });
+  });
+
+  it("rejects registration when the active tab is chrome:// or extension URL", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    chrome.tabs.query.mockResolvedValue([
+      { id: 999, url: "chrome://settings/", active: true, windowId: 1 },
+    ]);
+
+    await expect(handleMessage({ type: "TABS_REGISTER", name: "settings" }, {})).rejects.toThrow(
+      /chrome:\/\/ or extension tab/,
+    );
+  });
+});


### PR DESCRIPTION
This PR fixes a set of bugs in existing functionality across the provider clients (Perplexity, Grok, Gemini) and several browser commands (`tab.name`, `tab.move`, `zoom`, `page.read`, `type`). Each is an independent, conventional commit, so the branch reads as nine focused changes with no cross-cutting refactors.

Also, thank you for building surf. It has quietly become the workhorse of my testing sessions, and at this point my agents reach for it on instinct. Know there's a lot in this PR, but these were all bugs I ran into in my day to day usage :)

## What's fixed

**Providers**
- `perplexity`: settle completion on stable non-generating responses, and extract the full answer container instead of a single nested prose block. Multi-part answers (lists, step-by-step, "one fact about each") were truncating to just the last line because the current UI renders one answer as many sibling `.prose` blocks inside a `#markdown-content` container.
- `grok`: strip trailing follow-up suggestion chips from the answer, without dropping a legitimate final line that happens to match a chip label elsewhere on the page.
- `gemini`: harden stream response parsing and generated-image extraction; refresh the model list and warn once on an unknown `--model` before falling back to `gemini-3.1-pro`.

**Commands**
- `tab.name`: reject `chrome://` and extension tabs in the active-tab fallback instead of registering an unusable tab.
- `tab.move`: new command to move a tab (or several) to another window.
- `zoom --level`: preserve the requested level through stream option cleanup.
- `page.read --max-bytes`: cap visible text with UTF-8-safe truncation.
- `type --into`: fill the target selector instead of leaving only the first character.

## Testing

- 414 unit tests pass; typecheck and lint are clean.
- Live-verified end to end against real logged-in sessions: the Perplexity, Grok, and Gemini paths, plus the full command surface (`tab.*`, `zoom`, `page.read --max-bytes`, `type --into`, navigation, scrolling, page inspection, locate, search, waits, cookies, emulation, frames, perf, history, windows).
- Verified on both Google Chrome and Microsoft Edge as the host browser.
