### PR TITLE
feat: add Tailnet remote browser endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- **Authenticated Tailnet remote control** - Added mutually authenticated per-client remote access with Ed25519 host pinning, authorize/list/revoke lifecycle, shared local/remote FIFO serialization, disconnect cancellation, bounded single-file transfer, explicit `local:`/`remote:` path semantics, remote AI attachments and image outputs, network export, and transferred action/error screenshots. Thanks to @alvinunreal for the original remote-browser contribution in #155.
 - **Deep X Research skill** - Added `skills/deep-x-research/`, an agent skill that layers an exhaustive X (Twitter) research procedure on top of `surf grok`: a quota-budgeted multi-angle Grok sweep (keyword + semantic, with DeepSearch), Grok-native video analysis, quota-free URL verification via direct post opens, categorized findings, and a References section where every cited post carries its full post URL. Falls back to the x.com search UI when the Grok quota is exhausted.
 - **Tab movement** - Added `surf tab.move <id> --to-window <id>` with multi-tab and insertion-index support. (@zm2231, #148)
 - **Page text byte limit** - Added `page.read --max-bytes <n>` for UTF-8-safe visible-text truncation without changing the existing default limit. (@zm2231, #148)

--- a/README.md
+++ b/README.md
@@ -110,27 +110,43 @@ surf uninstall --target linux   # Remove WSLg/Linux-browser config from WSL2
 
 ### Remote Surf over Tailscale
 
-Run the browser and native host on a Mac in your Tailnet, then point a client at it. The native host is still launched by—and lives only while—the browser extension's native-messaging connection is alive.
+Remote Surf runs the browser and native host on one Tailnet machine while the CLI runs on another. The listener is available only while the browser extension's native-messaging connection is alive. Tailnet reachability is not authorization: every remote client also needs its own Surf credential.
 
-On the browser Mac, install with its explicit Tailnet IP and the TCP port to bind:
+On the browser host, authorize a client before installing the listener:
 
 ```bash
+surf remote authorize agent-macbook --output ~/agent-macbook.surf-credential.json
+surf remote list
 surf install <extension-id> --listen 100.101.102.103:4321
 ```
 
-This persists `SURF_LISTEN=100.101.102.103:4321` in the installed native-host wrapper. Re-run `surf install` without `--listen` to remove that persisted setting. `SURF_LISTEN` must be a host-and-port Tailnet address; Surf binds that explicit Tailnet IP only, not every interface. `tailscale serve` is not required.
+`authorize` creates a mode-0600 credential containing the client's Ed25519 private identity and the pinned host identity. Move it to that client through an existing secure channel, then remove the generated copy from the host if it is no longer needed there. The host keeps only the client's public identity in `~/.surf/remote/remote-clients.json`.
 
-From an authorized Tailnet client:
+From the authorized client:
 
 ```bash
-surf --remote 100.101.102.103:4321 tab.list
-# or
-SURF_REMOTE=100.101.102.103:4321 surf tab.list
+surf --remote 100.101.102.103:4321 \
+  --remote-credential ~/.config/surf/agent-macbook.json \
+  tab.list
+
+# Environment equivalent
+SURF_REMOTE=100.101.102.103:4321 \
+SURF_REMOTE_CREDENTIAL=~/.config/surf/agent-macbook.json \
+  surf tab.list
 ```
 
-`--remote <host>:<port>` takes precedence over `SURF_REMOTE`, which takes precedence over `SURF_SOCKET` and the default local socket. Existing local Unix-socket/named-pipe transport remains available when no remote endpoint is selected.
+Surf performs mutual Ed25519 challenge-response with fresh nonces and checks authorization throughout the connection. A credential grants the same browser and host-file authority as a trusted local Surf user. Give each client its own credential, do not share it, and revoke it immediately if the client or file is lost:
 
-Restrict access in your Tailscale policy to the intended source and TCP port. For example, an ACL policy can allow only an agent tag to reach a Mac tag on Surf's port:
+```bash
+surf remote revoke agent-macbook
+surf remote list
+```
+
+`--remote <host>:<port>` takes precedence over `SURF_REMOTE`; `--remote-credential` takes precedence over `SURF_REMOTE_CREDENTIAL`. A selected remote endpoint overrides `SURF_SOCKET` and the default local socket. Local and remote requests share one bounded FIFO browser lease, so they cannot race each other. Disconnects and timeouts abort queued or in-flight work and hold the lease until request-owned cleanup drains or the hard deadline is reached. Browser side effects that already completed are not rolled back.
+
+`surf install --listen` persists the explicit Tailnet address in the native-host wrapper. Re-run `surf install` without `--listen` to remove it. The address must be a Tailscale IPv4 or IPv6 address with a port; Surf does not bind every interface. Remote listeners currently require a POSIX browser host and are not supported by Windows native-host wrappers.
+
+Keep Tailscale policy restrictions as defense in depth. For example:
 
 ```json
 {
@@ -144,21 +160,35 @@ Restrict access in your Tailscale policy to the intended source and TCP port. Fo
 }
 ```
 
-Adapt tags and port to your Tailnet. Do not assume the default Tailnet policy is restrictive: it may allow much broader device-to-device access. This is raw TCP protected by Tailnet policy—Surf adds no SSH tunnel, TLS, or Surf authentication.
+Adapt tags and ports to your Tailnet. Surf authentication does not replace Tailnet policy, and Surf does not add a separate TLS or SSH tunnel.
 
 **Operations and troubleshooting**
 
 ```bash
 tailscale status
 tailscale ping 100.101.102.103
-surf doctor --remote 100.101.102.103:4321
+surf doctor --remote 100.101.102.103:4321 \
+  --remote-credential ~/.config/surf/agent-macbook.json
 ```
 
-Use `tailscale status` and `tailscale ping` to confirm Tailnet reachability, then run remote `doctor` to diagnose the selected remote endpoint.
+Use `tailscale status` and `tailscale ping` to confirm reachability, then use `doctor` to verify endpoint selection and authentication.
 
-**Remote filesystem semantics**
+**Remote filesystem and transfer semantics**
 
-There is no file transfer. `surf js --file script.js` is read by the client CLI, so `script.js` stays local. Paths acted on by the browser host are paths on the remote Mac: screenshot `--output` (including its default `/tmp` location), `upload --files`, AI attachment `--file` options, and output paths for `network.export`, Gemini image operations, and AI Studio build extraction. `perf-audit --output` is written by the client. `record` is intentionally rejected for remote endpoints and produces no remote output. Ensure host-side input/output paths exist on the remote Mac.
+Unprefixed paths and `local:` paths refer to the client. Only `remote:/absolute/path` refers directly to the browser host. For example:
+
+```bash
+surf --remote "$SURF_REMOTE" --remote-credential "$SURF_REMOTE_CREDENTIAL" \
+  upload --ref e5 --files ./client-file.pdf
+surf --remote "$SURF_REMOTE" --remote-credential "$SURF_REMOTE_CREDENTIAL" \
+  screenshot --output local:./shot.png
+surf --remote "$SURF_REMOTE" --remote-credential "$SURF_REMOTE_CREDENTIAL" \
+  network.export --output remote:/var/tmp/network.har --har
+```
+
+Client-local inputs are staged privately on the host and removed after the request. Client-local outputs are downloaded with size/hash verification and atomic destination replacement. `surf js --file` and `perf-audit --output` are handled by the client itself. `network.export` defaults to a generated client-local `.json`, `.jsonl`, or `.har` path. Gemini edits default to client-local `edited.png`. Successful remote actions transfer their automatic screenshot to a generated client-local path; `--auto-capture` on failure remains a separate screenshot and console diagnostic.
+
+The remote single-file boundary supports one `upload` file, one ChatGPT attachment, or one Gemini attachment/edit input, plus one screenshot, network export, or Gemini image output. Transfers are limited to 256 MiB per file, 512 MiB and 32 files per connection, with 256 KiB decoded chunks. Remote `record`, `aistudio.build`, smoke screenshot directories, directory transfer, and multi-file inputs are intentionally rejected. A `remote:` path bypasses transfer and gives the trusted client direct authority over that absolute host path.
 
 ### Development Setup
 
@@ -666,6 +696,8 @@ surf workflow.validate ./my-workflow.json
 SURF_NETWORK_PATH         # Path for network capture logs (default: /tmp/surf)
 SURF_SOCKET               # Socket path or named pipe (default: /tmp/surf.sock, Windows: //./pipe/surf)
 SURF_REMOTE               # Remote Surf endpoint as host:port (overrides SURF_SOCKET)
+SURF_REMOTE_CREDENTIAL    # Client Ed25519 credential for the selected remote endpoint
+SURF_REMOTE_STATE_DIR     # Host identity/authorization directory (default: ~/.surf/remote)
 SURF_LISTEN               # Native-host Tailnet bind address as <tailscale-ip>:<port>
 SURF_NODE_PATH            # Path to node binary (for native host wrapper)
 SURF_HOST_PATH            # Path to native/host.cjs (for native host wrapper)
@@ -675,6 +707,8 @@ SURF_EXTENSION_PATH       # Path to extension dist/ directory
 **Use cases:**
 - `SURF_SOCKET`: Advanced socket override. Set it for both the native host and CLI if you need a non-default socket, including separate sockets for separate browser/profile instances in hard-isolated multi-agent workflows. Each socket gets an independent request lock.
 - `SURF_REMOTE`: Remote client endpoint. `--remote <host>:<port>` overrides it; both override `SURF_SOCKET`.
+- `SURF_REMOTE_CREDENTIAL`: Credential used for mutual remote authentication. `--remote-credential <path>` overrides it.
+- `SURF_REMOTE_STATE_DIR`: Advanced host-side override for the mode-0700 identity and client registry directory.
 - `SURF_LISTEN`: Native-host listener address on the browser machine. Use `surf install ... --listen <tailscale-ip>:<port>` to persist it in that host's wrapper.
 - `SURF_NODE_PATH` / `SURF_HOST_PATH`: Package manager installs (e.g., Nix) that store binaries in non-standard locations
 - `SURF_EXTENSION_PATH`: Package managers that create stable symlinks instead of changing paths on reinstall

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Surf takes a different approach:
 |---------|------|-------|------------------|--------------|-------------|
 | Agent-agnostic | Yes | No (Manus only) | No (Claude only) | Partial | No (Claude skill) |
 | Zero config | Yes | No (subscription) | No (subscription) | No (MCP setup) | No (relay server) |
-| Local-only | Yes | No (cloud) | Partial | Yes | Partial |
+| Self-hosted (local or Tailnet) | Yes | No (cloud) | Partial | Yes | Partial |
 | CLI interface | Yes | No | No | No | No |
 | Free | Yes | No | No | Yes | Yes |
 | AI via browser cookies | Yes | No | No | No | No |
@@ -107,6 +107,58 @@ surf uninstall                  # Chrome only
 surf uninstall --all            # All browsers + wrapper files
 surf uninstall --target linux   # Remove WSLg/Linux-browser config from WSL2
 ```
+
+### Remote Surf over Tailscale
+
+Run the browser and native host on a Mac in your Tailnet, then point a client at it. The native host is still launched by—and lives only while—the browser extension's native-messaging connection is alive.
+
+On the browser Mac, install with its explicit Tailnet IP and the TCP port to bind:
+
+```bash
+surf install <extension-id> --listen 100.101.102.103:4321
+```
+
+This persists `SURF_LISTEN=100.101.102.103:4321` in the installed native-host wrapper. Re-run `surf install` without `--listen` to remove that persisted setting. `SURF_LISTEN` must be a host-and-port Tailnet address; Surf binds that explicit Tailnet IP only, not every interface. `tailscale serve` is not required.
+
+From an authorized Tailnet client:
+
+```bash
+surf --remote 100.101.102.103:4321 tab.list
+# or
+SURF_REMOTE=100.101.102.103:4321 surf tab.list
+```
+
+`--remote <host>:<port>` takes precedence over `SURF_REMOTE`, which takes precedence over `SURF_SOCKET` and the default local socket. Existing local Unix-socket/named-pipe transport remains available when no remote endpoint is selected.
+
+Restrict access in your Tailscale policy to the intended source and TCP port. For example, an ACL policy can allow only an agent tag to reach a Mac tag on Surf's port:
+
+```json
+{
+  "acls": [
+    {
+      "action": "accept",
+      "src": ["tag:surf-agent"],
+      "dst": ["tag:surf-browser:4321"]
+    }
+  ]
+}
+```
+
+Adapt tags and port to your Tailnet. Do not assume the default Tailnet policy is restrictive: it may allow much broader device-to-device access. This is raw TCP protected by Tailnet policy—Surf adds no SSH tunnel, TLS, or Surf authentication.
+
+**Operations and troubleshooting**
+
+```bash
+tailscale status
+tailscale ping 100.101.102.103
+surf doctor --remote 100.101.102.103:4321
+```
+
+Use `tailscale status` and `tailscale ping` to confirm Tailnet reachability, then run remote `doctor` to diagnose the selected remote endpoint.
+
+**Remote filesystem semantics**
+
+There is no file transfer. `surf js --file script.js` is read by the client CLI, so `script.js` stays local. Paths acted on by the browser host are paths on the remote Mac: screenshot `--output` (including its default `/tmp` location), `upload --files`, AI attachment `--file` options, and output paths for `network.export`, Gemini image operations, and AI Studio build extraction. `perf-audit --output` is written by the client. `record` is intentionally rejected for remote endpoints and produces no remote output. Ensure host-side input/output paths exist on the remote Mac.
 
 ### Development Setup
 
@@ -613,6 +665,8 @@ surf workflow.validate ./my-workflow.json
 ```bash
 SURF_NETWORK_PATH         # Path for network capture logs (default: /tmp/surf)
 SURF_SOCKET               # Socket path or named pipe (default: /tmp/surf.sock, Windows: //./pipe/surf)
+SURF_REMOTE               # Remote Surf endpoint as host:port (overrides SURF_SOCKET)
+SURF_LISTEN               # Native-host Tailnet bind address as <tailscale-ip>:<port>
 SURF_NODE_PATH            # Path to node binary (for native host wrapper)
 SURF_HOST_PATH            # Path to native/host.cjs (for native host wrapper)
 SURF_EXTENSION_PATH       # Path to extension dist/ directory
@@ -620,6 +674,8 @@ SURF_EXTENSION_PATH       # Path to extension dist/ directory
 
 **Use cases:**
 - `SURF_SOCKET`: Advanced socket override. Set it for both the native host and CLI if you need a non-default socket, including separate sockets for separate browser/profile instances in hard-isolated multi-agent workflows. Each socket gets an independent request lock.
+- `SURF_REMOTE`: Remote client endpoint. `--remote <host>:<port>` overrides it; both override `SURF_SOCKET`.
+- `SURF_LISTEN`: Native-host listener address on the browser machine. Use `surf install ... --listen <tailscale-ip>:<port>` to persist it in that host's wrapper.
 - `SURF_NODE_PATH` / `SURF_HOST_PATH`: Package manager installs (e.g., Nix) that store binaries in non-standard locations
 - `SURF_EXTENSION_PATH`: Package managers that create stable symlinks instead of changing paths on reinstall
 

--- a/native/abort.cjs
+++ b/native/abort.cjs
@@ -1,0 +1,65 @@
+class RequestAbortError extends Error {
+  constructor(message = "Request cancelled") {
+    super(message);
+    this.name = "RequestAbortError";
+    this.code = "SURF_REQUEST_ABORTED";
+  }
+}
+
+function abortError(signal, fallback = "Request cancelled") {
+  if (signal?.reason instanceof Error && signal.reason.name !== "AbortError") return signal.reason;
+  return new RequestAbortError(fallback);
+}
+
+function throwIfAborted(signal, fallback) {
+  if (signal?.aborted) throw abortError(signal, fallback);
+}
+
+function raceAbort(promiseOrFactory, signal, fallback) {
+  if (!signal) return typeof promiseOrFactory === "function" ? promiseOrFactory() : promiseOrFactory;
+  throwIfAborted(signal, fallback);
+  const promise = typeof promiseOrFactory === "function" ? promiseOrFactory() : promiseOrFactory;
+  if (signal.aborted) return Promise.reject(abortError(signal, fallback));
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const onAbort = () => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener("abort", onAbort);
+      reject(abortError(signal, fallback));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    Promise.resolve(promise).then(
+      (value) => {
+        if (settled) return;
+        settled = true;
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error) => {
+        if (settled) return;
+        settled = true;
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
+function abortableDelay(ms, signal, fallback) {
+  throwIfAborted(signal, fallback);
+  return new Promise((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+      reject(abortError(signal, fallback));
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+module.exports = { RequestAbortError, abortError, abortableDelay, raceAbort, throwIfAborted };

--- a/native/ai-queue.cjs
+++ b/native/ai-queue.cjs
@@ -1,0 +1,64 @@
+const { abortError } = require("./abort.cjs");
+
+class BoundedAiQueue {
+  constructor({ maxQueued = 8, spacingMs = 2000, audit = () => {}, run = (handler) => handler() } = {}) {
+    this.maxQueued = maxQueued;
+    this.spacingMs = spacingMs;
+    this.audit = audit;
+    this.run = run;
+    this.items = [];
+    this.active = false;
+  }
+
+  enqueue(handler, request) {
+    return new Promise((resolve, reject) => {
+      if (request?.signal.aborted) {
+        reject(abortError(request.signal));
+        return;
+      }
+      if (this.items.length >= this.maxQueued) {
+        reject(new Error("AI request queue is full"));
+        return;
+      }
+      const item = { handler, request, resolve, reject, abortCleanup: null };
+      const onAbort = () => {
+        const index = this.items.indexOf(item);
+        if (index === -1) return;
+        this.items.splice(index, 1);
+        item.abortCleanup = null;
+        reject(abortError(request.signal));
+        this.audit({ event: "request", context: request.context, request, outcome: "queued-cancel" });
+      };
+      if (request?.signal) {
+        request.signal.addEventListener("abort", onAbort, { once: true });
+        item.abortCleanup = () => request.signal.removeEventListener("abort", onAbort);
+      }
+      this.items.push(item);
+      this.#process();
+    });
+  }
+
+  get queued() {
+    return this.items.length;
+  }
+
+  async #process() {
+    if (this.active || this.items.length === 0) return;
+    this.active = true;
+    const item = this.items.shift();
+    item.abortCleanup?.();
+    try {
+      if (item.request?.signal.aborted) throw abortError(item.request.signal);
+      const result = await this.run(item.handler, item.request);
+      if (item.request?.signal.aborted) throw abortError(item.request.signal);
+      item.resolve(result);
+    } catch (error) {
+      item.reject(error);
+    } finally {
+      this.active = false;
+      setTimeout(() => this.#process(), this.spacingMs);
+    }
+  }
+}
+
+module.exports = { BoundedAiQueue };

--- a/native/aistudio-build.cjs
+++ b/native/aistudio-build.cjs
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const { raceAbort, throwIfAborted } = require("./abort.cjs");
 const { execFileSync } = require("child_process");
 const {
   delay,
@@ -483,26 +484,29 @@ async function build({
   cdpCommand,
   searchDownloads,
   log = () => {},
+  signal,
 }) {
+  throwIfAborted(signal);
+  const guardedSearchDownloads = (...args) => raceAbort(() => searchDownloads(...args), signal);
   const startedAt = Date.now();
   const timeoutMs = Number.isFinite(timeout) ? timeout : 600000;
   const requestedModel = normalizeModelString(model || "");
   const resolvedModel = requestedModel || DEFAULT_MODEL;
 
-  const cookieResult = await getCookies();
+  const cookieResult = await raceAbort(getCookies, signal);
   const cookies = cookieResult?.cookies || [];
   if (!hasRequiredCookies(cookies)) {
     throw new Error("Sign into Google in Chrome first.");
   }
 
-  const tabInfo = await createTab(AISTUDIO_APPS_URL);
+  const tabInfo = await raceAbort(() => createTab(AISTUDIO_APPS_URL), signal);
   const tabId = tabInfo?.tabId;
   if (!tabId) {
     throw new Error(`Failed to create AI Studio tab: ${JSON.stringify(tabInfo)}`);
   }
 
-  const cdp = (expression) => cdpEvaluate(tabId, expression);
-  const inputCdp = (method, params) => cdpCommand(tabId, method, params);
+  const cdp = (expression) => raceAbort(() => cdpEvaluate(tabId, expression), signal);
+  const inputCdp = (method, params) => raceAbort(() => cdpCommand(tabId, method, params), signal);
 
   let buildDuration = null;
   let zipPath = null;
@@ -510,7 +514,7 @@ async function build({
   let modelUsed = resolvedModel;
 
   try {
-    await waitForBuildPageReady(cdp, 30000);
+    await raceAbort(waitForBuildPageReady(cdp, 30000), signal);
 
     if (requestedModel) {
       const applied = await selectModelInAdvancedSettings(cdp, inputCdp, requestedModel, log);
@@ -518,20 +522,20 @@ async function build({
     }
 
     await typePromptAndBuild(cdp, inputCdp, prompt);
-    const completion = await waitForBuildCompletion(cdp, timeoutMs, log);
+    const completion = await raceAbort(waitForBuildCompletion(cdp, timeoutMs, log), signal);
     buildDuration = completion.buildDuration;
 
-    await activateCodeTab(cdp, inputCdp);
-    await waitForDownloadButton(cdp, 5000);
+    await raceAbort(activateCodeTab(cdp, inputCdp), signal);
+    await raceAbort(waitForDownloadButton(cdp, 5000), signal);
 
-    const beforeDownloads = await searchDownloads({
+    const beforeDownloads = await guardedSearchDownloads({
       limit: 1,
       orderBy: ["-startTime"],
     });
     const latestIdBefore = beforeDownloads?.[0]?.id || 0;
 
-    await clickDownloadButton(cdp);
-    zipPath = await waitForDownloadComplete(searchDownloads, latestIdBefore, 30000);
+    await raceAbort(clickDownloadButton(cdp), signal);
+    zipPath = await waitForDownloadComplete(guardedSearchDownloads, latestIdBefore, 30000);
 
     if (output) {
       const outputDir = String(output);
@@ -553,8 +557,12 @@ async function build({
       tookMs: Date.now() - startedAt,
     };
   } finally {
-    if (!keepOpen) {
-      await closeTab(tabId).catch(() => {});
+    if (!keepOpen || signal?.aborted) {
+      try {
+        await closeTab(tabId);
+      } catch (error) {
+        log(`Failed to close AI Studio Build tab ${tabId}: ${error?.message || error}`);
+      }
     }
   }
 }

--- a/native/aistudio-client.cjs
+++ b/native/aistudio-client.cjs
@@ -33,6 +33,7 @@ const {
   waitForGenerateResponseFromNetwork,
   waitForResponse,
 } = require("./aistudio-response.cjs");
+const { raceAbort, throwIfAborted } = require("./abort.cjs");
 
 const DEFAULT_MODEL = "gemini-3.1-pro-preview";
 
@@ -310,22 +311,27 @@ async function query(options) {
     cdpCommand,
     readNetworkEntries,
     log = () => {},
+    signal,
   } = options;
+  throwIfAborted(signal);
 
+  const guardedReadNetworkEntries = readNetworkEntries
+    ? (...args) => raceAbort(() => readNetworkEntries(...args), signal)
+    : readNetworkEntries;
   const startTime = Date.now();
   log("Starting AI Studio query");
 
   const resolvedModel = normalizeModelString(model) || DEFAULT_MODEL;
   log(`Requested model: ${resolvedModel}`);
 
-  const { cookies } = await getCookies();
+  const { cookies } = await raceAbort(getCookies, signal);
   if (!hasRequiredCookies(cookies)) {
     throw new Error("Google login required - sign into Google in Chrome first");
   }
   log(`Got ${cookies.length} cookies`);
 
   const createdUrl = buildAiStudioUrl(resolvedModel);
-  const tabInfo = await createTab(createdUrl);
+  const tabInfo = await raceAbort(() => createTab(createdUrl), signal);
   const { tabId } = tabInfo || {};
 
   if (!tabId) {
@@ -333,21 +339,21 @@ async function query(options) {
   }
   log(`Created tab ${tabId}`);
 
-  const cdp = (expr) => cdpEvaluate(tabId, expr);
-  const inputCdp = (method, params) => cdpCommand(tabId, method, params);
+  const cdp = (expr) => raceAbort(() => cdpEvaluate(tabId, expr), signal);
+  const inputCdp = (method, params) => raceAbort(() => cdpCommand(tabId, method, params), signal);
 
   let baselineGenerateEntryIds = new Set();
 
   try {
-    await waitForPageLoad(cdp);
+    await raceAbort(waitForPageLoad(cdp), signal);
     log("Page loaded");
 
-    await waitForStudioReady(cdp);
+    await raceAbort(waitForStudioReady(cdp), signal);
     log("AI Studio ready");
 
     if (typeof readNetworkEntries === 'function') {
       try {
-        const baselineNetwork = await readNetworkEntries(tabId);
+        const baselineNetwork = await guardedReadNetworkEntries(tabId);
         const baselineEntries = Array.isArray(baselineNetwork?.entries)
           ? baselineNetwork.entries
           : Array.isArray(baselineNetwork?.requests)
@@ -362,6 +368,7 @@ async function query(options) {
 
         log(`Network baseline ready (${baselineGenerateEntryIds.size} GenerateContent entries)`);
       } catch (e) {
+        if (signal?.aborted) throw e;
         log(`Network baseline failed: ${e.message || e}`);
       }
     }
@@ -369,6 +376,7 @@ async function query(options) {
     try {
       await enableUnformattedMarkdownView(cdp, log);
     } catch (e) {
+      if (signal?.aborted) throw e;
       log(`Markdown toggle failed: ${e.message}`);
     }
 
@@ -387,8 +395,8 @@ async function query(options) {
       try {
         log(`Runtime model param missing; retrying direct navigation: ${createdUrl}`);
         await inputCdp('Page.navigate', { url: createdUrl });
-        await waitForPageLoad(cdp);
-        await waitForStudioReady(cdp);
+        await raceAbort(waitForPageLoad(cdp), signal);
+        await raceAbort(waitForStudioReady(cdp), signal);
         runtimeUrl = await evaluate(cdp, 'location.href');
         runtimeModelParam = await evaluate(cdp, `(() => {
           try {
@@ -398,6 +406,7 @@ async function query(options) {
           }
         })()`);
       } catch (e) {
+        if (signal?.aborted) throw e;
         log(`Direct model URL navigation retry failed: ${e.message || e}`);
       }
     }
@@ -408,7 +417,10 @@ async function query(options) {
       log(`Model via UI (no URL param): requested="${resolvedModel}"`);
     }
 
-    const currentModelInfo = await readCurrentModelInfo(cdp).catch(() => ({ found: false, label: '', modelId: '' }));
+    const currentModelInfo = await readCurrentModelInfo(cdp).catch((error) => {
+      if (signal?.aborted) throw error;
+      return { found: false, label: '', modelId: '' };
+    });
 
     log(`AI Studio URL: ${runtimeUrl}`);
     if (currentModelInfo?.label) {
@@ -427,8 +439,9 @@ async function query(options) {
 
     if (!modelApplied && usedUrlParam) {
       try {
-        modelApplied = await waitForModelToApply(cdp, resolvedModel, log);
+        modelApplied = await raceAbort(waitForModelToApply(cdp, resolvedModel, log), signal);
       } catch (e) {
+        if (signal?.aborted) throw e;
         log(`Model apply wait failed: ${e.message}`);
       }
     }
@@ -436,19 +449,20 @@ async function query(options) {
     if (!modelApplied) {
       try {
         log(`Attempting UI model selection fallback: ${resolvedModel}`);
-        await selectModel(cdp, resolvedModel, log);
-        modelApplied = await waitForModelToApply(cdp, resolvedModel, log, 10000);
+        await raceAbort(selectModel(cdp, resolvedModel, log), signal);
+        modelApplied = await raceAbort(waitForModelToApply(cdp, resolvedModel, log, 10000), signal);
       } catch (e) {
+        if (signal?.aborted) throw e;
         log(`UI model selection fallback failed: ${e.message}`);
       }
     }
 
-    await closeModelSelectorIfOpen(cdp, log);
+    await raceAbort(closeModelSelectorIfOpen(cdp, log), signal);
 
-    await typePrompt(cdp, inputCdp, prompt);
+    await raceAbort(typePrompt(cdp, inputCdp, prompt), signal);
     log("Prompt typed");
 
-    await submitPrompt(cdp, inputCdp);
+    await raceAbort(submitPrompt(cdp, inputCdp), signal);
     log("Submitted, waiting for response...");
 
     let response;
@@ -457,10 +471,11 @@ async function query(options) {
       try {
         const networkResult = await waitForGenerateResponseFromNetwork({
           tabId,
-          readNetworkEntries,
+          readNetworkEntries: guardedReadNetworkEntries,
           timeoutMs: timeout,
           baselineEntryIds: baselineGenerateEntryIds,
           prompt,
+          signal,
           log,
         });
 
@@ -474,13 +489,14 @@ async function query(options) {
           `${networkResult.requestId ? ` (request ${networkResult.requestId})` : ''}`
         );
       } catch (networkErr) {
+        if (signal?.aborted) throw networkErr;
         log(`Network extraction failed, falling back to DOM: ${networkErr.message || networkErr}`);
 
         const remainingTimeoutMs = Math.max(timeout - (Date.now() - startTime), 10000);
-        response = await waitForResponse(cdp, remainingTimeoutMs, prompt, log);
+        response = await raceAbort(waitForResponse(cdp, remainingTimeoutMs, prompt, log), signal);
       }
     } else {
-      response = await waitForResponse(cdp, timeout, prompt, log);
+      response = await raceAbort(waitForResponse(cdp, timeout, prompt, log), signal);
     }
 
     const thinkingInfo = response.thinkingTime ? ` (thought for ${response.thinkingTime}s)` : '';
@@ -493,7 +509,11 @@ async function query(options) {
       tookMs: Date.now() - startTime,
     };
   } finally {
-    await closeTab(tabId).catch(() => {});
+    try {
+      await closeTab(tabId);
+    } catch (error) {
+      log(`Failed to close AI Studio tab ${tabId}: ${error?.message || error}`);
+    }
   }
 }
 

--- a/native/browser-lock.cjs
+++ b/native/browser-lock.cjs
@@ -11,8 +11,8 @@ function sleepSync(ms) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
-function getBrowserLockDir(socketPath, tempDir) {
-  const hash = crypto.createHash("sha256").update(socketPath).digest("hex").slice(0, 16);
+function getBrowserLockDir(endpointKey, tempDir) {
+  const hash = crypto.createHash("sha256").update(endpointKey).digest("hex").slice(0, 16);
   return path.join(tempDir, `surf-lock-${hash}`);
 }
 

--- a/native/chatgpt-client.cjs
+++ b/native/chatgpt-client.cjs
@@ -1,4 +1,5 @@
 const path = require("path");
+const { abortableDelay, raceAbort, throwIfAborted } = require("./abort.cjs");
 
 const CHATGPT_URL = "https://chatgpt.com/";
 
@@ -14,8 +15,8 @@ const SELECTORS = {
   cloudflareScript: 'script[src*="/challenge-platform/"]',
 };
 
-function delay(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function delay(ms, signal) {
+  return abortableDelay(ms, signal);
 }
 
 function buildClickDispatcher() {
@@ -189,8 +190,10 @@ function isChatGPTResponseComplete(snapshot, stableCycles, stableMs) {
   return stableCycles >= 6 && stableMs >= 1200;
 }
 
-async function evaluate(cdp, expression) {
+async function evaluate(cdp, expression, signal) {
+  throwIfAborted(signal);
   const result = await cdp(expression);
+  throwIfAborted(signal);
   if (result.exceptionDetails) {
     const desc = result.exceptionDetails.exception?.description || 
                  result.exceptionDetails.text || 
@@ -203,14 +206,15 @@ async function evaluate(cdp, expression) {
   return result.result?.value;
 }
 
-async function waitForPageLoad(cdp, timeoutMs = 45000) {
+async function waitForPageLoad(cdp, timeoutMs = 45000, signal) {
+  throwIfAborted(signal);
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const ready = await evaluate(cdp, "document.readyState");
     if (ready === "complete" || ready === "interactive") {
       return;
     }
-    await delay(100);
+    await delay(100, signal);
   }
   throw new Error("Page did not load in time");
 }
@@ -252,7 +256,8 @@ async function checkLoginStatus(cdp) {
   return result || { status: 0 };
 }
 
-async function waitForPromptReady(cdp, timeoutMs = 30000) {
+async function waitForPromptReady(cdp, timeoutMs = 30000, signal) {
+  throwIfAborted(signal);
   const deadline = Date.now() + timeoutMs;
   const selectors = JSON.stringify(SELECTORS.promptTextarea.split(", "));
   while (Date.now() < deadline) {
@@ -270,7 +275,7 @@ async function waitForPromptReady(cdp, timeoutMs = 30000) {
       })()`
     );
     if (found) return true;
-    await delay(200);
+    await delay(200, signal);
   }
   return false;
 }
@@ -302,7 +307,8 @@ function resolveChatGPTModelMenuOption(items, desiredModel) {
   }) || null;
 }
 
-async function selectModel(cdp, desiredModel, timeoutMs = 8000) {
+async function selectModel(cdp, desiredModel, timeoutMs = 8000, signal) {
+  throwIfAborted(signal);
   const modelButton = await evaluate(
     cdp,
     `(() => {
@@ -321,7 +327,7 @@ async function selectModel(cdp, desiredModel, timeoutMs = 8000) {
       if (btn) dispatchClickSequence(btn);
     })()`
   );
-  await delay(300);
+  await delay(300, signal);
 
   const normalizedModel = normalizeChatGPTModelChoice(desiredModel);
   const deadline = Date.now() + timeoutMs;
@@ -361,7 +367,7 @@ async function selectModel(cdp, desiredModel, timeoutMs = 8000) {
             if (item) dispatchClickSequence(item);
           })()`
         );
-        await delay(200);
+        await delay(200, signal);
         return match.label;
       }
 
@@ -379,13 +385,14 @@ async function selectModel(cdp, desiredModel, timeoutMs = 8000) {
       );
     }
 
-    await delay(100);
+    await delay(100, signal);
   }
 
   throw new Error(`Model not found: ${desiredModel} (timeout)`);
 }
 
-async function typePrompt(cdp, inputCdp, prompt) {
+async function typePrompt(cdp, inputCdp, prompt, signal) {
+  throwIfAborted(signal);
   const selectors = JSON.stringify(SELECTORS.promptTextarea.split(", "));
   const encodedPrompt = JSON.stringify(prompt);
   const focused = await evaluate(
@@ -416,7 +423,7 @@ async function typePrompt(cdp, inputCdp, prompt) {
     throw new Error("Failed to focus prompt textarea");
   }
   await inputCdp("Input.insertText", { text: prompt });
-  await delay(300);
+  await delay(300, signal);
   const verified = await evaluate(
     cdp,
     `(() => {
@@ -449,7 +456,8 @@ async function typePrompt(cdp, inputCdp, prompt) {
   }
 }
 
-async function clickSend(cdp, inputCdp) {
+async function clickSend(cdp, inputCdp, signal) {
+  throwIfAborted(signal);
   const selectors = SELECTORS.sendButton.split(", ");
   const selectorsJson = JSON.stringify(selectors);
   const deadline = Date.now() + 8000;
@@ -475,7 +483,7 @@ async function clickSend(cdp, inputCdp) {
     );
     if (result === "clicked") return true;
     if (result === "missing") break;
-    await delay(100);
+    await delay(100, signal);
   }
   await inputCdp("Input.dispatchKeyEvent", {
     type: "keyDown",
@@ -574,8 +582,10 @@ async function waitForResponse(
   cdp,
   timeoutMs = 2700000,
   baselineAssistant,
-  baselineAssistantCount
+  baselineAssistantCount,
+  signal
 ) {
+  throwIfAborted(signal);
   const deadline = Date.now() + timeoutMs;
   let previousText = "";
   let stableCycles = 0;
@@ -588,7 +598,7 @@ async function waitForResponse(
     const snapshot = await readChatGPTResponseSnapshot(cdp);
 
     if (!snapshot) {
-      await delay(400);
+      await delay(400, signal);
       continue;
     }
 
@@ -602,7 +612,7 @@ async function waitForResponse(
     );
 
     if (!hasNewAssistantContent) {
-      await delay(400);
+      await delay(400, signal);
       continue;
     }
 
@@ -630,7 +640,7 @@ async function waitForResponse(
       };
     }
 
-    await delay(400);
+    await delay(400, signal);
   }
 
   throw new Error("Response timeout");
@@ -649,26 +659,31 @@ async function query(options) {
     cdpCommand,
     uploadFile,
     log = () => {},
+    signal,
   } = options;
+  throwIfAborted(signal);
+  const guardedUploadFile = uploadFile
+    ? (...args) => raceAbort(() => uploadFile(...args), signal)
+    : uploadFile;
   const startTime = Date.now();
   log("Starting ChatGPT query");
-  const { cookies } = await getCookies();
+  const { cookies } = await raceAbort(getCookies, signal);
   if (!hasRequiredCookies(cookies)) {
     throw new Error("ChatGPT login required");
   }
   log(`Got ${cookies.length} cookies`);
-  const tabInfo = await createTab();
+  const tabInfo = await raceAbort(createTab, signal);
   const { tabId } = tabInfo;
   if (!tabId) {
     throw new Error("Failed to create ChatGPT tab");
   }
   log(`Created tab ${tabId}`);
   
-  const cdp = (expr) => cdpEvaluate(tabId, expr);
-  const inputCdp = (method, params) => cdpCommand(tabId, method, params);
+  const cdp = (expr) => raceAbort(() => cdpEvaluate(tabId, expr), signal);
+  const inputCdp = (method, params) => raceAbort(() => cdpCommand(tabId, method, params), signal);
   
   try {
-    await waitForPageLoad(cdp);
+    await waitForPageLoad(cdp, 45000, signal);
     log("Page loaded");
     if (await isCloudflareBlocked(cdp)) {
       throw new Error("Cloudflare challenge detected - complete in browser");
@@ -685,13 +700,13 @@ async function query(options) {
       throw new Error("ChatGPT login required");
     }
     log("Login verified");
-    const promptReady = await waitForPromptReady(cdp);
+    const promptReady = await waitForPromptReady(cdp, 30000, signal);
     if (!promptReady) {
       throw new Error("Prompt textarea not ready");
     }
     log("Prompt ready");
     if (model) {
-      const selectedLabel = await selectModel(cdp, model);
+      const selectedLabel = await selectModel(cdp, model, 8000, signal);
       log(`Selected model: ${selectedLabel}`);
     }
     if (file) {
@@ -701,7 +716,7 @@ async function query(options) {
       const files = Array.isArray(file) ? file : [file];
       const absFiles = files.map((filePath) => path.resolve(process.cwd(), filePath));
       log(`Uploading ${absFiles.length} file(s) to ChatGPT...`);
-      const uploadResult = await uploadFile(tabId, absFiles);
+      const uploadResult = await guardedUploadFile(tabId, absFiles);
       if (uploadResult?.error) {
         throw new Error(`ChatGPT file upload failed: ${uploadResult.error}`);
       }
@@ -709,18 +724,19 @@ async function query(options) {
         throw new Error("ChatGPT file upload failed: upload did not report success");
       }
       log("File uploaded, waiting for ChatGPT attachment processing...");
-      await delay(1500);
+      await delay(1500, signal);
     }
-    await typePrompt(cdp, inputCdp, prompt);
+    await typePrompt(cdp, inputCdp, prompt, signal);
     log("Prompt typed");
     const baseline = normalizeResponseSnapshot(await readChatGPTResponseSnapshot(cdp));
-    await clickSend(cdp, inputCdp);
+    await clickSend(cdp, inputCdp, signal);
     log("Prompt sent, waiting for response...");
     const response = await waitForResponse(
       cdp,
       timeout,
       baseline.latestAssistant,
-      baseline.assistantCount
+      baseline.assistantCount,
+      signal
     );
     log(`Response received (${response.text.length} chars)`);
     return {

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-const net = require("net");
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
@@ -12,8 +11,9 @@ const { executeDoSteps } = require("./do-executor.cjs");
 const { version: VERSION } = require("../package.json");
 
 const IS_WIN = process.platform === "win32";
-const { SOCKET_PATH, SURF_TMP, formatSocketError } = require("./socket-path.cjs");
+const { SURF_TMP, formatSocketError } = require("./socket-path.cjs");
 const { acquireBrowserLock } = require("./browser-lock.cjs");
+const { selectEndpoint, connectEndpoint, formatEndpointError } = require("./endpoint.cjs");
 if (IS_WIN) { try { fs.mkdirSync(SURF_TMP, { recursive: true }); } catch {} }
 
 function parseBrowserLockOptions(noLockFlag) {
@@ -29,11 +29,11 @@ function parseBrowserLockOptions(noLockFlag) {
   return { noLock, timeoutMs };
 }
 
-function installBrowserLock({ noLock, timeoutMs }) {
+function installBrowserLock({ noLock, timeoutMs }, endpoint) {
   let releaseBrowserLock = () => {};
   if (!noLock) {
     try {
-      const lock = acquireBrowserLock(SOCKET_PATH, SURF_TMP, { timeoutMs });
+      const lock = acquireBrowserLock(endpoint.key, SURF_TMP, { timeoutMs });
       releaseBrowserLock = lock.release;
     } catch (error) {
       console.error("Error:", error && error.message ? error.message : String(error));
@@ -336,7 +336,14 @@ function resizeImage(filePath, maxSize) {
     return { success: false, error: e.message };
   }
 }
-const args = process.argv.slice(2);
+let args = process.argv.slice(2);
+let endpoint;
+try {
+  ({ args, endpoint } = selectEndpoint(args));
+} catch (error) {
+  console.error(`Error: ${error.message}`);
+  process.exit(1);
+}
 
 const ALIASES = {
   snap: "screenshot",
@@ -1666,6 +1673,7 @@ Quick Examples:
   surf window.new "https://example.com" && surf --window-id 123 go "https://other.com"
 
 More Help:
+  --remote <host>:<port>    Route requests to a remote native host
   surf --help-full           All commands
   surf --llm-context         Compact reference for AI agents
   surf --help-topic <topic>  Topic guide (refs, semantic, frames, devices...)
@@ -1722,6 +1730,7 @@ Usage: surf <command> [args] [options]
   console.log(`Aliases: snap -> screenshot, read -> page.read, find -> search, go -> navigate
 
 Options:
+  --remote <host>:<port>  Route requests to a remote native host
   --tab-id <id>     Target specific tab
   --window-id <id>  Target specific window (isolate from your browsing)
   --json            Output raw JSON
@@ -1944,7 +1953,7 @@ if (args[0] === "server") {
     process.exit(0);
   }
   const { PiChromeMcpServer } = require("./mcp-server.cjs");
-  const server = new PiChromeMcpServer();
+  const server = new PiChromeMcpServer(endpoint);
   server.start().catch((err) => {
     console.error("MCP Server error:", err.message);
     process.exit(1);
@@ -1960,7 +1969,7 @@ if (args[0] === "extension-path" || args[0] === "path") {
 
 if (args[0] === "doctor") {
   const { runDoctorCli } = require("./doctor.cjs");
-  runDoctorCli(args.slice(1)).then((code) => process.exit(code));
+  runDoctorCli(args.slice(1), endpoint).then((code) => process.exit(code));
   return;
 }
 
@@ -2130,7 +2139,7 @@ if (args.includes("--script")) {
 
   const sendScriptRequest = (toolName, toolArgs = {}) => {
     return new Promise((resolve, reject) => {
-      const sock = net.createConnection(SOCKET_PATH, () => {
+      const sock = connectEndpoint(endpoint, () => {
         const req = {
           type: "tool_request",
           method: "execute_tool",
@@ -2157,7 +2166,7 @@ if (args.includes("--script")) {
           }
         }
       });
-      sock.on("error", (e) => reject(new Error(formatSocketError(e))));
+      sock.on("error", (e) => reject(new Error(formatEndpointError(e, endpoint, formatSocketError))));
       let timeoutId;
       timeoutId = setTimeout(() => { sock.destroy(); reject(new Error("Timeout")); }, 30000);
       sock.on("close", () => clearTimeout(timeoutId));
@@ -2227,7 +2236,7 @@ if (args.includes("--script")) {
   };
 
   if (!dryRun) {
-    installBrowserLock(parseBrowserLockOptions(args.includes("--no-lock")));
+    installBrowserLock(parseBrowserLockOptions(args.includes("--no-lock")), endpoint);
   }
 
   runScript();
@@ -2432,7 +2441,7 @@ if (args[0] === "do") {
     process.exit(0);
   }
 
-  installBrowserLock(parseBrowserLockOptions(doArgs.includes("--no-lock")));
+  installBrowserLock(parseBrowserLockOptions(doArgs.includes("--no-lock")), endpoint);
 
   if (!wantJson) {
     if (workflowName) {
@@ -2452,6 +2461,7 @@ if (args[0] === "do") {
       context: {
         tabId,
         windowId,
+        endpoint,
       },
     });
 
@@ -3008,7 +3018,7 @@ if (streamMode && (tool === "console" || tool === "network")) {
   let connectionTimeout = null;
   let receivedData = false;
 
-  const sock = net.createConnection(SOCKET_PATH, () => {
+  const sock = connectEndpoint(endpoint, () => {
     const req = {
       type: "stream_request",
       streamType,
@@ -3017,6 +3027,10 @@ if (streamMode && (tool === "console" || tool === "network")) {
       ...globalOpts,
     };
     sock.write(JSON.stringify(req) + "\n");
+    if (connectionTimeout) {
+      clearTimeout(connectionTimeout);
+      connectionTimeout = null;
+    }
     connectionTimeout = setTimeout(() => {
       if (!receivedData) {
         console.error("Error: Stream connection timeout (10s) - no data received");
@@ -3025,6 +3039,12 @@ if (streamMode && (tool === "console" || tool === "network")) {
       }
     }, 10000);
   });
+
+  connectionTimeout = setTimeout(() => {
+    console.error(`Error: Stream connection timeout (10s) - could not connect to ${endpoint.display}`);
+    sock.destroy();
+    process.exit(1);
+  }, 10000);
 
   let buf = "";
   sock.on("data", (d) => {
@@ -3071,11 +3091,13 @@ if (streamMode && (tool === "console" || tool === "network")) {
   });
 
   sock.on("error", (e) => {
-    console.error("Error:", formatSocketError(e));
+    if (connectionTimeout) clearTimeout(connectionTimeout);
+    console.error("Error:", formatEndpointError(e, endpoint, formatSocketError));
     process.exit(1);
   });
 
   process.on("SIGINT", () => {
+    if (connectionTimeout) clearTimeout(connectionTimeout);
     sock.write(JSON.stringify({ type: "stream_stop" }) + "\n");
     sock.end();
     process.exit(0);
@@ -3094,7 +3116,7 @@ const request = {
 
 const sendRequest = (toolName, toolArgs = {}, timeoutMs = 5000) => {
   return new Promise((resolve, reject) => {
-    const sock = net.createConnection(SOCKET_PATH, () => {
+    const sock = connectEndpoint(endpoint, () => {
       const req = {
         type: "tool_request",
         method: "execute_tool",
@@ -3126,7 +3148,7 @@ const sendRequest = (toolName, toolArgs = {}, timeoutMs = 5000) => {
         }
       }
     });
-    sock.on("error", (e) => reject(new Error(formatSocketError(e))));
+    sock.on("error", (e) => reject(new Error(formatEndpointError(e, endpoint, formatSocketError))));
     let timeoutId;
     timeoutId = setTimeout(() => { sock.destroy(); reject(new Error("Timeout")); }, timeoutMs);
     sock.on("close", () => clearTimeout(timeoutId));
@@ -3297,7 +3319,11 @@ const performAutoCapture = async () => {
 };
 
 if (finalTool === "record") {
-  installBrowserLock(lockOptions);
+  if (endpoint.kind === "remote") {
+    console.error(`Error: record is not supported with remote endpoint ${endpoint.display}`);
+    process.exit(1);
+  }
+  installBrowserLock(lockOptions, endpoint);
   runRecord()
     .then(() => process.exit(0))
     .catch((error) => {
@@ -3307,9 +3333,9 @@ if (finalTool === "record") {
   return;
 }
 
-installBrowserLock(lockOptions);
+installBrowserLock(lockOptions, endpoint);
 
-const socket = net.createConnection(SOCKET_PATH, () => {
+const socket = connectEndpoint(endpoint, () => {
   socket.write(JSON.stringify(request) + "\n");
 });
 
@@ -3357,7 +3383,7 @@ socket.on("data", (data) => {
 
 socket.on("error", (err) => {
   clearTimeout(timeout);
-  console.error("Error:", formatSocketError(err));
+  console.error("Error:", formatEndpointError(err, endpoint, formatSocketError));
   process.exit(1);
 });
 

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -8,12 +8,17 @@ const networkFormatters = require("./formatters/network.cjs");
 const networkStore = require("./network-store.cjs");
 const { parseDoCommands } = require("./do-parser.cjs");
 const { executeDoSteps } = require("./do-executor.cjs");
+const { openClientTransport } = require("./client-transport.cjs");
 const { version: VERSION } = require("../package.json");
 
 const IS_WIN = process.platform === "win32";
 const { SURF_TMP, formatSocketError } = require("./socket-path.cjs");
 const { acquireBrowserLock } = require("./browser-lock.cjs");
 const { selectEndpoint, connectEndpoint, formatEndpointError } = require("./endpoint.cjs");
+const { createFrameParser, createSocketWriter, writeFrame } = require("./remote-transport.cjs");
+const { resolveRequestDeadlineMs } = require("./host-sessions.cjs");
+const { AUTO_SCREENSHOT_TOOLS, prepareRemoteTool, validateLocalToolPaths } = require("./file-transfer.cjs");
+const { authorizeClient, listClients, revokeClient, getStateDir } = require("./remote-auth.cjs");
 if (IS_WIN) { try { fs.mkdirSync(SURF_TMP, { recursive: true }); } catch {} }
 
 function parseBrowserLockOptions(noLockFlag) {
@@ -337,6 +342,42 @@ function resizeImage(filePath, maxSize) {
   }
 }
 let args = process.argv.slice(2);
+if (args[0] === "remote") {
+  const remoteArgs = args.slice(1);
+  const subcommand = remoteArgs[0];
+  const stateDir = getStateDir();
+  try {
+    if (subcommand === "authorize") {
+      const label = remoteArgs[1];
+      const outputIndex = remoteArgs.indexOf("--output");
+      const output = outputIndex === -1 ? undefined : remoteArgs[outputIndex + 1];
+      if (!label || !output || output.startsWith("--")) throw new Error("Usage: surf remote authorize <label> --output <credential-file>");
+      const client = authorizeClient(label, output, stateDir);
+      console.log(`Authorized remote client: ${client.label}`);
+      console.log(`Credential: ${client.output}`);
+      process.exit(0);
+    }
+    if (subcommand === "list") {
+      const clients = listClients(stateDir);
+      if (clients.length === 0) console.log("No authorized remote clients.");
+      else for (const client of clients) console.log(`${client.label}\t${client.id}\t${client.createdAt}`);
+      process.exit(0);
+    }
+    if (subcommand === "revoke") {
+      const label = remoteArgs[1];
+      if (!label || label.startsWith("--")) throw new Error("Usage: surf remote revoke <label>");
+      revokeClient(label, stateDir);
+      console.log(`Revoked remote client: ${label}`);
+      process.exit(0);
+    }
+    console.error("Usage: surf remote authorize <label> --output <credential-file> | list | revoke <label>");
+    process.exit(1);
+  } catch (error) {
+    console.error(`Error: ${error.message}`);
+    process.exit(1);
+  }
+}
+
 let endpoint;
 try {
   ({ args, endpoint } = selectEndpoint(args));
@@ -1674,6 +1715,9 @@ Quick Examples:
 
 More Help:
   --remote <host>:<port>    Route requests to a remote native host
+  --remote-credential <path>  Use a mode-0600 Ed25519 remote credential file
+  surf remote authorize <label> --output <path>
+  surf remote list | surf remote revoke <label>
   surf --help-full           All commands
   surf --llm-context         Compact reference for AI agents
   surf --help-topic <topic>  Topic guide (refs, semantic, frames, devices...)
@@ -1730,13 +1774,19 @@ Usage: surf <command> [args] [options]
   console.log(`Aliases: snap -> screenshot, read -> page.read, find -> search, go -> navigate
 
 Options:
-  --remote <host>:<port>  Route requests to a remote native host
+  --remote <host>:<port>       Route requests to a remote native host
+  --remote-credential <path>   Use a mode-0600 Ed25519 remote credential file
   --tab-id <id>     Target specific tab
   --window-id <id>  Target specific window (isolate from your browsing)
   --json            Output raw JSON
   --auto-capture    On error: capture screenshot + console to /tmp
   --soft-fail       On error: warn and exit 0 (for non-critical commands)
   --no-lock         Bypass the per-socket browser request lock
+
+Remote Credentials (run on the browser host):
+  surf remote authorize <label> --output <credential-file>
+  surf remote list
+  surf remote revoke <label>
 
 Script Mode:
   surf --script <file>     Run workflow from JSON
@@ -1994,6 +2044,8 @@ Options:
                   Multiple: --browser chrome,brave
   --target        Install target: auto, linux, windows
                   On WSL2, auto installs for Windows Chrome. Use linux for WSLg/Linux browsers.
+  --listen <tailscale-ip>:<port>
+                  Requires surf remote authorize <label> --output <path> first.
 
 Examples:
   surf install hnfbepgmaoklhekckbpjnleifhahkcpl
@@ -2137,44 +2189,24 @@ if (args.includes("--script")) {
     process.exit(1);
   }
 
+  let scriptTransport;
   const sendScriptRequest = (toolName, toolArgs = {}) => {
-    return new Promise((resolve, reject) => {
-      const sock = connectEndpoint(endpoint, () => {
-        const req = {
-          type: "tool_request",
-          method: "execute_tool",
-          params: { tool: toolName, args: toolArgs },
-          id: "cli-" + Date.now() + "-" + Math.random(),
-        };
-        if (scriptTabId) req.tabId = parseInt(scriptTabId, 10);
-        sock.write(JSON.stringify(req) + "\n");
-      });
-      let buf = "";
-      sock.on("data", (d) => {
-        buf += d.toString();
-        const lines = buf.split("\n");
-        buf = lines.pop();
-        for (const line of lines) {
-          if (!line.trim()) continue;
-          try {
-            const resp = JSON.parse(line);
-            sock.end();
-            resolve(resp);
-          } catch {
-            sock.end();
-            reject(new Error("Invalid JSON"));
-          }
-        }
-      });
-      sock.on("error", (e) => reject(new Error(formatEndpointError(e, endpoint, formatSocketError))));
-      let timeoutId;
-      timeoutId = setTimeout(() => { sock.destroy(); reject(new Error("Timeout")); }, 30000);
-      sock.on("close", () => clearTimeout(timeoutId));
-    });
+    const req = {
+      type: "tool_request",
+      method: "execute_tool",
+      params: { tool: toolName, args: toolArgs },
+      id: "cli-" + Date.now() + "-" + Math.random(),
+    };
+    if (scriptTabId) req.tabId = parseInt(scriptTabId, 10);
+    const prepared = endpoint.kind === "remote" ? prepareRemoteTool(toolName, toolArgs) : (() => { const args = validateLocalToolPaths(toolName, toolArgs); return { args, uploads: [], downloads: [] }; })();
+    req.params.args = prepared.args;
+    return scriptTransport.request(req, resolveRequestDeadlineMs(toolName, prepared.args), prepared);
   };
 
   const runScript = async () => {
-    const total = script.steps.length;
+    try {
+      if (!dryRun) scriptTransport = await openClientTransport(endpoint);
+      const total = script.steps.length;
     const results = [];
     let failed = 0;
 
@@ -2232,14 +2264,22 @@ if (args.includes("--script")) {
       console.log(`Summary: ${passed} passed, ${failed} failed, ${total} total`);
     }
 
-    process.exit(failed > 0 ? 1 : 0);
+      return failed > 0 ? 1 : 0;
+    } finally {
+      await scriptTransport?.close();
+    }
   };
 
   if (!dryRun) {
     installBrowserLock(parseBrowserLockOptions(args.includes("--no-lock")), endpoint);
   }
 
-  runScript();
+  runScript()
+    .then((code) => process.exit(code))
+    .catch((error) => {
+      console.error(`Error: ${error.message}`);
+      process.exit(1);
+    });
   return;
 }
 
@@ -2452,7 +2492,10 @@ if (args[0] === "do") {
   }
 
   const runWorkflow = async () => {
-    const result = await executeDoSteps(steps, {
+    let transport;
+    try {
+      transport = await openClientTransport(endpoint);
+      const result = await executeDoSteps(steps, {
       onError,
       autoWait: !noAutoWait,
       stepDelay,
@@ -2462,30 +2505,39 @@ if (args[0] === "do") {
         tabId,
         windowId,
         endpoint,
+        transport,
       },
-    });
+      });
 
     // Print summary
     if (wantJson) {
       console.log(JSON.stringify(result, null, 2));
-      process.exit(result.status === "completed" ? 0 : 1);
+      return result.status === "completed" ? 0 : 1;
     }
 
     console.log("");
     if (result.status === "completed") {
       console.log(`Completed: ${result.completedSteps}/${result.totalSteps} steps (${result.totalMs}ms)`);
-      process.exit(0);
+      return 0;
     } else if (result.status === "partial") {
       console.log(`Partial: ${result.completedSteps}/${result.totalSteps} steps completed, ${result.failed} failed`);
-      process.exit(1);
+      return 1;
     } else {
       console.error(`Failed: ${result.completedSteps}/${result.totalSteps} steps completed`);
       if (result.error) console.error(`Error: ${result.error}`);
-      process.exit(1);
+      return 1;
+      }
+    } finally {
+      transport?.close();
     }
   };
 
-  runWorkflow();
+  runWorkflow()
+    .then((code) => process.exit(code))
+    .catch((error) => {
+      console.error(`Error: ${error.message}`);
+      process.exit(1);
+    });
   return;
 }
 
@@ -2611,8 +2663,6 @@ if (args[0] === "workflow.validate") {
 }
 
 const BOOLEAN_FLAGS = ["auto-capture", "json", "stream", "dry-run", "stop-on-error", "fail-fast", "clear", "submit", "all", "case-sensitive", "hard", "annotate", "fullpage", "full-page", "reset", "no-screenshot", "full", "soft-fail", "has-body", "exclude-static", "v", "vv", "request", "by-tab", "har", "jsonl", "no-save", "no-auto-wait", "no-lock"];
-
-const AUTO_SCREENSHOT_TOOLS = ["click", "type", "key", "smart_type", "form.fill", "form_input", "drag", "hover", "scroll", "scroll.top", "scroll.bottom", "scroll.to", "dialog.accept", "dialog.dismiss", "js", "eval"];
 
 const parseArgs = (rawArgs) => {
   const result = { positional: [], options: {} };
@@ -2781,7 +2831,7 @@ const PRIMARY_ARG_MAP = {
   "select": "selector",
 };
 
-const toolArgs = { ...options };
+let toolArgs = { ...options };
 
 if (tool === "scroll" && firstArg) {
   if (firstArg === "top" || firstArg === "bottom") {
@@ -2842,12 +2892,23 @@ if (firstArg !== undefined) {
   }
 }
 
-if (tool === "js" && toolArgs.file) {
+if ((tool === "js" || tool === "frame.js") && toolArgs.file) {
   try {
     toolArgs.code = fs.readFileSync(toolArgs.file, "utf8");
     delete toolArgs.file;
   } catch (e) {
     console.error(`Error: Failed to read file: ${e.message}`);
+    process.exit(1);
+  }
+}
+
+if (tool === "batch" && toolArgs.file) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(toolArgs.file, "utf8"));
+    toolArgs.actions = parsed;
+    delete toolArgs.file;
+  } catch (e) {
+    console.error(`Error: Failed to read batch file: ${e.message}`);
     process.exit(1);
   }
 }
@@ -2916,16 +2977,7 @@ if (tool === "aistudio.build" && outputPath) {
   toolArgs.output = path.resolve(outputPath);
 }
 if (tool === "gemini") {
-  if (outputPath) toolArgs.output = path.resolve(outputPath);
-  if (toolArgs["generate-image"] && typeof toolArgs["generate-image"] === "string") {
-    toolArgs["generate-image"] = path.resolve(toolArgs["generate-image"]);
-  }
-  if (toolArgs["edit-image"] && typeof toolArgs["edit-image"] === "string") {
-    toolArgs["edit-image"] = path.resolve(toolArgs["edit-image"]);
-  }
-  if (toolArgs.file && typeof toolArgs.file === "string") {
-    toolArgs.file = path.resolve(toolArgs.file);
-  }
+  if (outputPath !== undefined) toolArgs.output = outputPath;
   if (toolArgs.model) {
     const known = ["gemini-3.1-pro", "gemini-3.5-flash", "gemini-3.1-flash-lite"];
     if (!known.includes(toolArgs.model)) {
@@ -2935,12 +2987,8 @@ if (tool === "gemini") {
     }
   }
 }
-if (tool === "chatgpt" && toolArgs.file) {
-  if (Array.isArray(toolArgs.file)) {
-    toolArgs.file = toolArgs.file.map((filePath) => path.resolve(filePath));
-  } else if (typeof toolArgs.file === "string") {
-    toolArgs.file = path.resolve(toolArgs.file);
-  }
+if (tool === "network.export" && outputPath !== undefined) {
+  toolArgs.output = outputPath;
 }
 
 if ((tool === "screenshot" || tool === "record" || tool === "perf-audit") && outputPath && typeof outputPath !== "string") {
@@ -3017,8 +3065,10 @@ if (streamMode && (tool === "console" || tool === "network")) {
 
   let connectionTimeout = null;
   let receivedData = false;
+  let streamWriter;
 
   const sock = connectEndpoint(endpoint, () => {
+    streamWriter = createSocketWriter(sock, { onOverflow: ({ error }) => sock.destroy(error) });
     const req = {
       type: "stream_request",
       streamType,
@@ -3026,7 +3076,7 @@ if (streamMode && (tool === "console" || tool === "network")) {
       id: "cli-stream-" + Date.now(),
       ...globalOpts,
     };
-    sock.write(JSON.stringify(req) + "\n");
+    streamWriter.send(req).catch((error) => sock.destroy(error));
     if (connectionTimeout) {
       clearTimeout(connectionTimeout);
       connectionTimeout = null;
@@ -3046,49 +3096,46 @@ if (streamMode && (tool === "console" || tool === "network")) {
     process.exit(1);
   }, 10000);
 
-  let buf = "";
-  sock.on("data", (d) => {
-    if (!receivedData) {
-      receivedData = true;
-      if (connectionTimeout) {
-        clearTimeout(connectionTimeout);
-        connectionTimeout = null;
+  const parser = createFrameParser({
+    onFrame(msg) {
+      if (!receivedData) {
+        receivedData = true;
+        if (connectionTimeout) {
+          clearTimeout(connectionTimeout);
+          connectionTimeout = null;
+        }
       }
-    }
-    buf += d.toString();
-    const lines = buf.split("\n");
-    buf = lines.pop();
-    for (const line of lines) {
-      if (!line.trim()) continue;
-      try {
-        const msg = JSON.parse(line);
-        if (msg.error) {
-          console.error("Error:", msg.error);
-          sock.end();
-          process.exit(1);
-        }
-        if (msg.type === "extension_disconnected") {
-          console.error(msg.message);
-          sock.end();
-          process.exit(1);
-        }
-        if (msg.type === "stream_started") {
-          continue;
-        }
-        if (msg.type === "console_event") {
-          const { level, text, timestamp } = msg;
-          if (streamLevel && level !== streamLevel) continue;
-          console.log(`[console] [${level}] ${formatTime(timestamp)} ${text}`);
-        } else if (msg.type === "network_event") {
-          const { method, url, status, duration } = msg;
-          if (streamFilter && !url.includes(streamFilter)) continue;
-          const statusStr = status !== undefined ? status : "...";
-          const durationStr = duration !== undefined ? ` (${duration}ms)` : "";
-          console.log(`[network] ${method} ${url} ${statusStr}${durationStr}`);
-        }
-      } catch {}
-    }
+      if (msg.error) {
+        console.error("Error:", msg.error);
+        sock.end();
+        process.exit(1);
+      }
+      if (msg.type === "extension_disconnected") {
+        console.error(msg.message);
+        sock.end();
+        process.exit(1);
+      }
+      if (msg.type === "stream_started") return;
+      if (msg.type === "console_event") {
+        const { level, text, timestamp } = msg;
+        if (streamLevel && level !== streamLevel) return;
+        console.log(`[console] [${level}] ${formatTime(timestamp)} ${text}`);
+      } else if (msg.type === "network_event") {
+        const { method, url, status, duration } = msg;
+        if (streamFilter && !url.includes(streamFilter)) return;
+        const statusStr = status !== undefined ? status : "...";
+        const durationStr = duration !== undefined ? ` (${duration}ms)` : "";
+        console.log(`[network] ${method} ${url} ${statusStr}${durationStr}`);
+      }
+    },
+    onError(error) {
+      if (connectionTimeout) clearTimeout(connectionTimeout);
+      console.error("Error:", error.message);
+      sock.destroy();
+      process.exit(1);
+    },
   });
+  sock.on("data", (data) => parser.push(data));
 
   sock.on("error", (e) => {
     if (connectionTimeout) clearTimeout(connectionTimeout);
@@ -3098,7 +3145,7 @@ if (streamMode && (tool === "console" || tool === "network")) {
 
   process.on("SIGINT", () => {
     if (connectionTimeout) clearTimeout(connectionTimeout);
-    sock.write(JSON.stringify({ type: "stream_stop" }) + "\n");
+    streamWriter?.send({ type: "stream_stop" }).catch(() => {});
     sock.end();
     process.exit(0);
   });
@@ -3106,6 +3153,17 @@ if (streamMode && (tool === "console" || tool === "network")) {
   return;
 }
 
+let transferPlan;
+try {
+  transferPlan = endpoint.kind === "remote" ? prepareRemoteTool(finalTool, toolArgs) : (() => { const args = validateLocalToolPaths(finalTool, toolArgs); return { args, uploads: [], downloads: [] }; })();
+} catch (error) {
+  const message = finalTool === "record" && endpoint.kind === "remote"
+    ? `record is not supported with remote endpoint ${endpoint.display}`
+    : error.message;
+  console.error(`Error: ${message}`);
+  process.exit(1);
+}
+toolArgs = transferPlan.args;
 const request = {
   type: "tool_request",
   method: "execute_tool",
@@ -3114,45 +3172,20 @@ const request = {
   ...globalOpts,
 };
 
-const sendRequest = (toolName, toolArgs = {}, timeoutMs = 5000) => {
-  return new Promise((resolve, reject) => {
-    const sock = connectEndpoint(endpoint, () => {
-      const req = {
-        type: "tool_request",
-        method: "execute_tool",
-        params: { tool: toolName, args: toolArgs },
-        id: "cli-" + Date.now() + "-" + Math.random(),
-        ...globalOpts,
-      };
-      sock.write(JSON.stringify(req) + "\n");
-    });
-    let buf = "";
-    sock.on("data", (d) => {
-      buf += d.toString();
-      const lines = buf.split("\n");
-      buf = lines.pop();
-      for (const line of lines) {
-        if (!line.trim()) continue;
-        try {
-          const resp = JSON.parse(line);
-          if (resp.type === "extension_disconnected") {
-            sock.end();
-            reject(new Error(resp.message));
-            return;
-          }
-          sock.end();
-          resolve(resp);
-        } catch {
-          sock.end();
-          reject(new Error("Invalid JSON"));
-        }
-      }
-    });
-    sock.on("error", (e) => reject(new Error(formatEndpointError(e, endpoint, formatSocketError))));
-    let timeoutId;
-    timeoutId = setTimeout(() => { sock.destroy(); reject(new Error("Timeout")); }, timeoutMs);
-    sock.on("close", () => clearTimeout(timeoutId));
-  });
+const sendRequest = async (toolName, toolArgs = {}, timeoutMs = 5000) => {
+  const transport = await openClientTransport(endpoint, { requestTimeoutMs: timeoutMs });
+  try {
+    const prepared = endpoint.kind === "remote" ? prepareRemoteTool(toolName, toolArgs) : (() => { const args = validateLocalToolPaths(toolName, toolArgs); return { args, uploads: [], downloads: [] }; })();
+    return await transport.request({
+      type: "tool_request",
+      method: "execute_tool",
+      params: { tool: toolName, args: prepared.args },
+      id: "cli-" + Date.now() + "-" + Math.random(),
+      ...globalOpts,
+    }, timeoutMs, prepared);
+  } finally {
+    await transport.close();
+  }
 };
 
 function parseRecordNumber(value, fallback, name, min, max) {
@@ -3334,52 +3367,62 @@ if (finalTool === "record") {
 }
 
 installBrowserLock(lockOptions, endpoint);
+let socket;
+let timeout;
 
-const socket = connectEndpoint(endpoint, () => {
-  socket.write(JSON.stringify(request) + "\n");
+if (endpoint.kind === "remote") {
+  socket = { end() {}, destroy() {} };
+  const requestTimeout = resolveRequestDeadlineMs(tool, toolArgs);
+  openClientTransport(endpoint, { requestTimeoutMs: requestTimeout })
+    .then(async (transport) => {
+      try {
+        const response = await transport.request(request, requestTimeout, transferPlan);
+        await handleResponse(response);
+      } finally {
+        await transport.close();
+      }
+    })
+    .catch((error) => {
+      console.error(`Error: ${error.message}`);
+      process.exit(1);
+    });
+  return;
+}
+
+socket = connectEndpoint(endpoint, () => {
+  writeFrame(socket, request).catch((error) => socket.destroy(error));
 });
 
-const AI_TOOLS = ["smoke", "chatgpt", "gemini", "perplexity", "grok", "aistudio", "aistudio.build", "ai"];
-let requestTimeout = AI_TOOLS.includes(tool) ? 300000 : 30000;
-if (tool === "aistudio.build") {
-  const userTimeoutSec = parseInt(options.timeout || "600", 10);
-  requestTimeout = (userTimeoutSec * 1000) + 60000;
-}
-const timeout = setTimeout(() => {
+const requestTimeout = resolveRequestDeadlineMs(tool, options);
+timeout = setTimeout(() => {
   console.error(`Error: Request timed out (${requestTimeout / 1000}s)`);
   socket.destroy();
   process.exit(1);
 }, requestTimeout);
 
-let buffer = "";
-
-socket.on("data", (data) => {
-  buffer += data.toString();
-  const lines = buffer.split("\n");
-  buffer = lines.pop();
-
-  for (const line of lines) {
-    if (!line.trim()) continue;
-    try {
-      const msg = JSON.parse(line);
-
-      if (msg.type === "extension_disconnected") {
-        clearTimeout(timeout);
-        console.error(msg.message);
-        socket.end();
-        process.exit(1);
-      }
-
-      handleResponse(msg).catch((err) => {
-        console.error("Handler error:", err.message);
-        process.exit(1);
-      });
-    } catch (e) {
-      console.error("Invalid JSON response:", line);
+const responseParser = createFrameParser({
+  onFrame(msg) {
+    if (msg.type === "extension_disconnected") {
+      clearTimeout(timeout);
+      console.error(msg.message);
+      socket.end();
       process.exit(1);
     }
-  }
+    if (msg.id !== request.id) return;
+    handleResponse(msg).catch((err) => {
+      console.error("Handler error:", err.message);
+      process.exit(1);
+    });
+  },
+  onError(error) {
+    clearTimeout(timeout);
+    console.error("Invalid response frame:", error.message);
+    socket.destroy();
+    process.exit(1);
+  },
 });
+
+socket.on("data", (data) => responseParser.push(data));
 
 socket.on("error", (err) => {
   clearTimeout(timeout);
@@ -3442,7 +3485,7 @@ async function handleResponse(response) {
   }
 
   if (tool === "screenshot" && data?.base64 && (outputPath || toolArgs.savePath)) {
-    const saveTo = outputPath || toolArgs.savePath;
+    const saveTo = transferPlan.downloads?.[0]?.destination || toolArgs.savePath || outputPath;
     fs.writeFileSync(saveTo, Buffer.from(data.base64, "base64"));
 
     const skipResize = options.full || toolArgs.full;

--- a/native/client-transport.cjs
+++ b/native/client-transport.cjs
@@ -1,0 +1,168 @@
+const { connectEndpoint } = require("./endpoint.cjs");
+const { createFrameParser, createSocketWriter } = require("./remote-transport.cjs");
+const { createClientTransferController } = require("./file-transfer.cjs");
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 30000;
+
+async function openClientTransport(endpoint, { requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS } = {}) {
+  let socket;
+  let ready;
+  let readyReject;
+  let readyErrorListener;
+  ready = new Promise((resolve, reject) => {
+    readyReject = reject;
+    readyErrorListener = (error) => reject(error);
+    socket = connectEndpoint(endpoint, () => {
+      socket.removeListener("error", readyErrorListener);
+      resolve();
+    });
+    socket.once("error", readyErrorListener);
+  });
+  await ready;
+  const pending = new Map();
+  const writer = createSocketWriter(socket, { onOverflow: ({ error }) => socket.destroy(error) });
+  const transfers = endpoint.kind === "remote"
+    ? createClientTransferController({ writer, onActivity: () => {} })
+    : null;
+  let transferChain = Promise.resolve();
+  let transferCleanupPromise = null;
+  const cleanupTransfers = (error) => {
+    if (!transfers) return Promise.resolve();
+    transferCleanupPromise ||= transfers.cleanup(error);
+    return transferCleanupPromise;
+  };
+  const rejectPending = (error) => {
+    for (const entry of pending.values()) {
+      clearTimeout(entry.timer);
+      entry.reject(error);
+    }
+    pending.clear();
+  };
+  const parser = createFrameParser({
+    onFrame(message) {
+      if (transfers && message.type && message.type.startsWith("transfer_")) {
+        transferChain = transferChain.then(() => transfers.handle(message)).catch((error) => {
+          rejectPending(error);
+          return writer.send({ type: "transfer_error", version: 1, transferId: message.transferId, error: error.message }).finally(() => socket.destroy(error)).then(() => { throw error; });
+        });
+        transferChain.catch(() => undefined);
+        return;
+      }
+      if (message.type === "extension_disconnected") {
+        transferChain = transferChain.then(() => {
+          const error = new Error(message.message || "Surf extension disconnected");
+          rejectPending(error);
+          socket.end();
+        });
+        transferChain.catch(() => undefined);
+        return;
+      }
+      if (message.id === undefined || !pending.has(message.id)) return;
+      transferChain = transferChain.then(() => {
+        const entry = pending.get(message.id);
+        if (!entry) return;
+        pending.delete(message.id);
+        clearTimeout(entry.timer);
+        entry.resolve(message);
+      }).catch((error) => {
+        rejectPending(error);
+        socket.destroy(error);
+      });
+      transferChain.catch(() => undefined);
+    },
+    onError(error) {
+      rejectPending(error);
+      readyReject?.(error);
+      socket.destroy();
+    },
+  });
+  socket.on("data", (chunk) => parser.push(chunk));
+  let closed = false;
+  socket.on("close", () => {
+    parser.close();
+    const error = new Error("connection closed");
+    rejectPending(error);
+    writer.close(error);
+    cleanupTransfers(error);
+    closed = true;
+  });
+  return {
+    socket,
+    transfers,
+    async request(message, timeoutMs = requestTimeoutMs, transferPlan = {}) {
+      if (closed) throw new Error("client transport is closed");
+      if (message.id === undefined || message.id === null) throw new Error("request id is required");
+      if (pending.has(message.id)) throw new Error("duplicate request id");
+      const downloadIds = (transferPlan.downloads || []).map((download) => download.transferId);
+      const timeoutError = new Error("request timed out");
+      let rejectTimeout;
+      const timeout = new Promise((_, reject) => { rejectTimeout = reject; });
+      timeout.catch(() => undefined);
+      const timer = setTimeout(() => {
+        closed = true;
+        rejectPending(timeoutError);
+        cleanupTransfers(timeoutError).catch(() => {});
+        writer.close(timeoutError);
+        socket.destroy();
+        rejectTimeout(timeoutError);
+      }, timeoutMs);
+      const execute = async () => {
+        try {
+          if (transfers) {
+            for (const download of transferPlan.downloads || []) await transfers.expectDownload(download);
+            const uploadDescriptors = [];
+            for (const upload of transferPlan.uploads || []) {
+              const result = await transfers.upload(upload.path, upload);
+              uploadDescriptors.push({ transferId: result.transferId, field: upload.field, original: upload.original, kind: "upload" });
+            }
+            message = { ...message, _surfTransfers: { uploads: uploadDescriptors, downloads: (transferPlan.downloads || []).map(({ transferId, field, original }) => ({ transferId, field, original, kind: "download" })) }, _surfPaths: transferPlan.pathRefs || [] };
+          }
+          const response = new Promise((resolve, reject) => {
+            pending.set(message.id, { resolve, reject, timer });
+          });
+          response.catch(() => undefined);
+          try {
+            await writer.send(message);
+          } catch (error) {
+            const entry = pending.get(message.id);
+            if (entry) { pending.delete(message.id); clearTimeout(entry.timer); entry.reject(error); }
+            await transfers?.cancelDownloads(downloadIds);
+            await response.catch(() => undefined);
+            throw error;
+          }
+          const result = await response;
+          if (result.error || (transfers && downloadIds.some((id) => transfers.hasDownload(id)))) {
+            await transfers?.cancelDownloads(downloadIds);
+            if (!result.error) throw new Error("request completed without completing output download");
+          }
+          return result;
+        } catch (error) {
+          await transfers?.cancelDownloads(downloadIds);
+          throw error;
+        }
+      };
+      try {
+        return await Promise.race([execute(), timeout]);
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+    async closeAsync() {
+      if (closed) return transferCleanupPromise;
+      closed = true;
+      const error = new Error("client transport is closed");
+      parser.close();
+      rejectPending(error);
+      writer.close(error);
+      const cleanup = cleanupTransfers(error);
+      socket.end();
+      await cleanup;
+      return cleanup;
+    },
+    close() {
+      return this.closeAsync();
+    },
+  };
+}
+
+module.exports = { DEFAULT_REQUEST_TIMEOUT_MS, openClientTransport };

--- a/native/do-executor.cjs
+++ b/native/do-executor.cjs
@@ -10,8 +10,10 @@
  * Follows the same socket communication pattern as --script mode in cli.cjs.
  */
 
-const { formatSocketError } = require("./socket-path.cjs");
-const { connectEndpoint, selectEndpoint, formatEndpointError } = require("./endpoint.cjs");
+const { selectEndpoint } = require("./endpoint.cjs");
+const { openClientTransport } = require("./client-transport.cjs");
+const { resolveRequestDeadlineMs } = require("./host-sessions.cjs");
+const { prepareRemoteTool, validateLocalToolPaths } = require("./file-transfer.cjs");
 
 // Maximum iterations for loops (safety cap)
 const MAX_LOOP_ITERATIONS = 100;
@@ -71,49 +73,27 @@ function getAutoWaitCommand(cmd) {
  * @returns {Promise<object>} - Response from host
  */
 function sendDoRequest(toolName, toolArgs, context = {}) {
-  return new Promise((resolve, reject) => {
-    const endpoint = context.endpoint || selectEndpoint([]).endpoint;
-    const sock = connectEndpoint(endpoint, () => {
-      const req = {
-        type: "tool_request",
-        method: "execute_tool",
-        params: { tool: toolName, args: toolArgs },
-        id: "do-" + Date.now() + "-" + Math.random(),
-      };
-      if (context.tabId) req.tabId = context.tabId;
-      if (context.windowId) req.windowId = context.windowId;
-      sock.write(JSON.stringify(req) + "\n");
-    });
-    
-    let buf = "";
-    sock.on("data", (d) => {
-      buf += d.toString();
-      const lines = buf.split("\n");
-      buf = lines.pop();
-      for (const line of lines) {
-        if (!line.trim()) continue;
-        try {
-          const resp = JSON.parse(line);
-          sock.end();
-          resolve(resp);
-        } catch {
-          sock.end();
-          reject(new Error("Invalid JSON response"));
-        }
-      }
-    });
-    
-    sock.on("error", (e) => {
-      reject(new Error(formatEndpointError(e, endpoint, formatSocketError)));
-    });
-    
-    const timeoutId = setTimeout(() => { 
-      sock.destroy(); 
-      reject(new Error("Request timeout")); 
-    }, 30000);
-    
-    sock.on("close", () => clearTimeout(timeoutId));
-  });
+  const request = {
+    type: "tool_request",
+    method: "execute_tool",
+    params: { tool: toolName, args: toolArgs },
+    id: "do-" + Date.now() + "-" + Math.random(),
+  };
+  if (context.tabId) request.tabId = context.tabId;
+  if (context.windowId) request.windowId = context.windowId;
+  const requestTimeoutMs = context.timeoutMs || resolveRequestDeadlineMs(toolName, toolArgs);
+  const endpoint = context.endpoint || selectEndpoint([]).endpoint;
+  const prepared = endpoint.kind === "remote" ? prepareRemoteTool(toolName, toolArgs) : (() => { const args = validateLocalToolPaths(toolName, toolArgs); return { args, uploads: [], downloads: [] }; })();
+  request.params.args = prepared.args;
+  if (context.transport) return context.transport.request(request, requestTimeoutMs, prepared);
+  return (async () => {
+    const transport = await openClientTransport(endpoint);
+    try {
+      return await transport.request(request, requestTimeoutMs, prepared);
+    } finally {
+      await transport.close();
+    }
+  })();
 }
 
 /**

--- a/native/do-executor.cjs
+++ b/native/do-executor.cjs
@@ -10,8 +10,8 @@
  * Follows the same socket communication pattern as --script mode in cli.cjs.
  */
 
-const net = require("net");
-const { SOCKET_PATH, formatSocketError } = require("./socket-path.cjs");
+const { formatSocketError } = require("./socket-path.cjs");
+const { connectEndpoint, selectEndpoint, formatEndpointError } = require("./endpoint.cjs");
 
 // Maximum iterations for loops (safety cap)
 const MAX_LOOP_ITERATIONS = 100;
@@ -72,7 +72,8 @@ function getAutoWaitCommand(cmd) {
  */
 function sendDoRequest(toolName, toolArgs, context = {}) {
   return new Promise((resolve, reject) => {
-    const sock = net.createConnection(SOCKET_PATH, () => {
+    const endpoint = context.endpoint || selectEndpoint([]).endpoint;
+    const sock = connectEndpoint(endpoint, () => {
       const req = {
         type: "tool_request",
         method: "execute_tool",
@@ -103,7 +104,7 @@ function sendDoRequest(toolName, toolArgs, context = {}) {
     });
     
     sock.on("error", (e) => {
-      reject(new Error(formatSocketError(e)));
+      reject(new Error(formatEndpointError(e, endpoint, formatSocketError)));
     });
     
     const timeoutId = setTimeout(() => { 

--- a/native/doctor.cjs
+++ b/native/doctor.cjs
@@ -409,6 +409,7 @@ function remoteRecommendations(endpoint, code) {
   if (code === "ETIMEDOUT") return [...base, `Run \`tailscale ping ${endpoint.host}\`; check restrictive Tailnet ACLs/grants and host firewall rules.`];
   if (code === "ECONNREFUSED") return [...base, "Verify the host process is running and bound to the requested TCP port; check restrictive Tailnet ACLs/grants."];
   if (code === "ENETUNREACH" || code === "EHOSTUNREACH") return [...base, `Run \`tailscale status\` and \`tailscale ping ${endpoint.host}\`; check Tailnet routing plus restrictive ACLs/grants.`];
+  if (code === "EAUTH") return [...base, "Verify the client credential path, pinned host identity, and that the labeled client has not been revoked."].map((item) => item.replace("<host>", endpoint.host));
   return base;
 }
 
@@ -428,21 +429,29 @@ async function runDoctor(rawOptions = {}, deps = {}) {
     const endpoint = selectedEndpoint;
     const connection = await (deps.connectEndpoint || ((target, timeoutMs) => new Promise((resolve) => {
       let settled = false;
-      const socket = connectEndpoint(target);
+      let socket;
       const finish = (result) => {
         if (settled) return;
         settled = true;
         clearTimeout(timeout);
-        socket.destroy();
+        socket?.destroy();
         resolve(result);
       };
-      const timeout = setTimeout(() => finish({ ok: false, code: "ETIMEDOUT", message: `timed out after ${timeoutMs}ms` }), timeoutMs);
-      socket.once("connect", () => finish({ ok: true, message: "connected" }));
+      const timeout = setTimeout(() => finish({
+        ok: false,
+        code: socket?.connected ? "EAUTH" : "ETIMEDOUT",
+        message: socket?.connected ? "remote authentication timed out" : `timed out after ${timeoutMs}ms`,
+      }), timeoutMs);
+      socket = connectEndpoint(target, () => finish({ ok: true, message: "authenticated" }));
       socket.once("error", (error) => finish({ ok: false, code: error.code, message: error.message || String(error) }));
     })))(endpoint, options.connectTimeoutMs);
     const checks = [{ id: "remote-endpoint", status: "info", message: `Remote endpoint: ${endpoint.display}`, endpoint: endpoint.display }, {
       id: "remote-connect", status: connection.ok ? "pass" : "fail",
       message: connection.ok ? `Connected to remote endpoint ${endpoint.display}` : `Could not connect to remote endpoint ${endpoint.display}: ${connection.message}`,
+      code: connection.code,
+    }, {
+      id: "remote-auth", status: connection.ok ? "pass" : connection.code === "EAUTH" ? "fail" : "info",
+      message: connection.ok ? "Remote credential authenticated and server identity verified" : connection.code === "EAUTH" ? "Remote credential rejected, revoked, or server identity mismatch" : "Remote authentication was not reached",
       code: connection.code,
     }];
     const summary = summarize(checks);

--- a/native/doctor.cjs
+++ b/native/doctor.cjs
@@ -3,6 +3,7 @@ const net = require("net");
 const os = require("os");
 const path = require("path");
 const { execFileSync } = require("child_process");
+const { connectEndpoint, selectEndpoint } = require("./endpoint.cjs");
 
 const HOST_NAME = "surf.browser.host";
 
@@ -402,6 +403,15 @@ function buildRecommendations(report) {
   return Array.from(new Set(recommendations));
 }
 
+function remoteRecommendations(endpoint, code) {
+  const base = [`Confirm Surf is listening on ${endpoint.display}; the remote host listener must allow this Tailnet connection.`];
+  if (code === "ENOTFOUND") return [...base, "Check the Tailnet DNS name, then run `tailscale status` and `tailscale ping <host>`."].map((item) => item.replace("<host>", endpoint.host));
+  if (code === "ETIMEDOUT") return [...base, `Run \`tailscale ping ${endpoint.host}\`; check restrictive Tailnet ACLs/grants and host firewall rules.`];
+  if (code === "ECONNREFUSED") return [...base, "Verify the host process is running and bound to the requested TCP port; check restrictive Tailnet ACLs/grants."];
+  if (code === "ENETUNREACH" || code === "EHOSTUNREACH") return [...base, `Run \`tailscale status\` and \`tailscale ping ${endpoint.host}\`; check Tailnet routing plus restrictive ACLs/grants.`];
+  return base;
+}
+
 async function runDoctor(rawOptions = {}, deps = {}) {
   const env = deps.env || process.env;
   const platform = deps.platform || process.platform;
@@ -413,6 +423,33 @@ async function runDoctor(rawOptions = {}, deps = {}) {
     socket: rawOptions.socket || env.SURF_SOCKET || defaultSocketPath(platform),
     connectTimeoutMs: rawOptions.connectTimeoutMs ?? 750,
   };
+  const selectedEndpoint = rawOptions.endpoint || selectEndpoint([], env).endpoint;
+  if (selectedEndpoint.kind === "remote") {
+    const endpoint = selectedEndpoint;
+    const connection = await (deps.connectEndpoint || ((target, timeoutMs) => new Promise((resolve) => {
+      let settled = false;
+      const socket = connectEndpoint(target);
+      const finish = (result) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        socket.destroy();
+        resolve(result);
+      };
+      const timeout = setTimeout(() => finish({ ok: false, code: "ETIMEDOUT", message: `timed out after ${timeoutMs}ms` }), timeoutMs);
+      socket.once("connect", () => finish({ ok: true, message: "connected" }));
+      socket.once("error", (error) => finish({ ok: false, code: error.code, message: error.message || String(error) }));
+    })))(endpoint, options.connectTimeoutMs);
+    const checks = [{ id: "remote-endpoint", status: "info", message: `Remote endpoint: ${endpoint.display}`, endpoint: endpoint.display }, {
+      id: "remote-connect", status: connection.ok ? "pass" : "fail",
+      message: connection.ok ? `Connected to remote endpoint ${endpoint.display}` : `Could not connect to remote endpoint ${endpoint.display}: ${connection.message}`,
+      code: connection.code,
+    }];
+    const summary = summarize(checks);
+    const report = { ok: connection.ok, summary, environment: { platform, remoteEndpoint: endpoint.display, endpointKind: "remote", browsers: [] }, manifests: [], checks };
+    report.recommendations = connection.ok ? [] : remoteRecommendations(endpoint, connection.code);
+    return report;
+  }
   const effectiveTarget = resolveEffectiveTarget(options, { platform, runningInWsl });
   const browsers = resolveBrowsers(options.browser);
   const context = {
@@ -502,9 +539,13 @@ function formatCheck(check) {
 function formatDoctorReport(report) {
   const lines = ["Surf doctor", ""];
   lines.push(`Platform: ${report.environment.platform}${report.environment.runningInWsl ? " (WSL2 detected)" : ""}`);
-  lines.push(`Target: ${report.environment.effectiveTarget === "wsl-windows" ? "Windows browser from WSL2" : report.environment.effectiveTarget}`);
-  lines.push(`Socket: ${report.environment.socketPath}`);
-  lines.push(`Browsers: ${report.environment.browsers.join(", ")}`);
+  if (report.environment.endpointKind === "remote") {
+    lines.push(`Remote endpoint: ${report.environment.remoteEndpoint}`);
+  } else {
+    lines.push(`Target: ${report.environment.effectiveTarget === "wsl-windows" ? "Windows browser from WSL2" : report.environment.effectiveTarget}`);
+  }
+  if (report.environment.socketPath) lines.push(`Socket: ${report.environment.socketPath}`);
+  if (report.environment.browsers.length) lines.push(`Browsers: ${report.environment.browsers.join(", ")}`);
   lines.push("");
 
   for (const check of report.checks.filter((item) => item.status !== "info")) {
@@ -542,7 +583,7 @@ Examples:
 `;
 }
 
-async function runDoctorCli(rawArgs) {
+async function runDoctorCli(rawArgs, endpoint) {
   let options;
   try {
     options = parseDoctorArgs(rawArgs);
@@ -558,7 +599,7 @@ async function runDoctorCli(rawArgs) {
   }
 
   try {
-    const report = await runDoctor(options);
+    const report = await runDoctor({ ...options, endpoint });
     if (options.json) {
       console.log(JSON.stringify(report, null, 2));
     } else {

--- a/native/endpoint.cjs
+++ b/native/endpoint.cjs
@@ -1,5 +1,6 @@
 const net = require("net");
 const { DEFAULT_SOCKET_PATH } = require("./socket-path.cjs");
+const { authenticateClient } = require("./remote-transport.cjs");
 
 function parseRemoteEndpoint(value) {
   if (typeof value !== "string" || !value) throw new Error("--remote requires host:port");
@@ -32,9 +33,15 @@ function parseRemoteEndpoint(value) {
 function selectEndpoint(args, env) {
   const selectedEnv = env === undefined ? process.env : env;
   const remoteIndexes = [];
-  for (let i = 0; i < args.length; i++) if (args[i] === "--remote") remoteIndexes.push(i);
+  const credentialIndexes = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--remote") remoteIndexes.push(i);
+    if (args[i] === "--remote-credential") credentialIndexes.push(i);
+  }
   if (remoteIndexes.length > 1) throw new Error("--remote may only be specified once");
+  if (credentialIndexes.length > 1) throw new Error("--remote-credential may only be specified once");
   let cliRemote;
+  let cliCredential;
   const strippedArgs = [...args];
   if (remoteIndexes.length) {
     const index = remoteIndexes[0];
@@ -42,13 +49,120 @@ function selectEndpoint(args, env) {
     if (!cliRemote || cliRemote.startsWith("--")) throw new Error("--remote requires host:port");
     strippedArgs.splice(index, 2);
   }
-  if (cliRemote || selectedEnv.SURF_REMOTE) return { args: strippedArgs, endpoint: parseRemoteEndpoint(cliRemote || selectedEnv.SURF_REMOTE) };
+  if (credentialIndexes.length) {
+    const index = credentialIndexes[0];
+    cliCredential = args[index + 1];
+    if (!cliCredential || cliCredential.startsWith("--")) throw new Error("--remote-credential requires a file path");
+    const adjustedIndex = index - (remoteIndexes.length && index > remoteIndexes[0] ? 2 : 0);
+    strippedArgs.splice(adjustedIndex, 2);
+  }
+  const remoteValue = cliRemote || selectedEnv.SURF_REMOTE;
+  if (remoteValue) {
+    const credentialPath = cliCredential || selectedEnv.SURF_REMOTE_CREDENTIAL;
+    if (!credentialPath) throw new Error("remote endpoint requires --remote-credential <path> or SURF_REMOTE_CREDENTIAL");
+    return { args: strippedArgs, endpoint: { ...parseRemoteEndpoint(remoteValue), credentialPath } };
+  }
+  if (cliCredential) throw new Error("--remote-credential requires a remote endpoint");
   const socketPath = selectedEnv.SURF_SOCKET || DEFAULT_SOCKET_PATH;
   return { args: strippedArgs, endpoint: { kind: "local", path: socketPath, display: socketPath, key: `unix:${socketPath}`, connectionOptions: socketPath } };
 }
 
+function createRemoteSocket(endpoint) {
+  const rawSocket = net.createConnection(endpoint.connectionOptions, () => {});
+  let ready = false;
+  let connected = false;
+  let destroyed = false;
+  const pending = new Map();
+  const queue = (event, listener, once) => {
+    if (ready) {
+      once ? rawSocket.once(event, listener) : rawSocket.on(event, listener);
+      return;
+    }
+    const listeners = pending.get(event) || [];
+    listeners.push({ listener, once });
+    pending.set(event, listeners);
+  };
+  const flush = () => {
+    ready = true;
+    for (const [event, listeners] of pending) {
+      for (const { listener, once } of listeners) {
+        once ? rawSocket.once(event, listener) : rawSocket.on(event, listener);
+      }
+    }
+    pending.clear();
+  };
+  const proxy = {
+    on(event, listener) { queue(event, listener, false); return proxy; },
+    once(event, listener) { queue(event, listener, true); return proxy; },
+    removeListener(event, listener) {
+      if (ready) rawSocket.removeListener(event, listener);
+      else pending.set(event, (pending.get(event) || []).filter((entry) => entry.listener !== listener));
+      return proxy;
+    },
+    write(...args) { return rawSocket.write(...args); },
+    end(...args) { return rawSocket.end(...args); },
+    destroy(...args) { destroyed = true; return rawSocket.destroy(...args); },
+    setTimeout(...args) { rawSocket.setTimeout(...args); return proxy; },
+    get authenticated() { return ready; },
+    get connected() { return connected; },
+  };
+  rawSocket.once("connect", () => { connected = true; });
+  rawSocket.on("error", (error) => {
+    if (ready || destroyed) return;
+    ready = true;
+    const listeners = pending.get("error") || [];
+    pending.delete("error");
+    for (const { listener } of listeners) listener(error);
+    if (proxy.__pendingErrors) proxy.__pendingErrors.length = 0;
+    flush();
+  });
+  rawSocket.on("close", () => {
+    if (ready) return;
+    ready = true;
+    const error = new Error("remote authentication connection closed");
+    for (const { listener } of pending.get("error") || []) listener(error);
+    for (const { listener } of pending.get("close") || []) listener();
+    pending.clear();
+    if (proxy.__pendingErrors) proxy.__pendingErrors.length = 0;
+  });
+  return { rawSocket, proxy, flush };
+}
+
 function connectEndpoint(endpoint, onConnect) {
-  return net.createConnection(endpoint.connectionOptions, onConnect);
+  if (endpoint.kind === "local") {
+    return net.createConnection(endpoint.connectionOptions, onConnect || (() => {}));
+  }
+  const { rawSocket, proxy, flush } = createRemoteSocket(endpoint);
+  rawSocket.once("connect", () => {
+    authenticateClient(rawSocket, endpoint.credentialPath)
+      .then(() => {
+        flush();
+        if (onConnect) onConnect(proxy);
+      })
+      .catch((error) => {
+        error.code = error.code || "EAUTH";
+        const listeners = proxy.__pendingErrors || [];
+        for (const listener of listeners) {
+          proxy.removeListener("error", listener);
+          listener(error);
+        }
+        proxy.__pendingErrors.length = 0;
+        flush();
+        proxy.destroy();
+      });
+  });
+  proxy.__pendingErrors = [];
+  const originalOn = proxy.on;
+  const originalOnce = proxy.once;
+  proxy.on = (event, listener) => {
+    if (event === "error" && !proxy.authenticated) proxy.__pendingErrors.push(listener);
+    return originalOn(event, listener);
+  };
+  proxy.once = (event, listener) => {
+    if (event === "error" && !proxy.authenticated) proxy.__pendingErrors.push(listener);
+    return originalOnce(event, listener);
+  };
+  return proxy;
 }
 
 function formatEndpointError(error, endpoint, formatSocketError) {

--- a/native/endpoint.cjs
+++ b/native/endpoint.cjs
@@ -1,0 +1,60 @@
+const net = require("net");
+const { DEFAULT_SOCKET_PATH } = require("./socket-path.cjs");
+
+function parseRemoteEndpoint(value) {
+  if (typeof value !== "string" || !value) throw new Error("--remote requires host:port");
+  let host;
+  let portText;
+  if (value.startsWith("[")) {
+    const match = value.match(/^\[([^\]]+)\]:(\d+)$/);
+    if (!match || net.isIP(match?.[1]) !== 6) throw new Error("remote endpoint must use a bracketed IPv6 address and port");
+    [, host, portText] = match;
+    host = new URL(`http://[${host}]`).hostname.slice(1, -1);
+  } else {
+    const match = value.match(/^([^:]+):(\d+)$/);
+    if (!match) throw new Error("remote endpoint must be host:port (IPv6 must be bracketed)");
+    [, host, portText] = match;
+    if (host.includes("/") || host.includes("@") || host.includes(":") || host === "*" || host.includes("*")) throw new Error("remote endpoint host is invalid");
+    if ((/^\d+(?:\.\d+){3}$/.test(host) && net.isIP(host) !== 4) || (net.isIP(host) !== 4 && !/^(?=.{1,253}$)(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)*[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/.test(host))) {
+      throw new Error("remote endpoint host is invalid");
+    }
+    host = host.toLowerCase();
+  }
+  const port = Number(portText);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) throw new Error("remote endpoint port must be between 1 and 65535");
+  if ((net.isIP(host) === 4 && host === "0.0.0.0") || (net.isIP(host) === 6 && /^0*:?0*$/.test(host.replace(/:/g, "")))) {
+    throw new Error("remote endpoint host must not be unspecified");
+  }
+  const display = net.isIP(host) === 6 ? `[${host}]:${port}` : `${host}:${port}`;
+  return { kind: "remote", host, port, display, key: `tcp:${display}`, connectionOptions: { host, port } };
+}
+
+function selectEndpoint(args, env) {
+  const selectedEnv = env === undefined ? process.env : env;
+  const remoteIndexes = [];
+  for (let i = 0; i < args.length; i++) if (args[i] === "--remote") remoteIndexes.push(i);
+  if (remoteIndexes.length > 1) throw new Error("--remote may only be specified once");
+  let cliRemote;
+  const strippedArgs = [...args];
+  if (remoteIndexes.length) {
+    const index = remoteIndexes[0];
+    cliRemote = args[index + 1];
+    if (!cliRemote || cliRemote.startsWith("--")) throw new Error("--remote requires host:port");
+    strippedArgs.splice(index, 2);
+  }
+  if (cliRemote || selectedEnv.SURF_REMOTE) return { args: strippedArgs, endpoint: parseRemoteEndpoint(cliRemote || selectedEnv.SURF_REMOTE) };
+  const socketPath = selectedEnv.SURF_SOCKET || DEFAULT_SOCKET_PATH;
+  return { args: strippedArgs, endpoint: { kind: "local", path: socketPath, display: socketPath, key: `unix:${socketPath}`, connectionOptions: socketPath } };
+}
+
+function connectEndpoint(endpoint, onConnect) {
+  return net.createConnection(endpoint.connectionOptions, onConnect);
+}
+
+function formatEndpointError(error, endpoint, formatSocketError) {
+  if (endpoint.kind === "local") return formatSocketError(error);
+  const message = error?.message || String(error);
+  return `Remote endpoint connection failed (${endpoint.display}): ${message}`;
+}
+
+module.exports = { parseRemoteEndpoint, selectEndpoint, connectEndpoint, formatEndpointError };

--- a/native/file-transfer.cjs
+++ b/native/file-transfer.cjs
@@ -1,0 +1,734 @@
+const crypto = require("crypto");
+const fs = require("fs");
+const fsp = fs.promises;
+const os = require("os");
+const path = require("path");
+
+const TRANSFER_VERSION = 1;
+const DEFAULT_LIMITS = Object.freeze({
+  maxChunkBytes: 256 * 1024,
+  maxFileBytes: 256 * 1024 * 1024,
+  maxSessionBytes: 512 * 1024 * 1024,
+  maxFiles: 32,
+});
+const TRANSFER_TYPES = new Set([
+  "transfer_begin", "transfer_ready", "transfer_chunk", "transfer_end",
+  "transfer_complete", "transfer_error",
+]);
+
+function transferError(message, code = "SURF_TRANSFER_ERROR") {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+function isSha256(value) {
+  return typeof value === "string" && /^[a-f0-9]{64}$/i.test(value);
+}
+
+function decodeBase64(value, maxBytes) {
+  if (typeof value !== "string" || value.length % 4 !== 0 || !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)) {
+    throw transferError("transfer chunk is not strict base64", "SURF_TRANSFER_BASE64");
+  }
+  const decoded = Buffer.from(value, "base64");
+  if (decoded.toString("base64") !== value) throw transferError("transfer chunk is not canonical base64", "SURF_TRANSFER_BASE64");
+  if (decoded.length === 0) throw transferError("transfer chunk must not be empty", "SURF_TRANSFER_CHUNK");
+  if (decoded.length > maxBytes) throw transferError("transfer chunk exceeds limit", "SURF_TRANSFER_CHUNK_LIMIT");
+  return decoded;
+}
+
+function parsePathDescriptor(value, { mode = "remote", field = "path" } = {}) {
+  if (typeof value !== "string" || value.length === 0) throw transferError(`${field} must be a path string`, "SURF_PATH_INVALID");
+  const original = value;
+  if (value.startsWith("remote:")) {
+    if (mode === "local") throw transferError(`${field} remote: paths are not allowed in local mode`, "SURF_PATH_REMOTE_LOCAL");
+    const resolved = value.slice("remote:".length);
+    if (!path.isAbsolute(resolved)) throw transferError(`${field} remote: path must be absolute`, "SURF_PATH_REMOTE_RELATIVE");
+    return { kind: "remote", path: resolved, original };
+  }
+  if (value.startsWith("local:")) {
+    const resolved = value.slice("local:".length);
+    if (!resolved) throw transferError(`${field} local: path is empty`, "SURF_PATH_INVALID");
+    return { kind: "local", path: path.resolve(resolved), original };
+  }
+  return { kind: mode === "local" ? "local" : "local", path: path.resolve(value), original };
+}
+
+function rewritePath(value, descriptor) {
+  if (!descriptor) return value;
+  return descriptor.original;
+}
+
+function randomId(prefix = "transfer") {
+  return `${prefix}-${crypto.randomBytes(16).toString("hex")}`;
+}
+
+async function createStagingDirectory(root, connectionId = randomId("connection")) {
+  const dir = await fsp.mkdtemp(path.join(root || os.tmpdir(), `surf-transfer-${connectionId}-`));
+  try {
+    await fsp.chmod(dir, 0o700);
+    return dir;
+  } catch (error) {
+    await fsp.rm(dir, { recursive: true, force: true }).catch(() => {});
+    throw error;
+  }
+}
+
+function randomStagingPath(directory, extension = "") {
+  const suffix = extension && /^\.[A-Za-z0-9]{1,16}$/.test(extension) ? extension : "";
+  return path.join(directory, `${crypto.randomBytes(20).toString("hex")}${suffix}`);
+}
+
+async function assertRegularFile(filePath, field = "file") {
+  const stats = await fsp.stat(filePath);
+  if (!stats.isFile()) throw transferError(`${field} must be a regular file`, "SURF_PATH_NOT_REGULAR");
+  return stats;
+}
+
+function createTransferState({ directory, writer, limits = {}, completedTtlMs = 60000, onActivity = () => {}, onCleanup = () => {} } = {}) {
+  const caps = { ...DEFAULT_LIMITS, ...limits };
+  const transfers = new Map();
+  const completed = new Map();
+  const outboundWaiters = new Map();
+  const seenIds = new Set();
+  let usedBytes = 0;
+  let fileCount = 0;
+  let closed = false;
+
+  const remove = async (state) => {
+    if (!state || state.removed) return;
+    state.removed = true;
+    transfers.delete(state.id);
+    completed.delete(state.id);
+    if (state.completedTimer) clearTimeout(state.completedTimer);
+    try { await state.file?.close(); } catch {}
+    try { await fsp.rm(state.filePath, { force: true }); } catch {}
+    try { await onCleanup(state); } catch {}
+  };
+
+  const fail = async (state, error) => {
+    await remove(state);
+    throw error;
+  };
+
+  const begin = async (frame) => {
+    if (closed) throw transferError("transfer connection is closed", "SURF_TRANSFER_CLOSED");
+    if (frame.version !== TRANSFER_VERSION || !TRANSFER_TYPES.has(frame.type) || frame.type !== "transfer_begin") throw transferError("invalid transfer begin frame", "SURF_TRANSFER_PROTOCOL");
+    if (typeof frame.transferId !== "string" || seenIds.has(frame.transferId) || transfers.has(frame.transferId) || completed.has(frame.transferId)) throw transferError("duplicate or invalid transfer ID", "SURF_TRANSFER_DUPLICATE");
+    if (frame.direction !== "upload" && frame.direction !== "download") throw transferError("invalid transfer direction", "SURF_TRANSFER_PROTOCOL");
+    if (!Number.isSafeInteger(frame.size) || frame.size < 0 || frame.size > caps.maxFileBytes) throw transferError("declared transfer size exceeds limit", "SURF_TRANSFER_FILE_LIMIT");
+    if (!isSha256(frame.sha256)) throw transferError("declared transfer hash is invalid", "SURF_TRANSFER_HASH");
+    if (fileCount >= caps.maxFiles) throw transferError("transfer file count limit exceeded", "SURF_TRANSFER_COUNT_LIMIT");
+    if (usedBytes + frame.size > caps.maxSessionBytes) throw transferError("transfer session byte limit exceeded", "SURF_TRANSFER_SESSION_LIMIT");
+    if (frame.direction === "download") throw transferError("host transfer state accepts uploads only", "SURF_TRANSFER_DIRECTION");
+    seenIds.add(frame.transferId);
+    const state = {
+      id: frame.transferId,
+      direction: frame.direction,
+      size: frame.size,
+      sha256: frame.sha256.toLowerCase(),
+      sequence: 0,
+      received: 0,
+      hash: crypto.createHash("sha256"),
+      filePath: randomStagingPath(directory),
+      file: null,
+      removed: false,
+    };
+    state.file = await fsp.open(state.filePath, "wx", 0o600);
+    await fsp.chmod(state.filePath, 0o600);
+    transfers.set(state.id, state);
+    usedBytes += state.size;
+    fileCount += 1;
+    onActivity();
+    await writer.send({ type: "transfer_ready", version: TRANSFER_VERSION, transferId: state.id });
+    return state;
+  };
+
+  const chunk = async (frame) => {
+    const state = transfers.get(frame.transferId);
+    if (!state || state.direction !== "upload") throw transferError("unknown transfer ID or direction", "SURF_TRANSFER_UNKNOWN");
+    if (!Number.isSafeInteger(frame.sequence) || frame.sequence !== state.sequence) return fail(state, transferError("transfer chunks are out of order", "SURF_TRANSFER_SEQUENCE"));
+    let data;
+    try { data = decodeBase64(frame.data, caps.maxChunkBytes); } catch (error) { return fail(state, error); }
+    if (state.received + data.length > state.size) return fail(state, transferError("transfer exceeds declared size", "SURF_TRANSFER_SIZE"));
+    await state.file.write(data);
+    state.hash.update(data);
+    state.received += data.length;
+    state.sequence += 1;
+    onActivity();
+  };
+
+  const end = async (frame) => {
+    const state = transfers.get(frame.transferId);
+    if (!state || state.direction !== "upload") throw transferError("unknown transfer ID or direction", "SURF_TRANSFER_UNKNOWN");
+    if (state.received !== state.size || state.hash.digest("hex") !== state.sha256) return fail(state, transferError("transfer size or SHA-256 mismatch", "SURF_TRANSFER_INTEGRITY"));
+    await state.file.close();
+    transfers.delete(state.id);
+    completed.set(state.id, state);
+    state.completedTimer = setTimeout(() => { discardCompleted(state.id).catch(() => {}); }, completedTtlMs);
+    state.complete = true;
+    await writer.send({ type: "transfer_complete", version: TRANSFER_VERSION, transferId: state.id, size: state.size, sha256: state.sha256 });
+    onActivity();
+    return state;
+  };
+
+  const handle = async (frame) => {
+    if (!frame || !TRANSFER_TYPES.has(frame.type)) return false;
+    if (frame.version !== TRANSFER_VERSION) throw transferError("unsupported transfer protocol version", "SURF_TRANSFER_PROTOCOL");
+    if (frame.type === "transfer_complete" && outboundWaiters.has(frame.transferId)) {
+      outboundWaiters.get(frame.transferId).resolve(frame);
+      outboundWaiters.delete(frame.transferId);
+      return true;
+    }
+    if (frame.type === "transfer_begin") await begin(frame);
+    else if (frame.type === "transfer_chunk") await chunk(frame);
+    else if (frame.type === "transfer_end") await end(frame);
+    else throw transferError("unexpected transfer control frame", "SURF_TRANSFER_PROTOCOL");
+    return true;
+  };
+
+  const reserveOutbound = (size, id) => {
+    if (id && seenIds.has(id)) throw transferError("duplicate transfer ID", "SURF_TRANSFER_DUPLICATE");
+    if (id) seenIds.add(id);
+    if (size > caps.maxFileBytes) throw transferError("transfer file size limit exceeded", "SURF_TRANSFER_FILE_LIMIT");
+    if (fileCount >= caps.maxFiles) throw transferError("transfer file count limit exceeded", "SURF_TRANSFER_COUNT_LIMIT");
+    if (usedBytes + size > caps.maxSessionBytes) throw transferError("transfer session byte limit exceeded", "SURF_TRANSFER_SESSION_LIMIT");
+    usedBytes += size; fileCount += 1;
+  };
+  const releaseOutbound = (size) => {
+    usedBytes = Math.max(0, usedBytes - size);
+    fileCount = Math.max(0, fileCount - 1);
+  };
+  const waitOutbound = (id) => new Promise((resolve, reject) => outboundWaiters.set(id, { resolve, reject }));
+  const discardCompleted = async (id) => {
+    const state = completed.get(id);
+    if (!state) return false;
+    completed.delete(id);
+    if (state.completedTimer) clearTimeout(state.completedTimer);
+    try { await fsp.rm(state.filePath, { force: true }); } catch {}
+    try { await onCleanup(state); } catch {}
+    return true;
+  };
+  const takeCompleted = (id) => {
+    const state = completed.get(id);
+    if (state) {
+      completed.delete(id);
+      if (state.completedTimer) clearTimeout(state.completedTimer);
+    }
+    return state;
+  };
+  const cleanup = async () => {
+    closed = true;
+    await Promise.all([...transfers.values()].map(remove));
+    await Promise.all([...completed.keys()].map(discardCompleted));
+    transfers.clear();
+    for (const waiter of outboundWaiters.values()) waiter.reject(transferError("transfer connection closed", "SURF_TRANSFER_CLOSED"));
+    outboundWaiters.clear();
+    try { await fsp.rm(directory, { recursive: true, force: true }); } catch {}
+  };
+  return { handle, cleanup, reserveOutbound, releaseOutbound, waitOutbound, takeCompleted, discardCompleted, get directory() { return directory; }, get transfers() { return transfers; }, get completed() { return completed; }, get usedBytes() { return usedBytes; }, get fileCount() { return fileCount; } };
+}
+
+async function cleanupFilePaths(paths = []) {
+  const owned = paths.splice(0, paths.length);
+  await Promise.all(owned.map((filePath) => fsp.rm(filePath, { force: true }).catch(() => {})));
+}
+
+async function hashFile(filePath) {
+  const hash = crypto.createHash("sha256");
+  let size = 0;
+  for await (const chunk of fs.createReadStream(filePath)) { hash.update(chunk); size += chunk.length; }
+  return { size, sha256: hash.digest("hex") };
+}
+
+async function writeAtomicDownload(destination, chunks, expected) {
+  const directory = path.dirname(destination);
+  await fsp.mkdir(directory, { recursive: true });
+  const temp = path.join(directory, `.${path.basename(destination)}.surf-${crypto.randomBytes(12).toString("hex")}.tmp`);
+  const handle = await fsp.open(temp, "wx", 0o600);
+  const hash = crypto.createHash("sha256");
+  let size = 0;
+  try {
+    for await (const chunk of chunks) { size += chunk.length; if (size > expected.size) throw transferError("download exceeds declared size", "SURF_TRANSFER_SIZE"); hash.update(chunk); await handle.write(chunk); }
+    await handle.close();
+    if (size !== expected.size || hash.digest("hex") !== expected.sha256.toLowerCase()) throw transferError("download size or SHA-256 mismatch", "SURF_TRANSFER_INTEGRITY");
+    await fsp.chmod(temp, 0o600);
+    await fsp.rename(temp, destination);
+  } catch (error) {
+    await handle.close().catch(() => {});
+    await fsp.rm(temp, { force: true }).catch(() => {});
+    throw error;
+  }
+  return destination;
+}
+
+function validateLocalToolPaths(tool, args = {}) {
+  const normalized = { ...args };
+  const normalize = (field, value) => parsePathDescriptor(value, { mode: "local", field }).path;
+  if (tool === "upload" && args.files !== undefined) {
+    normalized.files = Array.isArray(args.files)
+      ? args.files.map((value) => normalize("files", value))
+      : String(args.files).split(",").map((value) => normalize("files", value.trim())).join(",");
+  }
+  if (tool === "screenshot") {
+    if (args.savePath !== undefined && args.output !== undefined) throw transferError("screenshot accepts only one output path", "SURF_PATH_FIELD");
+    for (const field of ["savePath", "output"]) if (args[field] !== undefined) normalized[field] = normalize(field, args[field]);
+  }
+  if (tool === "network.export") {
+    if (args.har !== undefined && typeof args.har !== "boolean") throw transferError("network.export har must be boolean", "SURF_PATH_FIELD");
+    if (args.jsonl !== undefined && typeof args.jsonl !== "boolean") throw transferError("network.export jsonl must be boolean", "SURF_PATH_FIELD");
+    if (args.har === true && args.jsonl === true) throw transferError("network.export cannot combine HAR and JSONL", "SURF_PATH_FIELD");
+    normalized.output = args.output === undefined
+      ? generatedClientPath("network-export", args.har === true ? ".har" : args.jsonl === true ? ".jsonl" : ".json")
+      : normalize("output", args.output);
+  }
+  if (tool === "gemini") for (const field of ["file", "edit-image", "generate-image", "output"]) if (args[field] !== undefined) normalized[field] = normalize(field, args[field]);
+  if (tool === "chatgpt" && args.file !== undefined) normalized.file = Array.isArray(args.file) ? args.file.map((value) => normalize("file", value)) : normalize("file", args.file);
+  return normalized;
+}
+
+function isPlainObject(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function rewriteTransferPaths(value, rewrites, depth = 0, seen = new Set(), budget = { remaining: 1000 }) {
+  if (budget.remaining-- <= 0 || depth > 8) throw transferError("response exceeds path rewrite limits", "SURF_TRANSFER_RESPONSE_LIMIT");
+  if (value === null || value === undefined) return value;
+  if (typeof value === "string") {
+    return rewrites.reduce((result, rewrite) => result.replaceAll(rewrite.path, rewrite.original), value);
+  }
+  if (Array.isArray(value)) return value.map((entry) => rewriteTransferPaths(entry, rewrites, depth + 1, seen, budget));
+  if (!isPlainObject(value)) return value;
+  if (seen.has(value)) throw transferError("response contains a cyclic value", "SURF_TRANSFER_RESPONSE_LIMIT");
+  seen.add(value);
+  const result = Object.create(Object.getPrototypeOf(value));
+  for (const [key, entry] of Object.entries(value)) {
+    Object.defineProperty(result, key, {
+      value: rewriteTransferPaths(entry, rewrites, depth + 1, seen, budget),
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+  }
+  return result;
+}
+
+const AUTO_SCREENSHOT_TOOLS = Object.freeze(["click", "type", "key", "smart_type", "form.fill", "form_input", "drag", "hover", "scroll", "scroll.top", "scroll.bottom", "scroll.to", "dialog.accept", "dialog.dismiss", "js", "eval"]);
+function generatedClientPath(prefix, extension) {
+  return path.join(os.tmpdir(), `surf-${prefix}-${crypto.randomBytes(12).toString("hex")}${extension}`);
+}
+
+function scalarPath(value, field) {
+  if (typeof value !== "string" || !value) throw transferError(`${field} must be one path string`, "SURF_PATH_DESCRIPTOR");
+  return value;
+}
+
+function prepareRemoteTool(tool, args = {}) {
+  const prepared = { ...args };
+  const uploads = [];
+  const downloads = [];
+  const pathRefs = [];
+  const addPath = (field, value, kind) => {
+    const descriptor = parsePathDescriptor(scalarPath(value, field), { mode: "remote", field });
+    pathRefs.push({ field, kind, original: descriptor.original, path: descriptor.kind === "remote" ? descriptor.path : descriptor.original, pathKind: descriptor.kind });
+    if (descriptor.kind === "remote") prepared[field] = `remote:${descriptor.path}`;
+    return descriptor;
+  };
+  const addInput = (field, value) => {
+    const descriptor = addPath(field, value, "input");
+    if (descriptor.kind === "local") uploads.push({ path: descriptor.path, field, original: descriptor.original, transferId: randomId("upload") });
+    return descriptor;
+  };
+  const addOutput = (field, value) => {
+    const descriptor = addPath(field, value, "output");
+    if (descriptor.kind === "local") downloads.push({ transferId: randomId("download"), field, original: descriptor.original, destination: descriptor.path });
+    return descriptor;
+  };
+
+  if (args.autoScreenshot !== undefined && typeof args.autoScreenshot !== "boolean") throw transferError("autoScreenshot must be boolean", "SURF_PATH_DESCRIPTOR");
+  if (args.autoScreenshot === true && !AUTO_SCREENSHOT_TOOLS.includes(tool)) throw transferError(`autoScreenshot is not supported for ${tool}`, "SURF_PATH_DESCRIPTOR");
+  if (args.autoScreenshotOutput !== undefined) throw transferError("autoScreenshotOutput is internal", "SURF_PATH_DESCRIPTOR");
+  if (tool === "record") throw transferError("record is not supported with remote endpoint", "SURF_REMOTE_UNSUPPORTED");
+  if (tool === "aistudio.build") throw transferError("aistudio.build is not supported for remote connections", "SURF_REMOTE_UNSUPPORTED");
+  if (tool === "smoke" && args.screenshot !== undefined) throw transferError("smoke screenshots are not supported for remote connections", "SURF_REMOTE_UNSUPPORTED");
+  if (tool === "network.export") {
+    if (args.har !== undefined && typeof args.har !== "boolean") throw transferError("network.export har must be boolean", "SURF_PATH_FIELD");
+    if (args.jsonl !== undefined && typeof args.jsonl !== "boolean") throw transferError("network.export jsonl must be boolean", "SURF_PATH_FIELD");
+    if (args.har === true && args.jsonl === true) throw transferError("network.export cannot combine --har and --jsonl", "SURF_PATH_FIELD");
+    const output = args.output === undefined
+      ? generatedClientPath("network-export", args.har === true ? ".har" : args.jsonl === true ? ".jsonl" : ".json")
+      : scalarPath(args.output, "output");
+    prepared.output = output;
+    addOutput("output", output);
+  }
+
+  if (tool === "chatgpt" && args.file !== undefined) {
+    addInput("file", scalarPath(args.file, "file"));
+  }
+
+  if (tool === "gemini") {
+    const hasFile = args.file !== undefined;
+    const hasEdit = args["edit-image"] !== undefined;
+    const hasGenerate = args["generate-image"] !== undefined;
+    const hasOutput = args.output !== undefined;
+    if (hasFile && (hasEdit || hasGenerate || hasOutput)) throw transferError("gemini attachment cannot combine with image mode or output", "SURF_REMOTE_UNSUPPORTED");
+    if (hasEdit && hasGenerate) throw transferError("gemini edit-image cannot combine with generate-image", "SURF_REMOTE_UNSUPPORTED");
+    if (hasGenerate && hasOutput) throw transferError("gemini generate-image uses its own output path", "SURF_REMOTE_UNSUPPORTED");
+    if (hasOutput && !hasEdit) throw transferError("gemini output requires edit-image", "SURF_REMOTE_UNSUPPORTED");
+    if (hasFile) addInput("file", scalarPath(args.file, "file"));
+    if (hasEdit) {
+      addInput("edit-image", scalarPath(args["edit-image"], "edit-image"));
+      const output = hasOutput ? scalarPath(args.output, "output") : "edited.png";
+      prepared.output = output;
+      addOutput("output", output);
+    } else if (hasGenerate) {
+      if (hasOutput) throw transferError("gemini generate-image uses its own output path", "SURF_REMOTE_UNSUPPORTED");
+      addOutput("generate-image", scalarPath(args["generate-image"], "generate-image"));
+    }
+  }
+
+  if (tool === "upload") {
+    const files = Array.isArray(args.files)
+      ? args.files
+      : typeof args.files === "string" ? args.files.split(",").map((value) => value.trim()).filter(Boolean) : [];
+    if (files.length !== 1) throw transferError("remote upload supports exactly one file", "SURF_REMOTE_UNSUPPORTED");
+    const descriptor = addInput("files", files[0]);
+    prepared.files = [descriptor.kind === "remote" ? `remote:${descriptor.path}` : files[0]];
+  }
+
+  if (tool === "screenshot") {
+    if (args.savePath !== undefined && args.output !== undefined) throw transferError("screenshot accepts only one output path", "SURF_PATH_FIELD");
+    if (args.savePath !== undefined || args.output !== undefined) {
+      const field = args.savePath !== undefined ? "savePath" : "output";
+      addOutput(field, args[field]);
+    }
+  }
+
+  if (args.autoScreenshot === true) {
+    const output = generatedClientPath("auto-screenshot", ".png");
+    prepared.autoScreenshotOutput = output;
+    addOutput("autoScreenshotOutput", output);
+  }
+
+  return { args: prepared, uploads, downloads, pathRefs };
+}
+
+function exactTransferObject(value, fields, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) throw transferError(`${label} must be an object`, "SURF_PATH_DESCRIPTOR");
+  const allowed = new Set(fields);
+  for (const key of Object.keys(value)) if (!allowed.has(key)) throw transferError(`${label} contains unsupported field ${key}`, "SURF_PATH_DESCRIPTOR");
+  for (const key of fields) if (!(key in value)) throw transferError(`${label} is missing ${key}`, "SURF_PATH_DESCRIPTOR");
+  return value;
+}
+
+async function materializeRemoteTool({ tool, args: rawArgs = {}, metadata = null, pathRefs = [], transferState, getTransferState } = {}) {
+  const args = { ...rawArgs };
+  if (args.autoScreenshot !== undefined && typeof args.autoScreenshot !== "boolean") throw transferError("autoScreenshot must be boolean", "SURF_PATH_DESCRIPTOR");
+  if (args.autoScreenshot === true && !AUTO_SCREENSHOT_TOOLS.includes(tool)) throw transferError(`autoScreenshot is not supported for ${tool}`, "SURF_PATH_DESCRIPTOR");
+  if (args.autoScreenshotOutput !== undefined && !(args.autoScreenshot === true && AUTO_SCREENSHOT_TOOLS.includes(tool))) throw transferError("autoScreenshotOutput is internal", "SURF_PATH_DESCRIPTOR");
+  const meta = metadata === undefined || metadata === null ? {} : exactTransferObject(metadata, ["uploads", "downloads"], "transfer metadata");
+  const uploads = meta.uploads === undefined ? [] : meta.uploads;
+  const downloads = meta.downloads === undefined ? [] : meta.downloads;
+  if (!Array.isArray(pathRefs) || !Array.isArray(uploads) || !Array.isArray(downloads) || uploads.length > 1 || downloads.length > 1) throw transferError("invalid transfer metadata", "SURF_PATH_DESCRIPTOR");
+  if (tool === "record" || tool === "aistudio.build") throw transferError(`${tool} is not supported for remote connections`, "SURF_REMOTE_UNSUPPORTED");
+  if (tool === "smoke" && args.screenshot !== undefined) throw transferError("smoke screenshots are not supported for remote connections", "SURF_REMOTE_UNSUPPORTED");
+  if (tool === "network.export") {
+    if (args.har !== undefined && typeof args.har !== "boolean") throw transferError("network.export har must be boolean", "SURF_PATH_FIELD");
+    if (args.jsonl !== undefined && typeof args.jsonl !== "boolean") throw transferError("network.export jsonl must be boolean", "SURF_PATH_FIELD");
+    if (args.har === true && args.jsonl === true) throw transferError("network.export cannot combine --har and --jsonl", "SURF_PATH_FIELD");
+  }
+
+  const descriptors = pathRefs.map((entry) => exactTransferObject(entry, ["field", "kind", "original", "path", "pathKind"], "path descriptor"));
+  const seenFields = new Set();
+  for (const descriptor of descriptors) {
+    if (typeof descriptor.field !== "string" || typeof descriptor.original !== "string" || !descriptor.original || typeof descriptor.path !== "string" || !descriptor.path) throw transferError("invalid path descriptor values", "SURF_PATH_DESCRIPTOR");
+    const parsed = parsePathDescriptor(descriptor.original, { mode: "remote", field: descriptor.field });
+    const expected = parsed.kind === "remote" ? parsed.path : descriptor.original;
+    if (seenFields.has(descriptor.field) || !["files", "file", "edit-image", "generate-image", "savePath", "output", "autoScreenshotOutput"].includes(descriptor.field) || !["input", "output"].includes(descriptor.kind) || descriptor.pathKind !== parsed.kind || descriptor.path !== expected) throw transferError("invalid or duplicate path descriptor", "SURF_PATH_DESCRIPTOR");
+    seenFields.add(descriptor.field);
+  }
+  const validateTransfer = (entry, fields, label) => {
+    exactTransferObject(entry, fields, label);
+    if (typeof entry.transferId !== "string" || !entry.transferId || entry.transferId.length > 128 || typeof entry.field !== "string" || typeof entry.original !== "string" || !entry.original || typeof entry.kind !== "string") throw transferError(`${label} contains invalid values`, "SURF_PATH_DESCRIPTOR");
+  };
+  uploads.forEach((entry) => validateTransfer(entry, ["transferId", "field", "original", "kind"], "upload descriptor"));
+  downloads.forEach((entry) => validateTransfer(entry, ["transferId", "field", "original", "kind"], "download descriptor"));
+
+  const pathFor = (field, kind) => descriptors.filter((entry) => entry.field === field && entry.kind === kind);
+  const rawMatches = (field, original) => field === "files"
+    ? Array.isArray(args[field]) && args[field].length === 1 && args[field][0] === original
+    : typeof args[field] === "string" && args[field] === original;
+  const outputTransfers = [];
+  const pathRewrites = [];
+  const transferCleanup = [];
+  let state = transferState;
+
+  const materializeInput = async (field) => {
+    const descriptor = descriptors.find((entry) => entry.field === field && entry.kind === "input");
+    if (!descriptor || !rawMatches(field, descriptor.original)) throw transferError(`${field} input descriptor mismatch`, "SURF_PATH_DESCRIPTOR");
+    if (descriptor.pathKind === "remote") {
+      if (uploads.length || descriptor.path !== parsePathDescriptor(descriptor.original, { mode: "remote", field }).path) throw transferError(`${field} remote descriptor mismatch`, "SURF_PATH_DESCRIPTOR");
+      await assertRegularFile(descriptor.path, field);
+      args[field] = descriptor.path;
+      pathRewrites.push({ path: descriptor.path, original: descriptor.original });
+      return descriptor;
+    }
+    const upload = uploads.find((entry) => entry.field === field && entry.kind === "upload" && entry.original === descriptor.original);
+    if (!upload || !state) throw transferError(`${field} upload is not complete`, "SURF_TRANSFER_UNKNOWN");
+    const completed = state.takeCompleted(upload.transferId);
+    if (!completed) throw transferError(`${field} upload is not complete`, "SURF_TRANSFER_UNKNOWN");
+    args[field] = completed.filePath;
+    pathRewrites.push({ path: completed.filePath, original: descriptor.original });
+    transferCleanup.push(completed.filePath);
+    return descriptor;
+  };
+  const materializeOutput = async (field) => {
+    const descriptor = descriptors.find((entry) => entry.field === field && entry.kind === "output");
+    if (!descriptor || !rawMatches(field, descriptor.original)) throw transferError(`${field} output descriptor mismatch`, "SURF_PATH_DESCRIPTOR");
+    if (descriptor.pathKind === "remote") {
+      const allowsGeminiInputOutput = tool === "gemini" && args["edit-image"] !== undefined;
+      if ((!allowsGeminiInputOutput && uploads.length) || downloads.length || descriptor.path !== parsePathDescriptor(descriptor.original, { mode: "remote", field }).path) throw transferError(`${field} remote descriptor mismatch`, "SURF_PATH_DESCRIPTOR");
+      args[field] = descriptor.path;
+      pathRewrites.push({ path: descriptor.path, original: descriptor.original });
+      return descriptor;
+    }
+    const download = downloads.find((entry) => entry.field === field && entry.kind === "download" && entry.original === descriptor.original);
+    const allowsGeminiInputOutput = tool === "gemini" && args["edit-image"] !== undefined;
+    if (!download || (!allowsGeminiInputOutput && uploads.length) || downloads.length !== 1) throw transferError(`${field} download descriptor mismatch`, "SURF_PATH_DESCRIPTOR");
+    state ||= await getTransferState();
+    const stagingPath = randomStagingPath(state.directory);
+    args[field] = stagingPath;
+    outputTransfers.push({ ...download, path: stagingPath });
+    pathRewrites.push({ path: stagingPath, original: descriptor.original });
+    transferCleanup.push(stagingPath);
+    return descriptor;
+  };
+
+  try {
+  if (tool === "upload") {
+    const files = args.files;
+    if (!Array.isArray(files) || files.length !== 1 || descriptors.length !== 1 || pathFor("files", "input").length !== 1 || downloads.length || !rawMatches("files", descriptors[0].original)) throw transferError("upload requires exactly one matching files input descriptor", "SURF_PATH_DESCRIPTOR");
+    await materializeInput("files");
+  } else if (tool === "chatgpt") {
+    if (args.file !== undefined) {
+      if (typeof args.file !== "string" || descriptors.length !== 1 || downloads.length) throw transferError("chatgpt attachment metadata mismatch", "SURF_PATH_DESCRIPTOR");
+      await materializeInput("file");
+    } else if (descriptors.length || uploads.length || downloads.length) throw transferError("chatgpt transfer metadata has no attachment", "SURF_PATH_DESCRIPTOR");
+  } else if (tool === "gemini") {
+    const hasFile = args.file !== undefined;
+    const hasEdit = args["edit-image"] !== undefined;
+    const hasGenerate = args["generate-image"] !== undefined;
+    const hasOutput = args.output !== undefined;
+    if (hasFile && (hasEdit || hasGenerate || hasOutput)) throw transferError("gemini attachment cannot combine with image mode or output", "SURF_REMOTE_UNSUPPORTED");
+    if (hasEdit && hasGenerate) throw transferError("gemini edit-image cannot combine with generate-image", "SURF_REMOTE_UNSUPPORTED");
+    if (hasGenerate && hasOutput) throw transferError("gemini generate-image uses its own output path", "SURF_REMOTE_UNSUPPORTED");
+    if (hasOutput && !hasEdit) throw transferError("gemini output requires edit-image", "SURF_REMOTE_UNSUPPORTED");
+    if (hasFile) {
+      if (descriptors.length !== 1 || downloads.length || pathFor("file", "input").length !== 1) throw transferError("gemini attachment metadata mismatch", "SURF_PATH_DESCRIPTOR");
+      await materializeInput("file");
+    } else if (hasEdit) {
+      if (descriptors.length !== 2 || pathFor("edit-image", "input").length !== 1 || pathFor("output", "output").length !== 1) throw transferError("gemini edit metadata mismatch", "SURF_PATH_DESCRIPTOR");
+      await materializeInput("edit-image");
+      await materializeOutput("output");
+    } else if (hasGenerate) {
+      if (descriptors.length !== 1 || pathFor("generate-image", "output").length !== 1) throw transferError("gemini generate metadata mismatch", "SURF_PATH_DESCRIPTOR");
+      await materializeOutput("generate-image");
+    }
+    else if (descriptors.length || uploads.length || downloads.length) throw transferError("gemini transfer metadata has no image path", "SURF_PATH_DESCRIPTOR");
+  } else if (tool === "screenshot") {
+    if (args.savePath !== undefined && args.output !== undefined) throw transferError("screenshot accepts only one output path", "SURF_PATH_FIELD");
+    const field = args.savePath !== undefined ? "savePath" : args.output !== undefined ? "output" : null;
+    if (field) {
+      if (descriptors.length !== 1) throw transferError("screenshot output metadata mismatch", "SURF_PATH_DESCRIPTOR");
+      await materializeOutput(field);
+    }
+    else if (descriptors.length || uploads.length || downloads.length) throw transferError("screenshot transfer metadata has no output path", "SURF_PATH_DESCRIPTOR");
+  } else if (tool === "network.export") {
+    if (typeof args.output !== "string" || descriptors.length !== 1 || pathFor("output", "output").length !== 1) throw transferError("network export output metadata mismatch", "SURF_PATH_DESCRIPTOR");
+    await materializeOutput("output");
+  } else if (AUTO_SCREENSHOT_TOOLS.includes(tool) && args.autoScreenshot === true) {
+    if (descriptors.length !== 1 || descriptors[0].field !== "autoScreenshotOutput" || descriptors[0].pathKind !== "local" || uploads.length) throw transferError("auto screenshot metadata mismatch", "SURF_PATH_DESCRIPTOR");
+    await materializeOutput("autoScreenshotOutput");
+  } else if (descriptors.length || uploads.length || downloads.length) {
+    throw transferError("file transfer metadata is not supported for this tool", "SURF_PATH_DESCRIPTOR");
+  }
+
+  if (uploads.length && !["upload", "chatgpt", "gemini"].includes(tool)) throw transferError("upload metadata is not supported for this tool", "SURF_PATH_DESCRIPTOR");
+  if (downloads.length && !["screenshot", "gemini", "network.export", ...AUTO_SCREENSHOT_TOOLS].includes(tool)) throw transferError("download metadata is not supported for this tool", "SURF_PATH_DESCRIPTOR");
+    return { args, transferState: state, outputTransfers, pathRewrites, transferCleanup };
+  } catch (error) {
+    await cleanupFilePaths([...new Set(transferCleanup)]);
+    throw error;
+  }
+}
+
+async function streamFileDownload({ writer, state, filePath, transferId = randomId("download"), original } = {}) {
+  const stats = await assertRegularFile(filePath, "download");
+  if (stats.size > DEFAULT_LIMITS.maxFileBytes) throw transferError("download exceeds file size limit", "SURF_TRANSFER_FILE_LIMIT");
+  state.reserveOutbound(stats.size, transferId);
+  let digest;
+  try {
+    digest = await hashFile(filePath);
+    if (digest.size !== stats.size || digest.size > DEFAULT_LIMITS.maxFileBytes) throw transferError("download changed during hashing", "SURF_TRANSFER_INTEGRITY");
+  } catch (error) {
+    state.releaseOutbound?.(stats.size);
+    throw error;
+  }
+  await writer.send({ type: "transfer_begin", version: TRANSFER_VERSION, direction: "download", transferId, size: digest.size, sha256: digest.sha256 });
+  let sequence = 0;
+  for await (const chunk of fs.createReadStream(filePath, { highWaterMark: DEFAULT_LIMITS.maxChunkBytes })) {
+    await writer.send({ type: "transfer_chunk", version: TRANSFER_VERSION, transferId, sequence, data: chunk.toString("base64") });
+    sequence += 1;
+  }
+  const completion = state.waitOutbound(transferId);
+  await writer.send({ type: "transfer_end", version: TRANSFER_VERSION, transferId });
+  await completion;
+  return { transferId, size: digest.size, sha256: digest.sha256 };
+}
+
+function createClientTransferController({ writer, limits = {}, onActivity = () => {} } = {}) {
+  const caps = { ...DEFAULT_LIMITS, ...limits };
+  const incoming = new Map();
+  const waiters = new Map();
+  let usedBytes = 0;
+  let fileCount = 0;
+  const seenIds = new Set();
+  let closed = false;
+  const waitFor = (id, type) => new Promise((resolve, reject) => {
+    const key = `${id}:${type}`;
+    waiters.set(key, { resolve, reject });
+  });
+  const settle = (frame) => {
+    const entry = waiters.get(`${frame.transferId}:${frame.type}`);
+    if (!entry) return false;
+    waiters.delete(`${frame.transferId}:${frame.type}`);
+    entry.resolve(frame);
+    return true;
+  };
+  const cancelDownload = async (transferId) => {
+    const state = incoming.get(transferId);
+    if (!state) return false;
+    incoming.delete(transferId);
+    await state.file?.close().catch(() => {});
+    await fsp.rm(state.temp, { force: true }).catch(() => {});
+    return true;
+  };
+  const cancelDownloads = async (ids) => {
+    for (const id of ids || [...incoming.keys()]) await cancelDownload(id);
+  };
+  const hasDownload = (id) => incoming.has(id);
+  const failDownload = async (id, error) => { await cancelDownload(id); throw error; };
+  const upload = async (filePath, { transferId = randomId("upload"), original, field } = {}) => {
+    if (closed) throw transferError("transfer connection is closed", "SURF_TRANSFER_CLOSED");
+    if (seenIds.has(transferId)) throw transferError("duplicate transfer ID", "SURF_TRANSFER_DUPLICATE");
+    seenIds.add(transferId);
+    const stats = await assertRegularFile(filePath, field || "upload");
+    if (stats.size > caps.maxFileBytes) throw transferError("upload exceeds file size limit", "SURF_TRANSFER_FILE_LIMIT");
+    if (fileCount >= caps.maxFiles || usedBytes + stats.size > caps.maxSessionBytes) throw transferError("transfer session limit exceeded", "SURF_TRANSFER_SESSION_LIMIT");
+    const digest = await hashFile(filePath);
+    usedBytes += digest.size; fileCount += 1;
+    const ready = waitFor(transferId, "transfer_ready");
+    await writer.send({ type: "transfer_begin", version: TRANSFER_VERSION, direction: "upload", transferId, size: digest.size, sha256: digest.sha256 });
+    await ready;
+    let sequence = 0;
+    for await (const chunk of fs.createReadStream(filePath, { highWaterMark: caps.maxChunkBytes })) {
+      await writer.send({ type: "transfer_chunk", version: TRANSFER_VERSION, transferId, sequence, data: chunk.toString("base64") });
+      sequence += 1;
+      onActivity();
+    }
+    const completeWait = waitFor(transferId, "transfer_complete");
+    await writer.send({ type: "transfer_end", version: TRANSFER_VERSION, transferId });
+    const complete = await completeWait;
+    return { transferId, size: digest.size, sha256: digest.sha256 };
+  };
+  const expectDownload = async ({ transferId, destination, size, sha256 }) => {
+    if (incoming.has(transferId) || seenIds.has(transferId)) throw transferError("duplicate transfer ID", "SURF_TRANSFER_DUPLICATE");
+    seenIds.add(transferId);
+    if (fileCount >= caps.maxFiles || (size !== undefined && (size > caps.maxFileBytes || usedBytes + size > caps.maxSessionBytes))) throw transferError("transfer session limit exceeded", "SURF_TRANSFER_SESSION_LIMIT");
+    const directory = path.dirname(destination);
+    await fsp.mkdir(directory, { recursive: true });
+    const temp = path.join(directory, `.${path.basename(destination)}.surf-${crypto.randomBytes(12).toString("hex")}.tmp`);
+    const file = await fsp.open(temp, "wx", 0o600);
+    incoming.set(transferId, { transferId, destination, size, sha256: sha256?.toLowerCase(), temp, file, hash: crypto.createHash("sha256"), sequence: 0, received: 0 });
+    fileCount += 1;
+  };
+  const handle = async (frame) => {
+    if (!frame || !TRANSFER_TYPES.has(frame.type)) return false;
+    if (frame.version !== TRANSFER_VERSION) throw transferError("unsupported transfer protocol version", "SURF_TRANSFER_PROTOCOL");
+    if (frame.type === "transfer_error") {
+      let found = false;
+      for (const [key, waiter] of waiters) {
+        if (key.startsWith(`${frame.transferId}:`)) { waiters.delete(key); waiter.reject(transferError(frame.error || "transfer failed")); found = true; }
+      }
+      if (!found) throw transferError("unknown transfer ID", "SURF_TRANSFER_UNKNOWN");
+      return true;
+    }
+    if (frame.type === "transfer_ready" || frame.type === "transfer_complete") {
+      if (!settle(frame)) throw transferError("unknown transfer ID", "SURF_TRANSFER_UNKNOWN");
+      return true;
+    }
+    if (frame.type === "transfer_begin") {
+      const state = incoming.get(frame.transferId);
+      if (!state || frame.direction !== "download" || (state.size !== undefined && frame.size !== state.size) || (state.sha256 && frame.sha256.toLowerCase() !== state.sha256)) return failDownload(frame.transferId, transferError("unknown or mismatched download", "SURF_TRANSFER_UNKNOWN"));
+      state.size = frame.size; state.sha256 = frame.sha256.toLowerCase();
+      if (usedBytes + state.size > caps.maxSessionBytes || state.size > caps.maxFileBytes) {
+        return failDownload(state.transferId, transferError("transfer session limit exceeded", "SURF_TRANSFER_SESSION_LIMIT"));
+      }
+      usedBytes += state.size;
+      state.started = true; onActivity(); return true;
+    }
+    const state = incoming.get(frame.transferId);
+    if (!state || !state.started) throw transferError("unknown transfer ID or state", "SURF_TRANSFER_UNKNOWN");
+    if (frame.type === "transfer_chunk") {
+      if (frame.sequence !== state.sequence) return failDownload(state.transferId, transferError("download chunks are out of order", "SURF_TRANSFER_SEQUENCE"));
+      let data;
+      try { data = decodeBase64(frame.data, caps.maxChunkBytes); } catch (error) { return failDownload(state.transferId, error); }
+      if (state.received + data.length > state.size) return failDownload(state.transferId, transferError("download exceeds declared size", "SURF_TRANSFER_SIZE"));
+      await state.file.write(data); state.hash.update(data); state.sequence += 1; state.received += data.length; onActivity(); return true;
+    }
+    if (frame.type === "transfer_end") {
+      const actualHash = state.hash.digest("hex");
+      if (state.received !== state.size || actualHash !== state.sha256) {
+        return failDownload(state.transferId, transferError(`download size or SHA-256 mismatch (received ${state.received}/${state.size})`, "SURF_TRANSFER_INTEGRITY"));
+      }
+      await state.file.close(); await fsp.chmod(state.temp, 0o600); await fsp.rename(state.temp, state.destination);
+      incoming.delete(state.transferId);
+      await writer.send({ type: "transfer_complete", version: TRANSFER_VERSION, transferId: state.transferId, size: state.size, sha256: state.sha256 });
+      onActivity(); return true;
+    }
+    throw transferError("unexpected transfer frame", "SURF_TRANSFER_PROTOCOL");
+  };
+  const cleanup = async (error = transferError("transfer connection closed", "SURF_TRANSFER_CLOSED")) => {
+    closed = true;
+    for (const entry of waiters.values()) entry.reject(error);
+    waiters.clear();
+    await cancelDownloads();
+  };
+  return { upload, expectDownload, cancelDownload, cancelDownloads, hasDownload, handle, cleanup };
+}
+
+module.exports = {
+  AUTO_SCREENSHOT_TOOLS,
+  DEFAULT_LIMITS,
+  TRANSFER_VERSION,
+  TRANSFER_TYPES,
+  assertRegularFile,
+  createStagingDirectory,
+  createTransferState,
+  createClientTransferController,
+  cleanupFilePaths,
+  decodeBase64,
+  streamFileDownload,
+  hashFile,
+  materializeRemoteTool,
+  parsePathDescriptor,
+  prepareRemoteTool,
+  randomStagingPath,
+  validateLocalToolPaths,
+  rewritePath,
+  rewriteTransferPaths,
+  transferError,
+  writeAtomicDownload,
+};

--- a/native/gemini-client.cjs
+++ b/native/gemini-client.cjs
@@ -6,6 +6,7 @@
  */
 
 const https = require("https");
+const { abortError, abortableDelay, raceAbort, throwIfAborted } = require("./abort.cjs");
 const fs = require("fs");
 const path = require("path");
 
@@ -96,7 +97,8 @@ function hasRequiredCookies(cookieMap) {
 // ============================================================================
 
 function httpsGet(url, headers, opts = {}) {
-  const { binary = false, timeoutMs = 30000, log = null, label = "httpsGet" } = opts;
+  const { binary = false, timeoutMs = 30000, log = null, label = "httpsGet", signal } = opts;
+  throwIfAborted(signal);
   return new Promise((resolve, reject) => {
     const urlObj = new URL(url);
     const options = {
@@ -131,13 +133,17 @@ function httpsGet(url, headers, opts = {}) {
       });
     });
 
+    const onAbort = () => req.destroy(abortError(signal, "Request cancelled"));
+    signal?.addEventListener("abort", onAbort, { once: true });
     req.on("timeout", () => {
       req.destroy(new Error(`${label}: request timeout after ${timeoutMs}ms`));
     });
     req.on("error", (err) => {
+      signal?.removeEventListener("abort", onAbort);
       if (log) log(`${label}: request error ${err.message}`);
       reject(err);
     });
+    req.on("close", () => signal?.removeEventListener("abort", onAbort));
     req.end();
   });
 }
@@ -151,7 +157,8 @@ function httpsPut(url, headers, body, opts = {}) {
 }
 
 function httpsSend(method, url, headers, body, opts = {}) {
-  const { timeoutMs = 30000, log = null, label = "httpsSend" } = opts;
+  const { timeoutMs = 30000, log = null, label = "httpsSend", signal } = opts;
+  throwIfAborted(signal);
   return new Promise((resolve, reject) => {
     const urlObj = new URL(url);
     const bodyBuffer = body == null
@@ -185,13 +192,17 @@ function httpsSend(method, url, headers, body, opts = {}) {
       });
     });
 
+    const onAbort = () => req.destroy(abortError(signal, "Request cancelled"));
+    signal?.addEventListener("abort", onAbort, { once: true });
     req.on("timeout", () => {
       req.destroy(new Error(`${label}: request timeout after ${timeoutMs}ms`));
     });
     req.on("error", (err) => {
+      signal?.removeEventListener("abort", onAbort);
       if (log) log(`${label}: request error ${err.message}`);
       reject(err);
     });
+    req.on("close", () => signal?.removeEventListener("abort", onAbort));
     if (bodyBuffer) req.write(bodyBuffer);
     req.end();
   });
@@ -549,16 +560,17 @@ function buildGeminiFReqPayload(prompt, uploaded, chatMetadata) {
 }
 
 async function runGeminiWebOnce(input) {
-  const { prompt, files, model, cookieMap, chatMetadata, timeoutMs = 30000, log = null } = input;
+  const { prompt, files, model, cookieMap, chatMetadata, timeoutMs = 30000, log = null, signal } = input;
+  throwIfAborted(signal);
   const cookieHeader = buildCookieHeader(cookieMap);
   
   // 1. Get access token
-  const at = await fetchGeminiAccessToken(cookieMap, { timeoutMs, log, label: "geminiAccessToken" });
+  const at = await fetchGeminiAccessToken(cookieMap, { timeoutMs, log, label: "geminiAccessToken", signal });
 
   // 2. Upload files
   const uploaded = [];
   for (const file of files ?? []) {
-    uploaded.push(await uploadGeminiFile(file, cookieMap, { timeoutMs, log, label: "geminiUpload" }));
+    uploaded.push(await uploadGeminiFile(file, cookieMap, { timeoutMs, log, label: "geminiUpload", signal }));
   }
 
   // 3. Build request
@@ -576,7 +588,7 @@ async function runGeminiWebOnce(input) {
     "x-same-domain": "1",
     "cookie": cookieHeader,
     [MODEL_HEADER_NAME]: MODEL_HEADERS[model] || MODEL_HEADERS["gemini-3.1-pro"],
-  }, params.toString(), { timeoutMs, log, label: "geminiStreamGenerate" });
+  }, params.toString(), { timeoutMs, log, label: "geminiStreamGenerate", signal });
 
   const rawResponseText = res.text;
   
@@ -623,6 +635,7 @@ async function runGeminiWebOnce(input) {
 }
 
 async function runGeminiWebWithFallback(input) {
+  throwIfAborted(input.signal);
   const attempt = await runGeminiWebOnce(input);
   
   // Auto-fallback to flash if model unavailable
@@ -639,7 +652,14 @@ async function runGeminiWebWithFallback(input) {
 // ============================================================================
 
 async function runGeminiWebViaPage(input) {
-  const { prompt, files, model, timeoutMs = 120000, log = null, createTab, closeTab, jsEval, fetchUrl, uploadFile } = input;
+  const { prompt, files, model, timeoutMs = 120000, log = null, createTab, closeTab, jsEval, fetchUrl, uploadFile, signal } = input;
+  throwIfAborted(signal);
+  const guardedUploadFile = uploadFile
+    ? (...args) => raceAbort(() => uploadFile(...args), signal)
+    : uploadFile;
+  const guardedFetchUrl = fetchUrl
+    ? (...args) => raceAbort(() => fetchUrl(...args), signal)
+    : fetchUrl;
 
   if (!createTab || !closeTab || !jsEval) {
     throw new Error("In-page execution requires createTab, closeTab, and jsEval callbacks");
@@ -648,19 +668,19 @@ async function runGeminiWebViaPage(input) {
   let tabId = null;
   try {
     if (log) log("Creating Gemini tab...");
-    const tabResult = await createTab();
+    const tabResult = await raceAbort(createTab, signal);
     tabId = tabResult?.tabId;
     if (!tabId) throw new Error("Failed to create Gemini tab");
     if (log) log(`Gemini tab created: ${tabId}`);
-    await new Promise(r => setTimeout(r, 12000));
+    await abortableDelay(12000, signal);
 
     if (files?.length && uploadFile) {
       const absFiles = files.map(f => path.resolve(process.cwd(), f));
       if (log) log(`Uploading ${absFiles.length} file(s) via file chooser...`);
-      const result = await uploadFile(tabId, absFiles);
+      const result = await guardedUploadFile(tabId, absFiles);
       if (result?.error) throw new Error(`File upload failed: ${result.error}`);
       if (log) log("File uploaded, waiting for processing...");
-      await new Promise(r => setTimeout(r, 3000));
+      await abortableDelay(3000, signal);
     }
 
     const checkJsResult = (result, context) => {
@@ -717,7 +737,7 @@ async function runGeminiWebViaPage(input) {
     let responseText = "";
 
     while (Date.now() < deadline) {
-      await new Promise(r => setTimeout(r, 2000));
+      await abortableDelay(2000, signal);
       const pollResult = await jsEval(tabId, `(async () => {
         const baselineKeys = new Set(${JSON.stringify(baselineImageKeys)});
         const imageKey = (img) => {
@@ -812,7 +832,7 @@ async function runGeminiWebViaPage(input) {
       }
       if (img?.url && fetchUrl) {
         if (log) log(`Downloading image (${img.url.slice(0, 60)}...)...`);
-        const dlResult = await fetchUrl(img.url);
+        const dlResult = await guardedFetchUrl(img.url);
         if (dlResult?.b64) {
           images.push({ url: img.url, b64: dlResult.b64, type: dlResult.type || "image/png" });
         }
@@ -830,7 +850,13 @@ async function runGeminiWebViaPage(input) {
       _pageTabId: tabId,
     };
   } catch (err) {
-    if (tabId) { try { await closeTab(tabId); } catch {} }
+    if (tabId) {
+      try {
+        await closeTab(tabId);
+      } catch (closeError) {
+        log?.(`Failed to close Gemini tab ${tabId}: ${closeError?.message || closeError}`);
+      }
+    }
     throw err;
   }
 }
@@ -857,14 +883,17 @@ async function query(options) {
     uploadFile,
     timeout = 300000,
     log = () => {},
+    signal,
   } = options;
+  throwIfAborted(signal);
   const hasPageCallbacks = !!(createTab && closeTab && jsEval);
+  const guardedJsEval = (...args) => raceAbort(() => jsEval(...args), signal);
 
   const startTime = Date.now();
   log("Starting Gemini query");
 
   // 1. Get cookies from Chrome
-  const cookieResponse = await getCookies();
+  const cookieResponse = await raceAbort(getCookies, signal);
   const cookies = cookieResponse?.cookies;
   if (!Array.isArray(cookies)) {
     throw new Error("Failed to get cookies from Chrome. Make sure the extension is loaded and Chrome is running.");
@@ -921,16 +950,17 @@ async function query(options) {
         log,
         createTab,
         closeTab,
-        jsEval,
+        jsEval: guardedJsEval,
         fetchUrl,
         uploadFile,
+        signal,
       });
 
       response = out;
       
       // Save output image
       const outputPath = output || generateImage || "edited.png";
-      const saveOpts = { timeoutMs: timeout, log };
+      const saveOpts = { timeoutMs: timeout, log, signal };
       if (fetchUrl) saveOpts.fetchUrl = fetchUrl;
       try {
         const imageSave = await saveFirstGeminiImage(out, cookieMap, outputPath, saveOpts);
@@ -938,7 +968,13 @@ async function query(options) {
           throw new Error(`No images generated. Response: ${out.text?.slice(0, 200) || "(empty)"}`);
         }
       } finally {
-        if (out._pageTabId && closeTab) { try { await closeTab(out._pageTabId); } catch {} }
+        if (out._pageTabId && closeTab) {
+          try {
+            await closeTab(out._pageTabId);
+          } catch (closeError) {
+            log(`Failed to close Gemini tab ${out._pageTabId}: ${closeError?.message || closeError}`);
+          }
+        }
       }
       imagePath = outputPath;
       
@@ -954,8 +990,9 @@ async function query(options) {
           log,
           createTab,
           closeTab,
-          jsEval,
+          jsEval: guardedJsEval,
           fetchUrl,
+          signal,
         });
       } else {
         out = await runGeminiWebWithFallback({
@@ -966,13 +1003,14 @@ async function query(options) {
           chatMetadata: null,
           timeoutMs: timeout,
           log,
+          signal,
         });
       }
 
       response = out;
       
       // Save output image
-      const saveOpts = { timeoutMs: timeout, log };
+      const saveOpts = { timeoutMs: timeout, log, signal };
       if (fetchUrl) saveOpts.fetchUrl = fetchUrl;
       try {
         const imageSave = await saveFirstGeminiImage(out, cookieMap, generateImage, saveOpts);
@@ -980,7 +1018,13 @@ async function query(options) {
           throw new Error(`No images generated. Response: ${out.text?.slice(0, 200) || "(empty)"}`);
         }
       } finally {
-        if (out._pageTabId && closeTab) { try { await closeTab(out._pageTabId); } catch {} }
+        if (out._pageTabId && closeTab) {
+          try {
+            await closeTab(out._pageTabId);
+          } catch (closeError) {
+            log(`Failed to close Gemini tab ${out._pageTabId}: ${closeError?.message || closeError}`);
+          }
+        }
       }
       imagePath = generateImage;
       
@@ -995,11 +1039,13 @@ async function query(options) {
         chatMetadata: null,
         timeoutMs: timeout,
         log,
+        signal,
       });
 
       response = out;
     }
   } catch (error) {
+    if (error?.code === "SURF_REQUEST_ABORTED") throw error;
     throw new Error(`Gemini request failed: ${error.message}`);
   }
 
@@ -1021,6 +1067,7 @@ async function query(options) {
 // ============================================================================
 
 module.exports = {
+  httpsGet,
   query,
   hasRequiredCookies,
   buildCookieMap,

--- a/native/grok-client.cjs
+++ b/native/grok-client.cjs
@@ -6,6 +6,7 @@
  */
 
 const { loadConfig, getConfigPath, clearCache } = require("./config.cjs");
+const { abortableDelay, raceAbort, throwIfAborted } = require("./abort.cjs");
 
 const GROK_URL = "https://x.com/i/grok";
 const DEFAULT_MODEL = "fast";
@@ -38,8 +39,8 @@ const GROK_MODELS = DEFAULT_GROK_MODELS;
 // Helpers
 // ============================================================================
 
-function delay(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
+function delay(ms, signal) {
+  return abortableDelay(ms, signal);
 }
 
 function buildClickDispatcher() {
@@ -132,8 +133,10 @@ function hasRequiredCookies(cookies) {
   return Boolean(authToken);
 }
 
-async function evaluate(cdp, expression) {
+async function evaluate(cdp, expression, signal) {
+  throwIfAborted(signal);
   const result = await cdp(expression);
+  throwIfAborted(signal);
   if (result.exceptionDetails) {
     const desc = result.exceptionDetails.exception?.description ||
                  result.exceptionDetails.text ||
@@ -533,7 +536,8 @@ function extractGrokResponse(bodyText, userPrompt = '', chipTexts = []) {
   return null;
 }
 
-async function waitForResponse(cdp, timeoutMs = 300000, userPrompt = '') {
+async function waitForResponse(cdp, timeoutMs = 300000, userPrompt = '', signal) {
+  throwIfAborted(signal);
   // Grok can take a long time:
   // - Thinking models: 40-60+ seconds to think, then streams
   // - Fast/Auto models: No thinking phase, just streams directly
@@ -619,7 +623,7 @@ async function waitForResponse(cdp, timeoutMs = 300000, userPrompt = '') {
     })()`);
 
     if (!snapshot || !snapshot.bodyText) {
-      await delay(300);
+      await delay(300, signal);
       continue;
     }
 
@@ -638,7 +642,7 @@ async function waitForResponse(cdp, timeoutMs = 300000, userPrompt = '') {
     if (snapshot.thinkingDone && !thinkingComplete) {
       thinkingComplete = true;
       // Give a brief moment for final render, then we're done
-      await delay(500);
+      await delay(500, signal);
     }
 
     // Extract the actual response text - try DOM-extracted first, fall back to body parsing
@@ -696,7 +700,7 @@ async function waitForResponse(cdp, timeoutMs = 300000, userPrompt = '') {
       };
     }
 
-    await delay(300);
+    await delay(300, signal);
   }
 
   // Timeout - return whatever we have (partial response is better than nothing)
@@ -728,20 +732,22 @@ async function query(options) {
     cdpEvaluate,
     cdpCommand,
     log = () => {},
+    signal,
   } = options;
+  throwIfAborted(signal);
 
   const startTime = Date.now();
   log("Starting Grok query");
 
   // Check cookies for X.com authentication
-  const { cookies } = await getCookies();
+  const { cookies } = await raceAbort(getCookies, signal);
   if (!hasRequiredCookies(cookies)) {
     throw new Error("X.com login required - log in to x.com in Chrome first");
   }
   log(`Got ${cookies.length} cookies`);
 
   // Create tab
-  const tabInfo = await createTab();
+  const tabInfo = await raceAbort(createTab, signal);
   const { tabId } = tabInfo || {};
 
   if (!tabId) {
@@ -749,8 +755,8 @@ async function query(options) {
   }
   log(`Created tab ${tabId}`);
 
-  const cdp = (expr) => cdpEvaluate(tabId, expr);
-  const inputCdp = (method, params) => cdpCommand(tabId, method, params);
+  const cdp = (expr) => raceAbort(() => cdpEvaluate(tabId, expr), signal);
+  const inputCdp = (method, params) => raceAbort(() => cdpCommand(tabId, method, params), signal);
 
   try {
     // Wait for page load
@@ -788,6 +794,7 @@ async function query(options) {
         warnings.push(`Requested model "${targetModel}" but got "${selectedModel}" - model may not be available`);
       }
     } catch (e) {
+      if (signal?.aborted) throw e;
       modelSelectionFailed = true;
       warnings.push(`Model selection failed: ${e.message}. Run 'surf grok --validate' to check available models.`);
       log(`Model selection failed: ${e.message}`);
@@ -805,6 +812,7 @@ async function query(options) {
           warnings.push(`DeepSearch toggle not found - feature may require X Premium or UI changed`);
         }
       } catch (e) {
+        if (signal?.aborted) throw e;
         warnings.push(`DeepSearch toggle failed: ${e.message}`);
         log(`DeepSearch toggle failed: ${e.message}`);
       }
@@ -819,7 +827,7 @@ async function query(options) {
     log("Submitted, waiting for response...");
 
     // Wait for response
-    const response = await waitForResponse(cdp, timeout, prompt);
+    const response = await waitForResponse(cdp, timeout, prompt, signal);
     const thinkingInfo = response.thinkingTime ? ` (thought for ${response.thinkingTime}s)` : '';
     log(`Response: ${response.text.length} chars${thinkingInfo}${response.partial ? ' (partial)' : ''}`);
 
@@ -837,7 +845,11 @@ async function query(options) {
       tookMs: Date.now() - startTime,
     };
   } finally {
-    await closeTab(tabId).catch(() => {});
+    try {
+      await closeTab(tabId);
+    } catch (error) {
+      log(`Failed to close Grok tab ${tabId}: ${error?.message || error}`);
+    }
   }
 }
 
@@ -852,7 +864,9 @@ async function validate(options) {
     closeTab,
     cdpEvaluate,
     log = () => {},
+    signal,
   } = options;
+  throwIfAborted(signal);
 
   const startTime = Date.now();
   log("Starting Grok validation");
@@ -871,7 +885,7 @@ async function validate(options) {
 
   // Check cookies
   try {
-    const { cookies } = await getCookies();
+    const { cookies } = await raceAbort(getCookies, signal);
     result.authenticated = hasRequiredCookies(cookies);
     if (!result.authenticated) {
       result.errors.push("Not authenticated - log in to x.com in Chrome first");
@@ -879,6 +893,7 @@ async function validate(options) {
     }
     log("Cookies OK");
   } catch (e) {
+    if (signal?.aborted) throw e;
     result.errors.push(`Cookie check failed: ${e.message}`);
     return { ...result, tookMs: Date.now() - startTime };
   }
@@ -886,7 +901,7 @@ async function validate(options) {
   // Create tab
   let tabId;
   try {
-    const tabInfo = await createTab();
+    const tabInfo = await raceAbort(createTab, signal);
     tabId = tabInfo?.tabId;
     if (!tabId) {
       result.errors.push("Failed to create tab");
@@ -894,15 +909,16 @@ async function validate(options) {
     }
     log(`Created tab ${tabId}`);
   } catch (e) {
+    if (signal?.aborted) throw e;
     result.errors.push(`Tab creation failed: ${e.message}`);
     return { ...result, tookMs: Date.now() - startTime };
   }
 
-  const cdp = (expr) => cdpEvaluate(tabId, expr);
+  const cdp = (expr) => raceAbort(() => cdpEvaluate(tabId, expr), signal);
 
   try {
     // Wait for page load
-    await waitForPageLoad(cdp);
+    await raceAbort(waitForPageLoad(cdp), signal);
     log("Page loaded");
 
     // Check login status
@@ -917,7 +933,7 @@ async function validate(options) {
     log(`Login: yes${result.premium ? ' (Premium)' : ''}`);
 
     // Wait for Grok UI
-    await waitForGrokReady(cdp);
+    await raceAbort(waitForGrokReady(cdp), signal);
     log("Grok ready");
 
     // Check for input field
@@ -954,7 +970,7 @@ async function validate(options) {
     })()`);
 
     if (modelButtonClicked?.success) {
-      await delay(500);
+      await abortableDelay(500, signal);
 
       // Scrape model options
       const modelScrape = await evaluate(cdp, `(() => {
@@ -1000,9 +1016,14 @@ async function validate(options) {
     }
 
   } catch (e) {
+    if (signal?.aborted) throw e;
     result.errors.push(`Validation error: ${e.message}`);
   } finally {
-    await closeTab(tabId).catch(() => {});
+    try {
+      await closeTab(tabId);
+    } catch (error) {
+      log(`Failed to close Grok validation tab ${tabId}: ${error?.message || error}`);
+    }
   }
 
   result.tookMs = Date.now() - startTime;

--- a/native/host-helpers.cjs
+++ b/native/host-helpers.cjs
@@ -20,7 +20,7 @@ function normalizeModelString(model) {
  * @param {Function} log - Logging function (defaults to no-op for testing)
  * @returns {Array} Array of content objects with type and text/data
  */
-function formatToolContent(result, log = () => {}) {
+function formatToolContent(result, log = () => {}, options = {}) {
   const text = (s) => [{ type: "text", text: s }];
   
   if (!result) return text("OK");
@@ -390,6 +390,7 @@ function formatToolContent(result, log = () => {}) {
 
   if (result.autoScreenshot) {
     const { path: ssPath, width, height } = result.autoScreenshot;
+    if (options.suppressImages) return text(`OK\nScreenshot saved: ${ssPath}`);
     try {
       const imgData = fs.readFileSync(ssPath);
       const base64 = imgData.toString("base64");
@@ -731,7 +732,6 @@ function mapToolToMessage(tool, args, tabId) {
         type: "EXPORT_NETWORK_REQUESTS",
         har: a.har,
         jsonl: a.jsonl,
-        output: a.output,
         ...baseMsg 
       };
 

--- a/native/host-sessions.cjs
+++ b/native/host-sessions.cjs
@@ -1,0 +1,283 @@
+const { abortError } = require("./abort.cjs");
+
+const MAX_CONNECTIONS = 32;
+const MAX_REMOTE_CONNECTIONS = 16;
+const MAX_PRINCIPAL_CONNECTIONS = 4;
+const MAX_WAITERS = 16;
+const MAX_STREAMS_PER_PRINCIPAL = 2;
+const MAX_REMOTE_STREAMS = 4;
+const MAX_STREAMS = 4;
+const REQUEST_ID_LIMIT = 128;
+const TOOL_NAME_LIMIT = 128;
+const LEASE_IDLE_MS = 5000;
+const AUTHENTICATED_IDLE_MS = 15000;
+const QUEUE_TIMEOUT_MS = 60000;
+const DEFAULT_DEADLINE_MS = 60000;
+const MAX_DEADLINE_MS = 50 * 60 * 1000;
+const CLEANUP_GRACE_MS = 60000;
+const PROVIDER_DEFAULT_TIMEOUT_SECONDS = {
+  ai: 300,
+  aistudio: 300,
+  "aistudio.build": 600,
+  chatgpt: 2700,
+  gemini: 300,
+  grok: 300,
+  perplexity: 120,
+};
+
+function resolveRequestDeadlineMs(tool, args = {}) {
+  const defaultSeconds = PROVIDER_DEFAULT_TIMEOUT_SECONDS[tool];
+  if (defaultSeconds === undefined) return DEFAULT_DEADLINE_MS;
+  const requestedSeconds = Number(
+    args && typeof args === "object" && !Array.isArray(args) ? args.timeout : undefined,
+  );
+  const seconds = Number.isFinite(requestedSeconds) && requestedSeconds > 0
+    ? requestedSeconds
+    : defaultSeconds;
+  return Math.min(seconds * 1000 + CLEANUP_GRACE_MS, MAX_DEADLINE_MS);
+}
+
+class HostSessionManager {
+  constructor({ audit = () => {}, onTimeout = () => {} } = {}) {
+    this.audit = audit;
+    this.onTimeout = onTimeout;
+    this.contexts = new Set();
+    this.principalCounts = new Map();
+    this.waiters = [];
+    this.leaseOwner = null;
+    this.remoteConnections = 0;
+    this.streams = new Set();
+  }
+
+  admit(socket, isRemote) {
+    if (this.contexts.size >= MAX_CONNECTIONS) throw new Error("maximum client connections reached");
+    if (isRemote && this.remoteConnections >= MAX_REMOTE_CONNECTIONS) throw new Error("maximum remote connections reached");
+    const context = {
+      socket,
+      isRemote,
+      principal: null,
+      closed: false,
+      activeRequest: null,
+      seenRequestIds: new Set(),
+      idleTimer: null,
+      workTimer: null,
+      admitted: true,
+      stream: false,
+    };
+    this.contexts.add(context);
+    if (isRemote) this.remoteConnections += 1;
+    this.audit({ event: "connection", context, outcome: "accepted" });
+    return context;
+  }
+
+  authenticate(context, principal) {
+    if (context.closed) throw new Error("connection is closed");
+    const count = this.principalCounts.get(principal.clientId) || 0;
+    if (count >= MAX_PRINCIPAL_CONNECTIONS) throw new Error("maximum connections for remote principal reached");
+    context.principal = principal;
+    this.principalCounts.set(principal.clientId, count + 1);
+    context.workTimer = setTimeout(() => {
+      if (!context.closed && !context.activeRequest) {
+        this.audit({ event: "connection", context, outcome: "authenticated-idle-timeout" });
+        context.socket.destroy();
+      }
+    }, AUTHENTICATED_IDLE_MS);
+    this.audit({ event: "authentication", context, outcome: "success" });
+  }
+
+  touch(context) {
+    if (!context || context.closed || !context.isRemote || context.activeRequest) return;
+    if (context.workTimer) clearTimeout(context.workTimer);
+    context.workTimer = setTimeout(() => {
+      if (!context.closed && !context.activeRequest) {
+        this.audit({ event: "connection", context, outcome: "authenticated-idle-timeout" });
+        context.socket.destroy();
+      }
+    }, AUTHENTICATED_IDLE_MS);
+  }
+
+  canStartStream(context) {
+    if (context.closed || context.stream || context.activeRequest || this.leaseOwner === context) return false;
+    const principalId = context.principal?.clientId || "local";
+    const principalStreams = [...this.streams].filter((entry) => entry.principalId === principalId).length;
+    if (principalStreams >= MAX_STREAMS_PER_PRINCIPAL) return false;
+    if (this.streams.size >= MAX_STREAMS) return false;
+    if (context.isRemote && [...this.streams].filter((entry) => entry.isRemote).length >= MAX_REMOTE_STREAMS) return false;
+    if (context.workTimer) {
+      clearTimeout(context.workTimer);
+      context.workTimer = null;
+    }
+    context.stream = true;
+    this.streams.add({ context, principalId, isRemote: context.isRemote });
+    return true;
+  }
+
+  stopStream(context) {
+    for (const entry of this.streams) if (entry.context === context) this.streams.delete(entry);
+    context.stream = false;
+  }
+
+  beginRequest(context, { id, tool, deadlineMs }) {
+    if (context.closed) return Promise.reject(new Error("connection is closed"));
+    if (context.workTimer) {
+      clearTimeout(context.workTimer);
+      context.workTimer = null;
+    }
+    if (context.stream) return Promise.reject(new Error("stream connection cannot execute tools"));
+    if (typeof id !== "string" || !id) return Promise.reject(new Error("request id is required"));
+    if (id.length > REQUEST_ID_LIMIT) return Promise.reject(new Error("request ID is too long"));
+    if (typeof tool !== "string" || !tool) return Promise.reject(new Error("tool name is required"));
+    if (tool.length > TOOL_NAME_LIMIT) return Promise.reject(new Error("tool name is too long"));
+    if (context.seenRequestIds.has(id)) return Promise.reject(new Error("duplicate request id"));
+    if (context.seenRequestIds.size >= REQUEST_ID_LIMIT) return Promise.reject(new Error("request ID limit reached"));
+    if (context.activeRequest) return Promise.reject(new Error("one in-flight request per connection"));
+    context.seenRequestIds.add(id);
+    const controller = new AbortController();
+    const request = {
+      id,
+      tool,
+      startedAt: Date.now(),
+      deadlineMs: Math.min(Math.max(deadlineMs || DEFAULT_DEADLINE_MS, 1), MAX_DEADLINE_MS),
+      queued: true,
+      settled: false,
+      controller,
+      signal: controller.signal,
+      tombstoned: false,
+    };
+    context.activeRequest = request;
+    const grant = () => {
+      if (context.closed) return Promise.reject(new Error("connection closed while waiting for browser lease"));
+      request.queued = false;
+      request.timer = setTimeout(() => this.onRequestTimeout(context, request), request.deadlineMs);
+      this.leaseOwner = context;
+      this.audit({ event: "lease", context, request, outcome: "acquired" });
+      return Promise.resolve(request);
+    };
+    if (!this.leaseOwner || this.leaseOwner === context) {
+      if (context.idleTimer) clearTimeout(context.idleTimer);
+      context.idleTimer = null;
+      return grant();
+    }
+    if (this.waiters.length >= MAX_WAITERS) {
+      context.activeRequest = null;
+      return Promise.reject(new Error("browser lease queue is full"));
+    }
+    return new Promise((resolve, reject) => {
+      const waiter = { context, request, resolve, reject };
+      waiter.timer = setTimeout(() => {
+        const index = this.waiters.indexOf(waiter);
+        if (index !== -1) this.waiters.splice(index, 1);
+        if (context.activeRequest === request) context.activeRequest = null;
+        this.audit({ event: "lease", context, request, outcome: "queue-timeout" });
+        reject(new Error("timed out waiting for browser lease"));
+      }, QUEUE_TIMEOUT_MS);
+      this.waiters.push(waiter);
+      this.audit({ event: "lease", context, request, outcome: "queued" });
+    }).then(() => grant());
+  }
+
+  onRequestTimeout(context, request) {
+    if (context.activeRequest !== request || request.settled) return;
+    request.tombstoned = true;
+    if (!request.signal.aborted) request.controller.abort(abortError(null, "Request timed out"));
+    this.audit({ event: "request", context, request, outcome: "hard-timeout" });
+    this.onTimeout(context, request);
+  }
+
+  canRespond(context, id) {
+    return Boolean(context && context.activeRequest && context.activeRequest.id === id && !context.activeRequest.settled);
+  }
+
+  complete(context, id, outcome = "completed") {
+    const request = context?.activeRequest;
+    if (!request || request.id !== id || request.settled) return;
+    request.settled = true;
+    if (request.timer) clearTimeout(request.timer);
+    if (request.abortCleanup) request.abortCleanup();
+    context.activeRequest = null;
+    this.audit({ event: "request", context, request, outcome, elapsedMs: Date.now() - request.startedAt });
+    if (this.leaseOwner === context) {
+      if (context.closed) this.releaseLease(context);
+      else {
+        if (context.idleTimer) clearTimeout(context.idleTimer);
+        context.idleTimer = setTimeout(() => {
+          if (!context.activeRequest && this.leaseOwner === context) this.releaseLease(context);
+        }, LEASE_IDLE_MS);
+      }
+    }
+  }
+
+  releaseLease(context) {
+    if (this.leaseOwner !== context) return;
+    if (context.idleTimer) clearTimeout(context.idleTimer);
+    context.idleTimer = null;
+    this.leaseOwner = null;
+    this.audit({ event: "lease", context, outcome: "released" });
+    while (this.waiters.length) {
+      const waiter = this.waiters.shift();
+      if (!waiter || waiter.context.closed) continue;
+      clearTimeout(waiter.timer);
+      this.leaseOwner = waiter.context;
+      waiter.resolve();
+      return;
+    }
+  }
+
+  close(context) {
+    if (!context || context.closed) return;
+    context.closed = true;
+    if (context.workTimer) clearTimeout(context.workTimer);
+    context.workTimer = null;
+    this.stopStream(context);
+    if (context.principal) {
+      const count = this.principalCounts.get(context.principal.clientId) || 1;
+      if (count <= 1) this.principalCounts.delete(context.principal.clientId);
+      else this.principalCounts.set(context.principal.clientId, count - 1);
+    }
+    for (let index = this.waiters.length - 1; index >= 0; index -= 1) {
+      const waiter = this.waiters[index];
+      if (waiter.context !== context) continue;
+      this.waiters.splice(index, 1);
+      clearTimeout(waiter.timer);
+      waiter.reject(new Error("connection closed while waiting for browser lease"));
+    }
+    if (context.activeRequest?.queued) {
+      const request = context.activeRequest;
+      context.activeRequest = null;
+      if (!request.signal.aborted) request.controller.abort(abortError(null, "Request cancelled: queued client disconnected"));
+      this.audit({ event: "request", context, request, outcome: "queue-canceled" });
+    } else if (context.activeRequest) {
+      const request = context.activeRequest;
+      request.abandoned = true;
+      request.tombstoned = true;
+      if (!request.signal.aborted) request.controller.abort(abortError(null, "Request cancelled: client disconnected"));
+      this.audit({ event: "request", context, request, outcome: "abort-requested" });
+      this.audit({ event: "request", context, request, outcome: "abandoned" });
+    } else if (this.leaseOwner === context) {
+      this.releaseLease(context);
+    }
+    this.contexts.delete(context);
+    if (context.isRemote) this.remoteConnections -= 1;
+    this.audit({ event: "connection", context, outcome: "closed" });
+  }
+}
+
+module.exports = {
+  AUTHENTICATED_IDLE_MS,
+  DEFAULT_DEADLINE_MS,
+  HostSessionManager,
+  MAX_DEADLINE_MS,
+  PROVIDER_DEFAULT_TIMEOUT_SECONDS,
+  resolveRequestDeadlineMs,
+  LEASE_IDLE_MS,
+  MAX_CONNECTIONS,
+  MAX_PRINCIPAL_CONNECTIONS,
+  MAX_REMOTE_CONNECTIONS,
+  MAX_REMOTE_STREAMS,
+  MAX_STREAMS,
+  MAX_STREAMS_PER_PRINCIPAL,
+  TOOL_NAME_LIMIT,
+  MAX_WAITERS,
+  QUEUE_TIMEOUT_MS,
+  REQUEST_ID_LIMIT,
+};

--- a/native/host.cjs
+++ b/native/host.cjs
@@ -3,6 +3,8 @@ const net = require("net");
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
+const { AsyncLocalStorage } = require("async_hooks");
+const requestStorage = new AsyncLocalStorage();
 const https = require("https");
 const { execSync } = require("child_process");
 const { GoogleGenerativeAI } = require("@google/generative-ai");
@@ -17,7 +19,18 @@ const { mapToolToMessage, mapComputerAction, formatToolContent, buildProviderUpl
 const IS_WIN = process.platform === "win32";
 const { SOCKET_PATH, SURF_TMP } = require("./socket-path.cjs");
 const { parseListenEndpoint } = require("./listener.cjs");
-const MAX_CLIENT_FRAME_BYTES = 1024 * 1024;
+const { getStateDir } = require("./remote-auth.cjs");
+const { createFrameParser, createServerAuthSession, createSocketWriter, isClientAuthorized, writeFrame, MAX_FRAME_BYTES } = require("./remote-transport.cjs");
+const { HostSessionManager, resolveRequestDeadlineMs } = require("./host-sessions.cjs");
+const { abortError, throwIfAborted } = require("./abort.cjs");
+const { BoundedAiQueue } = require("./ai-queue.cjs");
+const { RequestPendingMap } = require("./request-pending.cjs");
+const { cleanupFilePaths, createStagingDirectory, createTransferState, materializeRemoteTool, rewriteTransferPaths, streamFileDownload, transferError } = require("./file-transfer.cjs");
+const { writeNetworkExport } = require("./network-export.cjs");
+const MAX_CLIENT_FRAME_BYTES = MAX_FRAME_BYTES;
+const TEST_REQUEST_DEADLINE_MS = process.env.SURF_TEST_MODE === "1" && Number.isFinite(Number(process.env.SURF_TEST_REQUEST_DEADLINE_MS))
+  ? Number(process.env.SURF_TEST_REQUEST_DEADLINE_MS)
+  : null;
 if (IS_WIN) { try { fs.mkdirSync(SURF_TMP, { recursive: true }); } catch {} }
 
 // The endpoint passed here is already validated by the caller. Keeping this
@@ -115,29 +128,9 @@ function resizeImage(filePath, maxSize) {
   }
 }
 
-const aiRequestQueue = [];
-let aiRequestInProgress = false;
-
-function queueAiRequest(handler) {
-  return new Promise((resolve, reject) => {
-    aiRequestQueue.push({ handler, resolve, reject });
-    processAiQueue();
-  });
-}
-
-async function processAiQueue() {
-  if (aiRequestInProgress || aiRequestQueue.length === 0) return;
-  aiRequestInProgress = true;
-  const { handler, resolve, reject } = aiRequestQueue.shift();
-  try {
-    const result = await handler();
-    resolve(result);
-  } catch (err) {
-    reject(err);
-  } finally {
-    aiRequestInProgress = false;
-    setTimeout(processAiQueue, 2000);
-  }
+let aiQueue;
+function queueAiRequest(handler, request = requestStorage.getStore()) {
+  return aiQueue.enqueue(handler, request);
 }
 const LOG_FILE = path.join(SURF_TMP, "surf-host.log");
 const AUTH_FILE = path.join(os.homedir(), ".pi", "agent", "auth.json");
@@ -150,7 +143,8 @@ const DEFAULT_RETRY_OPTIONS = {
   retryableStatusCodes: [429, 500, 502, 503, 504]
 };
 
-async function withRetry(fn, retryOptions = DEFAULT_RETRY_OPTIONS, retryCount = 0) {
+async function withRetry(fn, retryOptions = DEFAULT_RETRY_OPTIONS, retryCount = 0, signal) {
+  throwIfAborted(signal);
   try {
     return await fn();
   } catch (error) {
@@ -186,8 +180,8 @@ async function withRetry(fn, retryOptions = DEFAULT_RETRY_OPTIONS, retryCount = 
     const jitter = 0.8 + Math.random() * 0.4;
     const delayWithJitter = Math.floor(delay * jitter);
     
-    await new Promise(resolve => setTimeout(resolve, delayWithJitter));
-    return withRetry(fn, retryOptions, retryCount + 1);
+    await require("./abort.cjs").abortableDelay(delayWithJitter, signal);
+    return withRetry(fn, retryOptions, retryCount + 1, signal);
   }
 }
 
@@ -255,13 +249,14 @@ class GeminiClient {
 
   async analyze(query, pageContext, options = {}) {
     const mode = options.mode || detectQueryMode(query);
+    throwIfAborted(options.signal);
     const promptFn = AI_PROMPTS[mode];
     const prompt = promptFn(query, pageContext);
     
     const result = await withRetry(async () => {
       const response = await this.model.generateContent(prompt);
       return response.response.text();
-    });
+    }, DEFAULT_RETRY_OPTIONS, 0, options.signal);
     
     let content = result.trim();
     
@@ -358,52 +353,232 @@ log("Host starting...");
 if (!IS_WIN) { try { fs.unlinkSync(SOCKET_PATH); } catch {} }
 
 const pendingRequests = new Map();
-const pendingToolRequests = new Map();
+const pendingToolRequests = new RequestPendingMap({ getRequest: () => requestStorage.getStore() });
 const activeStreams = new Map();
+const socketContexts = new WeakMap();
+const socketWriters = new WeakMap();
 let requestCounter = 0;
 
+function auditSession(event) {
+  const context = event.context;
+  const principal = context?.principal;
+  const request = event.request;
+  log(`SESSION ${JSON.stringify({
+    event: event.event,
+    outcome: event.outcome,
+    principalId: principal?.clientId || "local",
+    principalLabel: principal?.label || "local",
+    peer: context?.socket?.remoteAddress || "local",
+    requestId: request?.id,
+    tool: request?.tool,
+    elapsedMs: event.elapsedMs,
+  })}`);
+}
+
+aiQueue = new BoundedAiQueue({
+  maxQueued: 8,
+  audit: (event) => auditSession(event),
+  run: (handler, request) => request
+    ? requestStorage.run(request, () => handler())
+    : handler(),
+});
+
+function sendSocket(socket, value, options = {}) {
+  const writer = socketWriters.get(socket);
+  return writer ? writer.send(value, options) : writeFrame(socket, value);
+}
+
+function sendOwnedExtensionMessage(request, message) {
+  const cleanupMessage = typeof message?.type === "string" && /(?:CLOSE_TAB|TAB_CLOSE)$/.test(message.type);
+  if (request?.hardBoundary) throwIfAborted(request.signal, "Request timed out");
+  if (!cleanupMessage) throwIfAborted(request?.signal, "Request cancelled");
+  writeMessage(message);
+}
+
+function requestCallExtension(request, tool, message, timeoutMs = 30000, cleanup = false) {
+  cleanup = cleanup || tool === "close_tab";
+  if (request?.hardBoundary) throwIfAborted(request.signal, "Request timed out");
+  if (!cleanup) throwIfAborted(request?.signal, "Request cancelled");
+  return new Promise((resolve, reject) => {
+    const id = ++requestCounter;
+    const timer = setTimeout(() => {
+      pendingToolRequests.expire(id, new Error(`Timeout waiting for extension: ${tool}`));
+    }, timeoutMs);
+    const pending = {
+      request,
+      cleanup,
+      tool,
+      resolve: (result) => {
+        clearTimeout(timer);
+        resolve(result);
+      },
+      reject: (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    };
+    pendingToolRequests.set(id, pending);
+    try {
+      if (cleanup) writeMessage({ ...message, id });
+      else sendOwnedExtensionMessage(request, { ...message, id });
+    } catch (error) {
+      pendingToolRequests.delete(id);
+      reject(error);
+    }
+  });
+}
+
+const sessionManager = new HostSessionManager({
+  audit: auditSession,
+  onTimeout(context, request) {
+    pendingToolRequests.hardDeadline(request);
+    const response = {
+      type: "tool_response",
+      id: request.id,
+      error: { content: [{ type: "text", text: "Request timed out" }] },
+    };
+    cleanupRequestTransfers(request)
+      .then(() => {
+        sessionManager.complete(context, request.id, "hard-timeout");
+        if (!context.closed) return sendSocket(context.socket, response);
+      })
+      .catch((error) => log(`Error settling timed-out request: ${error.message}`));
+  },
+});
+
+async function discardRequestTransfers(message, state) {
+  if (!state) return;
+  const ids = [];
+  for (const entry of message?._surfTransfers?.uploads || []) if (typeof entry?.transferId === "string") ids.push(entry.transferId);
+  for (const entry of message?._surfTransfers?.downloads || []) if (typeof entry?.transferId === "string") ids.push(entry.transferId);
+  await Promise.all([...new Set(ids)].map((id) => state.discardCompleted(id)));
+}
+
+async function applyRequestTransfers(msg, request, transferState, getTransferState) {
+  if (!request.context?.isRemote) return;
+  const materialized = await materializeRemoteTool({
+    tool: request.tool,
+    args: msg.params?.args || {},
+    metadata: msg._surfTransfers,
+    pathRefs: msg._surfPaths || [],
+    transferState,
+    getTransferState,
+  });
+  request.transferState = materialized.transferState;
+  request.outputTransfers = materialized.outputTransfers;
+  request.pathRewrites = materialized.pathRewrites;
+  request.transferCleanup = materialized.transferCleanup;
+  msg.params = { ...msg.params, args: materialized.args };
+}
+
+async function cleanupRequestTransfers(request) {
+  if (!request || request.transferCleanupStarted) return request?.transferCleanupPromise;
+  request.transferCleanupStarted = true;
+  const paths = request.transferCleanup || [];
+  request.transferCleanup = [];
+  request.transferCleanupPromise = cleanupFilePaths(paths);
+  await request.transferCleanupPromise;
+  return request.transferCleanupPromise;
+}
+
+function completeOwnedRequest(context, id, outcome) {
+  const request = context?.activeRequest;
+  if (!request || request.id !== id) return Promise.resolve();
+  if (request.pendingEntries?.size && !request.hardBoundary) {
+    if (request.completionRequested) return request.completionPromise;
+    request.completionRequested = true;
+    request.completionOutcome = outcome;
+    request.completionPromise = new Promise((resolve) => {
+      pendingToolRequests.onDrain(request, () => {
+        sessionManager.complete(context, id, request.completionOutcome);
+        resolve();
+      });
+    });
+    return request.completionPromise;
+  }
+  sessionManager.complete(context, id, outcome);
+  return Promise.resolve();
+}
+
+async function sendRequestDownloads(context, request, result) {
+  if (!request) return result;
+  let rewritten = result;
+  for (const output of request.outputTransfers || []) {
+    await streamFileDownload({
+      writer: { send: (frame) => sendSocket(context.socket, frame) },
+      state: request.transferState,
+      filePath: output.path,
+      transferId: output.transferId,
+      original: output.original,
+    });
+  }
+  rewritten = rewriteTransferPaths(rewritten, request.pathRewrites || []);
+  return rewritten;
+}
+
 function sendToolResponse(socket, id, result, error) {
-  const response = { type: "tool_response", id };
-  
-  if (error) {
-    response.error = { content: [{ type: "text", text: error }] };
-  } else {
-    response.result = { content: formatToolContent(result, log) };
-  }
-  
-  try {
-    socket.write(JSON.stringify(response) + "\n");
-  } catch (e) {
-    log(`Error sending tool_response: ${e.message}`);
-  }
+  const context = socketContexts.get(socket);
+  if (context && !sessionManager.canRespond(context, id)) return;
+  const request = context?.activeRequest;
+  let finalError = error;
+  (async () => {
+    let output = result;
+    try {
+      if (!error) output = await sendRequestDownloads(context, request, result);
+    } catch (transferFailure) {
+      finalError = transferFailure.message;
+    }
+    if (finalError && request) {
+      finalError = rewriteTransferPaths(finalError, request.pathRewrites || []);
+    }
+    await cleanupRequestTransfers(request);
+    if (request?.settled) return;
+    const outcome = request?.signal.aborted
+      ? (request.tombstoned ? "cleanup-settled" : "cancelled")
+      : finalError ? "error" : "completed";
+    await completeOwnedRequest(context, id, outcome);
+    const response = { type: "tool_response", id };
+    if (finalError) response.error = { content: [{ type: "text", text: finalError }] };
+    else response.result = { content: formatToolContent(output, log, { suppressImages: Boolean(context?.isRemote) }) };
+    if (!context?.closed) await sendSocket(socket, response);
+  })().catch((sendError) => log(`Error sending tool_response: ${sendError.message}`));
+}
+
+function stopActiveStream(streamId, { notifyExtension = true } = {}) {
+  const stream = activeStreams.get(streamId);
+  if (!stream) return;
+  activeStreams.delete(streamId);
+  sessionManager.stopStream(socketContexts.get(stream.socket));
+  if (notifyExtension) writeMessage({ type: "STREAM_STOP", streamId });
 }
 
 function handleStreamRequest(msg, socket) {
   const { streamType, options, id: originalId } = msg;
   const tabId = msg.tabId;
   const streamId = ++requestCounter;
-  
+
   activeStreams.set(streamId, {
     socket,
     originalId,
     streamType,
   });
-  
+
   writeMessage({
     type: streamType,
     streamId,
     options: options || {},
     tabId,
   });
-  
-  try {
-    socket.write(JSON.stringify({ type: "stream_started", streamId }) + "\n");
-  } catch (e) {
-    log(`Error sending stream_started: ${e.message}`);
-  }
+
+  sendSocket(socket, { type: "stream_started", streamId }, { stream: true }).catch((error) => {
+    log(`Error sending stream_started: ${error.message}`);
+    stopActiveStream(streamId);
+    socket.destroy(error);
+  });
 }
 
-function handleToolRequest(msg, socket) {
+function handleToolRequest(msg, socket, requestContext = requestStorage.getStore()) {
+  const writeMessage = (message) => sendOwnedExtensionMessage(requestContext, message);
   const { method, params } = msg;
   const originalId = msg.id || null;
   
@@ -445,14 +620,14 @@ function handleToolRequest(msg, socket) {
   }
   
   if (extensionMsg.type === "LOCAL_WAIT") {
-    setTimeout(() => {
-      sendToolResponse(socket, originalId, { success: true }, null);
-    }, extensionMsg.seconds * 1000);
+    require("./abort.cjs").abortableDelay(extensionMsg.seconds * 1000, requestContext.signal)
+      .then(() => sendToolResponse(socket, originalId, { success: true }, null))
+      .catch((error) => sendToolResponse(socket, originalId, null, error.message));
     return;
   }
   
   if (extensionMsg.type === "BATCH_EXECUTE") {
-    executeBatch(extensionMsg.actions, extensionMsg.tabId, socket, originalId);
+    executeBatch(extensionMsg.actions, extensionMsg.tabId, socket, originalId, requestContext);
     return;
   }
   
@@ -468,46 +643,23 @@ function handleToolRequest(msg, socket) {
       return;
     }
     
-    const pageRequestId = ++requestCounter;
-    pendingToolRequests.set(pageRequestId, {
-      socket: null,
-      originalId: null,
-      tool: "read_page",
-      onComplete: async (pageResult) => {
-        if (pageResult.error) {
-          sendToolResponse(socket, originalId, null, `Failed to read page: ${pageResult.error}`);
-          return;
-        }
-        
-        const pageContent = pageResult.pageContent || "";
-        if (!pageContent) {
-          sendToolResponse(socket, originalId, null, "No page content available");
-          return;
-        }
-        
-        try {
-          const gemini = getGeminiClient(apiKey);
-          const result = await gemini.analyze(extensionMsg.query, pageContent, { mode: extensionMsg.mode });
-          
-          if (result.mode === "find") {
-            sendToolResponse(socket, originalId, { 
-              ref: result.content === "NOT_FOUND" ? null : result.content,
-              mode: result.mode,
-              aiResult: true
-            }, null);
-          } else {
-            sendToolResponse(socket, originalId, { 
-              content: result.content,
-              mode: result.mode,
-              aiResult: true
-            }, null);
-          }
-        } catch (err) {
-          sendToolResponse(socket, originalId, null, `AI analysis failed: ${err.message}`);
-        }
-      }
+    requestCallExtension(
+      requestContext,
+      "read_page",
+      { type: "READ_PAGE", options: { filter: "interactive" }, tabId: extensionMsg.tabId },
+      45000,
+    ).then(async (pageResult) => {
+      if (pageResult.error) throw new Error(`Failed to read page: ${pageResult.error}`);
+      const pageContent = pageResult.pageContent || "";
+      if (!pageContent) throw new Error("No page content available");
+      const gemini = getGeminiClient(apiKey);
+      const result = await gemini.analyze(extensionMsg.query, pageContent, { mode: extensionMsg.mode, signal: requestContext.signal });
+      return result.mode === "find"
+        ? { ref: result.content === "NOT_FOUND" ? null : result.content, mode: result.mode, aiResult: true }
+        : { content: result.content, mode: result.mode, aiResult: true };
+    }).then((result) => sendToolResponse(socket, originalId, result, null)).catch((err) => {
+      sendToolResponse(socket, originalId, null, err.message);
     });
-    writeMessage({ type: "READ_PAGE", options: { filter: "interactive" }, tabId: extensionMsg.tabId, id: pageRequestId });
     return;
   }
   
@@ -517,16 +669,12 @@ function handleToolRequest(msg, socket) {
     queueAiRequest(async () => {
       let pageContext = null;
       if (withPage) {
-        const pageResult = await new Promise((resolve) => {
-          const pageId = ++requestCounter;
-          pendingToolRequests.set(pageId, {
-            socket: null,
-            originalId: null,
-            tool: "read_page",
-            onComplete: resolve
-          });
-          writeMessage({ type: "GET_PAGE_TEXT", tabId: extensionMsg.tabId, id: pageId });
-        });
+        const pageResult = await requestCallExtension(
+          requestContext,
+          "read_page",
+          { type: "GET_PAGE_TEXT", tabId: extensionMsg.tabId },
+          45000,
+        );
         if (pageResult && !pageResult.error) {
           pageContext = {
             url: pageResult.url,
@@ -542,69 +690,36 @@ function handleToolRequest(msg, socket) {
       
       const result = await chatgptClient.query({
         prompt: fullPrompt,
+        signal: requestContext.signal,
         model,
         file,
         timeout,
-        getCookies: () => new Promise((resolve) => {
-          const cookieId = ++requestCounter;
-          pendingToolRequests.set(cookieId, {
-            socket: null,
-            originalId: null,
-            tool: "get_cookies",
-            onComplete: (r) => resolve(r)
-          });
-          writeMessage({ type: "GET_CHATGPT_COOKIES", id: cookieId });
-        }),
-        createTab: () => new Promise((resolve) => {
-          const tabCreateId = ++requestCounter;
-          pendingToolRequests.set(tabCreateId, {
-            socket: null,
-            originalId: null,
-            tool: "create_tab",
-            onComplete: (r) => resolve(r)
-          });
-          writeMessage({ type: "CHATGPT_NEW_TAB", id: tabCreateId });
-        }),
-        closeTab: (tabIdToClose) => new Promise((resolve) => {
-          const tabCloseId = ++requestCounter;
-          pendingToolRequests.set(tabCloseId, {
-            socket: null,
-            originalId: null,
-            tool: "close_tab",
-            onComplete: (r) => resolve(r)
-          });
-          writeMessage({ type: "CHATGPT_CLOSE_TAB", tabId: tabIdToClose, id: tabCloseId });
-        }),
-        cdpEvaluate: (tabId, expression) => new Promise((resolve) => {
-          const evalId = ++requestCounter;
-          pendingToolRequests.set(evalId, {
-            socket: null,
-            originalId: null,
-            tool: "cdp_evaluate",
-            onComplete: (r) => resolve(r)
-          });
-          writeMessage({ type: "CHATGPT_EVALUATE", tabId, expression, id: evalId });
-        }),
-        cdpCommand: (tabId, method, params) => new Promise((resolve) => {
-          const cmdId = ++requestCounter;
-          pendingToolRequests.set(cmdId, {
-            socket: null,
-            originalId: null,
-            tool: "cdp_command",
-            onComplete: (r) => resolve(r)
-          });
-          writeMessage({ type: "CHATGPT_CDP_COMMAND", tabId, method, params, id: cmdId });
-        }),
-        uploadFile: (tabId, filePaths) => new Promise((resolve) => {
-          const uploadId = ++requestCounter;
-          pendingToolRequests.set(uploadId, {
-            socket: null,
-            originalId: null,
-            tool: "upload_file",
-            onComplete: (r) => resolve(r)
-          });
-          writeMessage(buildProviderUploadMessage("chatgpt", tabId, filePaths, uploadId));
-        }),
+        getCookies: () => requestCallExtension(
+          requestContext,
+          "get_cookies",
+          { type: "GET_CHATGPT_COOKIES" },
+        ),
+        createTab: () => requestCallExtension(
+          requestContext,
+          "create_tab",
+          { type: "CHATGPT_NEW_TAB" },
+        ),
+        closeTab: (tabIdToClose) => requestCallExtension(requestContext, "close_tab", { type: "CHATGPT_CLOSE_TAB", tabId: tabIdToClose }, 45000, true),
+        cdpEvaluate: (tabId, expression) => requestCallExtension(
+          requestContext,
+          "cdp_evaluate",
+          { type: "CHATGPT_EVALUATE", tabId, expression },
+        ),
+        cdpCommand: (tabId, method, params) => requestCallExtension(
+          requestContext,
+          "cdp_command",
+          { type: "CHATGPT_CDP_COMMAND", tabId, method, params },
+        ),
+        uploadFile: (tabId, filePaths) => requestCallExtension(
+          requestContext,
+          "upload_file",
+          buildProviderUploadMessage("chatgpt", tabId, filePaths),
+        ),
         log: (msg) => log(`[chatgpt] ${msg}`)
       });
       
@@ -628,16 +743,12 @@ function handleToolRequest(msg, socket) {
     queueAiRequest(async () => {
       let pageContext = null;
       if (withPage) {
-        const pageResult = await new Promise((resolve) => {
-          const pageId = ++requestCounter;
-          pendingToolRequests.set(pageId, {
-            socket: null,
-            originalId: null,
-            tool: "read_page",
-            onComplete: resolve
-          });
-          writeMessage({ type: "GET_PAGE_TEXT", tabId: extensionMsg.tabId, id: pageId });
-        });
+        const pageResult = await requestCallExtension(
+          requestContext,
+          "read_page",
+          { type: "GET_PAGE_TEXT", tabId: extensionMsg.tabId },
+          45000,
+        );
         if (pageResult && !pageResult.error) {
           pageContext = {
             url: pageResult.url,
@@ -653,49 +764,26 @@ function handleToolRequest(msg, socket) {
       
       const result = await perplexityClient.query({
         prompt: fullPrompt,
+        signal: requestContext.signal,
         mode: mode || 'search',
         model,
         timeout: timeout || 120000,
-        createTab: () => new Promise((resolve) => {
-          const tabCreateId = ++requestCounter;
-          pendingToolRequests.set(tabCreateId, {
-            socket: null,
-            originalId: null,
-            tool: "create_tab",
-            onComplete: (r) => resolve(r)
-          });
-          writeMessage({ type: "PERPLEXITY_NEW_TAB", id: tabCreateId });
-        }),
-        closeTab: (tabIdToClose) => new Promise((resolve) => {
-          const tabCloseId = ++requestCounter;
-          pendingToolRequests.set(tabCloseId, {
-            socket: null,
-            originalId: null,
-            tool: "close_tab",
-            onComplete: (r) => resolve(r)
-          });
-          writeMessage({ type: "PERPLEXITY_CLOSE_TAB", tabId: tabIdToClose, id: tabCloseId });
-        }),
-        cdpEvaluate: (tabId, expression) => new Promise((resolve) => {
-          const evalId = ++requestCounter;
-          pendingToolRequests.set(evalId, {
-            socket: null,
-            originalId: null,
-            tool: "cdp_evaluate",
-            onComplete: (r) => resolve(r)
-          });
-          writeMessage({ type: "PERPLEXITY_EVALUATE", tabId, expression, id: evalId });
-        }),
-        cdpCommand: (tabId, method, params) => new Promise((resolve) => {
-          const cmdId = ++requestCounter;
-          pendingToolRequests.set(cmdId, {
-            socket: null,
-            originalId: null,
-            tool: "cdp_command",
-            onComplete: (r) => resolve(r)
-          });
-          writeMessage({ type: "PERPLEXITY_CDP_COMMAND", tabId, method, params, id: cmdId });
-        }),
+        createTab: () => requestCallExtension(
+          requestContext,
+          "create_tab",
+          { type: "PERPLEXITY_NEW_TAB" },
+        ),
+        closeTab: (tabIdToClose) => requestCallExtension(requestContext, "close_tab", { type: "PERPLEXITY_CLOSE_TAB", tabId: tabIdToClose }, 45000, true),
+        cdpEvaluate: (tabId, expression) => requestCallExtension(
+          requestContext,
+          "cdp_evaluate",
+          { type: "PERPLEXITY_EVALUATE", tabId, expression },
+        ),
+        cdpCommand: (tabId, method, params) => requestCallExtension(
+          requestContext,
+          "cdp_command",
+          { type: "PERPLEXITY_CDP_COMMAND", tabId, method, params },
+        ),
         log: (msg) => log(`[perplexity] ${msg}`)
       });
       
@@ -723,16 +811,12 @@ function handleToolRequest(msg, socket) {
       // 1. Get page context if requested
       let pageContext = null;
       if (withPage) {
-        const pageResult = await new Promise((resolve) => {
-          const pageId = ++requestCounter;
-          pendingToolRequests.set(pageId, {
-            socket: null,
-            originalId: null,
-            tool: "get_page_text",
-            onComplete: resolve
-          });
-          writeMessage({ type: "GET_PAGE_TEXT", tabId: extensionMsg.tabId, id: pageId });
-        });
+        const pageResult = await requestCallExtension(
+          requestContext,
+          "get_page_text",
+          { type: "GET_PAGE_TEXT", tabId: extensionMsg.tabId },
+          45000,
+        );
         if (pageResult && !pageResult.error) {
           pageContext = {
             url: pageResult.url,
@@ -750,6 +834,7 @@ function handleToolRequest(msg, socket) {
       // 3. Call Gemini client
       const result = await geminiClient.query({
         prompt: fullPrompt,
+        signal: requestContext.signal,
         model: model || "gemini-3.1-pro",
         file,
         generateImage,
@@ -758,67 +843,32 @@ function handleToolRequest(msg, socket) {
         youtube,
         aspectRatio,
         timeout: timeout || 300000,
-        getCookies: () => new Promise((resolve) => {
-          const cookieId = ++requestCounter;
-          pendingToolRequests.set(cookieId, {
-            socket: null,
-            originalId: null,
-            tool: "get_cookies",
-            onComplete: (r) => resolve(r)
-          });
-          writeMessage({ type: "GET_GOOGLE_COOKIES", id: cookieId });
-        }),
-        createTab: () => new Promise((resolve) => {
-          const tabCreateId = ++requestCounter;
-          pendingToolRequests.set(tabCreateId, {
-            socket: null,
-            originalId: null,
-            tool: "create_tab",
-            onComplete: (r) => resolve(r)
-          });
-          writeMessage({ type: "GEMINI_NEW_TAB", id: tabCreateId });
-        }),
-        closeTab: (tabIdToClose) => new Promise((resolve) => {
-          const tabCloseId = ++requestCounter;
-          pendingToolRequests.set(tabCloseId, {
-            socket: null,
-            originalId: null,
-            tool: "close_tab",
-            onComplete: (r) => resolve(r)
-          });
-          writeMessage({ type: "GEMINI_CLOSE_TAB", tabId: tabIdToClose, id: tabCloseId });
-        }),
-        jsEval: (tabId, code) => new Promise((resolve) => {
-          const jsId = ++requestCounter;
-          pendingToolRequests.set(jsId, {
-            socket: null,
-            originalId: null,
-            tool: "js_eval",
-            onComplete: (r) => resolve(r)
-          });
-          log(`[gemini] Sending EXECUTE_JAVASCRIPT id=${jsId} tabId=${tabId} code=${code.length} chars`);
-          writeMessage({ type: "EXECUTE_JAVASCRIPT", tabId, code, id: jsId });
-        }),
-        uploadFile: (tabId, filePaths) => new Promise((resolve) => {
-          const uploadId = ++requestCounter;
-          pendingToolRequests.set(uploadId, {
-            socket: null,
-            originalId: null,
-            tool: "upload_file",
-            onComplete: (r) => resolve(r)
-          });
-          writeMessage(buildProviderUploadMessage("gemini", tabId, filePaths, uploadId));
-        }),
-        fetchUrl: (url) => new Promise((resolve) => {
-          const fetchId = ++requestCounter;
-          pendingToolRequests.set(fetchId, {
-            socket: null,
-            originalId: null,
-            tool: "fetch_url",
-            onComplete: (r) => resolve(r)
-          });
-          writeMessage({ type: "GEMINI_FETCH_URL", url, id: fetchId });
-        }),
+        getCookies: () => requestCallExtension(
+          requestContext,
+          "get_cookies",
+          { type: "GET_GOOGLE_COOKIES" },
+        ),
+        createTab: () => requestCallExtension(
+          requestContext,
+          "create_tab",
+          { type: "GEMINI_NEW_TAB" },
+        ),
+        closeTab: (tabIdToClose) => requestCallExtension(requestContext, "close_tab", { type: "GEMINI_CLOSE_TAB", tabId: tabIdToClose }, 45000, true),
+        jsEval: (tabId, code) => requestCallExtension(
+          requestContext,
+          "js_eval",
+          { type: "EXECUTE_JAVASCRIPT", tabId, code },
+        ),
+        uploadFile: (tabId, filePaths) => requestCallExtension(
+          requestContext,
+          "upload_file",
+          buildProviderUploadMessage("gemini", tabId, filePaths),
+        ),
+        fetchUrl: (url) => requestCallExtension(
+          requestContext,
+          "fetch_url",
+          { type: "GEMINI_FETCH_URL", url },
+        ),
         log: (msg) => log(`[gemini] ${msg}`)
       });
       
@@ -847,16 +897,12 @@ function handleToolRequest(msg, socket) {
       // 1. Get page context if requested
       let pageContext = null;
       if (withPage) {
-        const pageResult = await new Promise((resolve) => {
-          const pageId = ++requestCounter;
-          pendingToolRequests.set(pageId, {
-            socket: null,
-            originalId: null,
-            tool: "get_page_text",
-            onComplete: resolve
-          });
-          writeMessage({ type: "GET_PAGE_TEXT", tabId: extensionMsg.tabId, id: pageId });
-        });
+        const pageResult = await requestCallExtension(
+          requestContext,
+          "get_page_text",
+          { type: "GET_PAGE_TEXT", tabId: extensionMsg.tabId },
+          45000,
+        );
         if (pageResult && !pageResult.error) {
           pageContext = {
             url: pageResult.url,
@@ -874,59 +920,31 @@ function handleToolRequest(msg, socket) {
       // 3. Call Grok client
       const result = await grokClient.query({
         prompt: fullPrompt,
+        signal: requestContext.signal,
         model: model,
         deepSearch: deepSearch || false,
         timeout: timeout || 300000,
-        getCookies: () => new Promise((resolve) => {
-          const cookieId = ++requestCounter;
-          pendingToolRequests.set(cookieId, {
-            socket: null,
-            originalId: null,
-            tool: "get_cookies",
-            onComplete: (r) => resolve(r)
-          });
-          writeMessage({ type: "GET_TWITTER_COOKIES", id: cookieId });
-        }),
-        createTab: () => new Promise((resolve) => {
-          const tabCreateId = ++requestCounter;
-          pendingToolRequests.set(tabCreateId, {
-            socket: null,
-            originalId: null,
-            tool: "create_tab",
-            onComplete: (r) => resolve(r)
-          });
-          writeMessage({ type: "GROK_NEW_TAB", id: tabCreateId });
-        }),
-        closeTab: (tabIdToClose) => new Promise((resolve) => {
-          const tabCloseId = ++requestCounter;
-          pendingToolRequests.set(tabCloseId, {
-            socket: null,
-            originalId: null,
-            tool: "close_tab",
-            onComplete: (r) => resolve(r)
-          });
-          writeMessage({ type: "GROK_CLOSE_TAB", tabId: tabIdToClose, id: tabCloseId });
-        }),
-        cdpEvaluate: (tabId, expression) => new Promise((resolve) => {
-          const evalId = ++requestCounter;
-          pendingToolRequests.set(evalId, {
-            socket: null,
-            originalId: null,
-            tool: "cdp_evaluate",
-            onComplete: (r) => resolve(r)
-          });
-          writeMessage({ type: "GROK_EVALUATE", tabId, expression, id: evalId });
-        }),
-        cdpCommand: (tabId, method, params) => new Promise((resolve) => {
-          const cmdId = ++requestCounter;
-          pendingToolRequests.set(cmdId, {
-            socket: null,
-            originalId: null,
-            tool: "cdp_command",
-            onComplete: (r) => resolve(r)
-          });
-          writeMessage({ type: "GROK_CDP_COMMAND", tabId, method, params, id: cmdId });
-        }),
+        getCookies: () => requestCallExtension(
+          requestContext,
+          "get_cookies",
+          { type: "GET_TWITTER_COOKIES" },
+        ),
+        createTab: () => requestCallExtension(
+          requestContext,
+          "create_tab",
+          { type: "GROK_NEW_TAB" },
+        ),
+        closeTab: (tabIdToClose) => requestCallExtension(requestContext, "close_tab", { type: "GROK_CLOSE_TAB", tabId: tabIdToClose }, 45000, true),
+        cdpEvaluate: (tabId, expression) => requestCallExtension(
+          requestContext,
+          "cdp_evaluate",
+          { type: "GROK_EVALUATE", tabId, expression },
+        ),
+        cdpCommand: (tabId, method, params) => requestCallExtension(
+          requestContext,
+          "cdp_command",
+          { type: "GROK_CDP_COMMAND", tabId, method, params },
+        ),
         log: (msg) => log(`[grok] ${msg}`)
       });
       
@@ -965,46 +983,29 @@ function handleToolRequest(msg, socket) {
     
     queueAiRequest(async () => {
       const result = await grokClient.validate({
-        getCookies: () => new Promise((resolve) => {
-          const cookieId = ++requestCounter;
-          pendingToolRequests.set(cookieId, {
-            socket: null,
-            originalId: null,
-            tool: "get_cookies",
-            onComplete: (r) => resolve(r)
-          });
-          writeMessage({ type: "GET_TWITTER_COOKIES", id: cookieId });
-        }),
-        createTab: () => new Promise((resolve) => {
-          const tabCreateId = ++requestCounter;
-          pendingToolRequests.set(tabCreateId, {
-            socket: null,
-            originalId: null,
-            tool: "create_tab",
-            onComplete: (r) => resolve(r)
-          });
-          writeMessage({ type: "GROK_NEW_TAB", id: tabCreateId });
-        }),
-        closeTab: (tabIdToClose) => new Promise((resolve) => {
-          const tabCloseId = ++requestCounter;
-          pendingToolRequests.set(tabCloseId, {
-            socket: null,
-            originalId: null,
-            tool: "close_tab",
-            onComplete: (r) => resolve(r)
-          });
-          writeMessage({ type: "GROK_CLOSE_TAB", tabId: tabIdToClose, id: tabCloseId });
-        }),
-        cdpEvaluate: (tabId, expression) => new Promise((resolve) => {
-          const evalId = ++requestCounter;
-          pendingToolRequests.set(evalId, {
-            socket: null,
-            originalId: null,
-            tool: "cdp_evaluate",
-            onComplete: (r) => resolve(r)
-          });
-          writeMessage({ type: "GROK_EVALUATE", tabId, expression, id: evalId });
-        }),
+        signal: requestContext.signal,
+        getCookies: () => requestCallExtension(
+          requestContext,
+          "get_cookies",
+          { type: "GET_TWITTER_COOKIES" },
+        ),
+        createTab: () => requestCallExtension(
+          requestContext,
+          "create_tab",
+          { type: "GROK_NEW_TAB" },
+        ),
+        closeTab: (tabIdToClose) => requestCallExtension(
+          requestContext,
+          "close_tab",
+          { type: "GROK_CLOSE_TAB", tabId: tabIdToClose },
+          45000,
+          true,
+        ),
+        cdpEvaluate: (tabId, expression) => requestCallExtension(
+          requestContext,
+          "cdp_evaluate",
+          { type: "GROK_EVALUATE", tabId, expression },
+        ),
         log: (msg) => log(`[grok:validate] ${msg}`)
       });
       
@@ -1049,30 +1050,12 @@ function handleToolRequest(msg, socket) {
     queueAiRequest(async () => {
       const EXT_CALL_TIMEOUT_MS = 30000;
 
-      const callExtension = (toolName, msg, timeoutMs = EXT_CALL_TIMEOUT_MS) => new Promise((resolve, reject) => {
-        const id = ++requestCounter;
-
-        if (msg && msg.type === "AISTUDIO_NEW_TAB") {
+      const callExtension = (toolName, msg, timeoutMs = EXT_CALL_TIMEOUT_MS) => {
+        if (msg?.type === "AISTUDIO_NEW_TAB") {
           log(`[aistudio] Opening tab: ${(msg.url || "https://aistudio.google.com/prompts/new_chat")}`);
         }
-
-        const timeoutId = setTimeout(() => {
-          pendingToolRequests.delete(id);
-          reject(new Error(`Timeout waiting for extension: ${toolName}`));
-        }, timeoutMs);
-
-        pendingToolRequests.set(id, {
-          socket: null,
-          originalId: null,
-          tool: toolName,
-          onComplete: (r) => {
-            clearTimeout(timeoutId);
-            resolve(r);
-          }
-        });
-
-        writeMessage({ ...msg, id });
-      });
+        return requestCallExtension(requestContext, toolName, msg, timeoutMs);
+      };
 
       // 1. Get page context if requested
       let pageContext = null;
@@ -1106,6 +1089,7 @@ function handleToolRequest(msg, socket) {
       // 3. Call AI Studio client
       const result = await aistudioClient.query({
         prompt: fullPrompt,
+        signal: requestContext.signal,
         model: model || undefined,
         timeout: timeout || 300000,
         getCookies: () => callExtension("get_cookies", { type: "GET_GOOGLE_COOKIES" }, 45000),
@@ -1164,33 +1148,16 @@ function handleToolRequest(msg, socket) {
     queueAiRequest(async () => {
       const EXT_CALL_TIMEOUT_MS = 30000;
 
-      const callExtension = (toolName, msg, timeoutMs = EXT_CALL_TIMEOUT_MS) => new Promise((resolve, reject) => {
-        const id = ++requestCounter;
-
-        if (msg && msg.type === "AISTUDIO_NEW_TAB") {
+      const callExtension = (toolName, msg, timeoutMs = EXT_CALL_TIMEOUT_MS) => {
+        if (msg?.type === "AISTUDIO_NEW_TAB") {
           log(`[aistudio] Opening tab: ${(msg.url || "https://aistudio.google.com/apps")}`);
         }
-
-        const timeoutId = setTimeout(() => {
-          pendingToolRequests.delete(id);
-          reject(new Error(`Timeout waiting for extension: ${toolName}`));
-        }, timeoutMs);
-
-        pendingToolRequests.set(id, {
-          socket: null,
-          originalId: null,
-          tool: toolName,
-          onComplete: (r) => {
-            clearTimeout(timeoutId);
-            resolve(r);
-          }
-        });
-
-        writeMessage({ ...msg, id });
-      });
+        return requestCallExtension(requestContext, toolName, msg, timeoutMs);
+      };
 
       const result = await aistudioBuild.build({
         prompt: query,
+        signal: requestContext.signal,
         model: model || undefined,
         output,
         keepOpen,
@@ -1241,6 +1208,7 @@ function handleToolRequest(msg, socket) {
     let lastError = null;
     
     const sendNextKey = () => {
+      if (requestContext.signal.aborted) return;
       if (completed >= repeat) {
         if (lastError) {
           sendToolResponse(socket, originalId, null, `Key repeat failed: ${lastError}`);
@@ -1249,18 +1217,15 @@ function handleToolRequest(msg, socket) {
         }
         return;
       }
-      const id = ++requestCounter;
-      pendingToolRequests.set(id, { 
-        socket: null,
-        originalId: null,
+      requestCallExtension(
+        requestContext,
         tool,
-        onComplete: (result) => {
-          if (result.error) lastError = result.error;
-          completed++;
-          setTimeout(sendNextKey, 50);
-        }
-      });
-      writeMessage({ type: "EXECUTE_KEY", key, tabId: tid, id });
+        { type: "EXECUTE_KEY", key, tabId: tid },
+      ).then((result) => {
+        if (result.error) lastError = result.error;
+        completed++;
+        return require("./abort.cjs").abortableDelay(50, requestContext.signal);
+      }).then(sendNextKey).catch((error) => sendToolResponse(socket, originalId, null, error.message));
     };
     sendNextKey();
     return;
@@ -1268,23 +1233,25 @@ function handleToolRequest(msg, socket) {
   
   if (extensionMsg.type === "NAMED_TAB_SWITCH" || extensionMsg.type === "NAMED_TAB_CLOSE") {
     const { name, type: opType } = extensionMsg;
-    const lookupId = ++requestCounter;
-    pendingToolRequests.set(lookupId, {
-      socket: null,
-      originalId: null,
-      tool: "tabs_get_by_name",
-      onComplete: (result) => {
-        if (result.error || !result.tabId) {
-          sendToolResponse(socket, originalId, null, result.error || `No tab found with name "${name}"`);
-          return;
-        }
-        const actionId = ++requestCounter;
-        const actionType = opType === "NAMED_TAB_SWITCH" ? "SWITCH_TAB" : "CLOSE_TAB";
-        pendingToolRequests.set(actionId, { socket, originalId, tool, tabId: result.tabId });
-        writeMessage({ type: actionType, tabId: result.tabId, id: actionId });
+    requestCallExtension(
+      requestContext,
+      "tabs_get_by_name",
+      { type: "TABS_GET_BY_NAME", name },
+    ).then((result) => {
+      if (result.error || !result.tabId) {
+        throw new Error(result.error || `No tab found with name "${name}"`);
       }
-    });
-    writeMessage({ type: "TABS_GET_BY_NAME", name, id: lookupId });
+      const actionType = opType === "NAMED_TAB_SWITCH" ? "SWITCH_TAB" : "CLOSE_TAB";
+      const actionTool = opType === "NAMED_TAB_SWITCH" ? "switch_tab" : "close_tab";
+      return requestCallExtension(
+        requestContext,
+        actionTool,
+        { type: actionType, tabId: result.tabId },
+        30000,
+        actionTool === "close_tab",
+      );
+    }).then((result) => sendToolResponse(socket, originalId, result, result?.error || null))
+      .catch((error) => sendToolResponse(socket, originalId, null, error.message));
     return;
   }
   
@@ -1294,7 +1261,11 @@ function handleToolRequest(msg, socket) {
     originalId, 
     tool, 
     savePath: extensionMsg.savePath || args?.savePath,
-    autoScreenshot: args?.autoScreenshot,
+    autoScreenshot: args?.autoScreenshot === true,
+    autoScreenshotOutput: args?.autoScreenshotOutput,
+    networkExport: extensionMsg.type === "EXPORT_NETWORK_REQUESTS",
+    networkExportPath: args?.output,
+    networkExportFormat: extensionMsg.har ? "har" : extensionMsg.jsonl ? "jsonl" : "json",
     fullRes: extensionMsg.fullRes || args?.fullRes,
     maxSize: extensionMsg.maxSize || args?.maxSize,
     tabId: extensionMsg.tabId || tabId
@@ -1307,12 +1278,14 @@ function handleToolRequest(msg, socket) {
   writeMessage(finalMsg);
 }
 
-function executeBatch(actions, tabId, socket, originalId) {
+function executeBatch(actions, tabId, socket, originalId, requestContext = requestStorage.getStore()) {
+  const writeMessage = (message) => sendOwnedExtensionMessage(requestContext, message);
   const results = [];
   const DELAY_MS = 100;
   let currentIndex = 0;
   
   function executeNextAction() {
+    if (requestContext.signal.aborted) return;
     if (currentIndex >= actions.length) {
       sendToolResponse(socket, originalId, {
         success: true,
@@ -1343,16 +1316,14 @@ function executeBatch(actions, tabId, socket, originalId) {
     if (extensionMsg.type === "LOCAL_WAIT") {
       results.push({ index: currentIndex, type: action.type, success: true });
       currentIndex++;
-      setTimeout(executeNextAction, extensionMsg.seconds * 1000);
+      require("./abort.cjs").abortableDelay(extensionMsg.seconds * 1000, requestContext.signal)
+        .then(executeNextAction)
+        .catch((error) => sendToolResponse(socket, originalId, null, error.message));
       return;
     }
     
-    const id = ++requestCounter;
-    pendingToolRequests.set(id, {
-      socket: null,
-      originalId: null,
-      tool: toolName,
-      onComplete: (result) => {
+    requestCallExtension(requestContext, toolName, extensionMsg, 30000)
+      .then((result) => {
         if (result.error) {
           results.push({ index: currentIndex, type: action.type, success: false, error: result.error });
           sendToolResponse(socket, originalId, {
@@ -1364,15 +1335,12 @@ function executeBatch(actions, tabId, socket, originalId) {
           }, null);
           return;
         }
-        
         results.push({ index: currentIndex, type: action.type, success: true });
         currentIndex++;
-        
-        setTimeout(executeNextAction, DELAY_MS);
-      }
-    });
-    
-    writeMessage({ ...extensionMsg, id });
+        return require("./abort.cjs").abortableDelay(DELAY_MS, requestContext.signal)
+          .then(executeNextAction);
+      })
+      .catch((error) => sendToolResponse(socket, originalId, null, error.message));
   }
   
   executeNextAction();
@@ -1433,7 +1401,7 @@ function processInput() {
     
     try {
       const msg = JSON.parse(jsonStr);
-      log(`Received from extension: ${JSON.stringify(msg)}`);
+      log(`Received from extension: ${msg.type || "unknown"}${msg.id !== undefined ? ` id=${msg.id}` : ""}`);
       
       if (msg.type === "GET_AUTH") {
         log("Handling GET_AUTH from extension");
@@ -1467,24 +1435,24 @@ function processInput() {
       if (msg.type === "STREAM_EVENT") {
         const stream = activeStreams.get(msg.streamId);
         if (stream) {
-          try {
-            stream.socket.write(JSON.stringify(msg.event) + "\n");
-          } catch (e) {
-            log(`Error forwarding stream event: ${e.message}`);
-            activeStreams.delete(msg.streamId);
-            writeMessage({ type: "STREAM_STOP", streamId: msg.streamId });
-          }
+          sendSocket(stream.socket, msg.event, { stream: true }).catch((error) => {
+            log(`Error forwarding stream event: ${error.message}`);
+            stopActiveStream(msg.streamId);
+            stream.socket.destroy(error);
+          });
         }
         return;
       }
-      
+
       if (msg.type === "STREAM_ERROR") {
         const stream = activeStreams.get(msg.streamId);
         if (stream) {
-          try {
-            stream.socket.write(JSON.stringify({ error: msg.error }) + "\n");
-          } catch (e) {}
-          activeStreams.delete(msg.streamId);
+          sendSocket(stream.socket, { error: msg.error }, { stream: true })
+            .catch((error) => {
+              log(`Error forwarding stream error: ${error.message}`);
+              stream.socket.destroy(error);
+            })
+            .finally(() => stopActiveStream(msg.streamId));
         }
         return;
       }
@@ -1492,19 +1460,41 @@ function processInput() {
       
       if (msg.id && pendingToolRequests.has(msg.id)) {
         const pending = pendingToolRequests.get(msg.id);
+        if (pending.request?.signal.aborted || pending.request?.tombstoned) {
+          const request = pending.request;
+          const topLevelResponse = !pending.resolve && !pending.onComplete;
+          pendingToolRequests.resolve(msg.id, msg);
+          if (topLevelResponse && request?.context) {
+            completeOwnedRequest(request.context, request.id, "cleanup-settled");
+          }
+          return;
+        }
+        if (pending.resolve || pending.onComplete) {
+          pendingToolRequests.resolve(msg.id, msg);
+          return;
+        }
         pendingToolRequests.delete(msg.id);
-        
-        if (pending.onComplete) {
-          pending.onComplete(msg);
-        } else {
+        {
+
           const { socket, originalId, savePath, autoScreenshot, tabId: storedTabId } = pending;
           const tabId = storedTabId || msg._resolvedTabId;
+          const failAutoScreenshot = (message) => pending.autoScreenshotOutput
+            ? sendToolResponse(socket, originalId, null, `Auto-screenshot failed: ${message}`)
+            : sendToolResponse(socket, originalId, { ...msg, autoScreenshotError: message }, null);
           
-          if (savePath && msg.base64) {
+          if (pending.networkExport && Array.isArray(msg.entries)) {
+            try {
+              const exportResult = writeNetworkExport(pending.networkExportPath, msg.entries, pending.networkExportFormat);
+              sendToolResponse(socket, originalId, exportResult, null);
+            } catch (error) {
+              sendToolResponse(socket, originalId, null, `Failed to export network requests: ${error.message}`);
+            }
+          } else if (savePath && msg.base64) {
             try {
               const dir = path.dirname(savePath);
               if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-              fs.writeFileSync(savePath, Buffer.from(msg.base64, "base64"));
+              fs.writeFileSync(savePath, Buffer.from(msg.base64, "base64"), { mode: 0o600 });
+              try { fs.chmodSync(savePath, 0o600); } catch {}
               const origWidth = msg.width || 0;
               const origHeight = msg.height || 0;
               const maxSize = pending.maxSize || 1200;
@@ -1527,8 +1517,7 @@ function processInput() {
             }
           } else if (autoScreenshot && tabId && !msg.error && !msg.base64) {
             
-            const screenshotId = ++requestCounter;
-            const screenshotPath = path.join(SURF_TMP, `pi-auto-${Date.now()}.png`);
+            const screenshotPath = pending.autoScreenshotOutput || path.join(SURF_TMP, `pi-auto-${Date.now()}.png`);
             
             const autoFiles = fs.readdirSync(SURF_TMP)
               .filter(f => f.startsWith("pi-auto-") && f.endsWith(".png"))
@@ -1539,14 +1528,17 @@ function processInput() {
                 try { fs.unlinkSync(path.join(SURF_TMP, f.name)); } catch (e) {}
               });
             }
-            pendingToolRequests.set(screenshotId, {
-              socket: null,
-              originalId: null,
-              tool: "screenshot",
-              onComplete: (screenshotMsg) => {
+            require("./abort.cjs").abortableDelay(500, pending.request?.signal)
+              .then(() => requestCallExtension(
+                pending.request,
+                "screenshot",
+                { type: "EXECUTE_SCREENSHOT", tabId },
+              ))
+              .then((screenshotMsg) => {
                 if (screenshotMsg.base64) {
                   try {
-                    fs.writeFileSync(screenshotPath, Buffer.from(screenshotMsg.base64, "base64"));
+                    fs.writeFileSync(screenshotPath, Buffer.from(screenshotMsg.base64, "base64"), { mode: 0o600 });
+                    try { fs.chmodSync(screenshotPath, 0o600); } catch {}
                     const origW = screenshotMsg.width || 0;
                     const origH = screenshotMsg.height || 0;
                     let finalW = origW, finalH = origH;
@@ -1563,16 +1555,17 @@ function processInput() {
                       autoScreenshot: { path: screenshotPath, width: finalW, height: finalH, originalWidth: origW, originalHeight: origH }
                     }, null);
                   } catch (e) {
-                    sendToolResponse(socket, originalId, { ...msg, autoScreenshotError: e.message }, null);
+                    failAutoScreenshot(e.message);
                   }
                 } else {
                   const errMsg = screenshotMsg.error || "Failed to capture";
-                  sendToolResponse(socket, originalId, { ...msg, autoScreenshotError: errMsg }, null);
+                  failAutoScreenshot(errMsg);
                 }
-              }
-            });
-            setTimeout(() => writeMessage({ type: "EXECUTE_SCREENSHOT", tabId, id: screenshotId }), 500);
+              })
+              .catch((error) => failAutoScreenshot(error.message));
             return;
+          } else if (autoScreenshot && pending.autoScreenshotOutput && !msg.error) {
+            failAutoScreenshot(tabId ? "screenshot response was invalid" : "no tab available");
           } else if (msg.results && msg.savePath) {
             try {
               const dir = msg.savePath;
@@ -1606,11 +1599,7 @@ function processInput() {
         }
       } else if (msg.id && pendingRequests.has(msg.id)) {
         const { socket } = pendingRequests.get(msg.id);
-        try {
-          socket.write(JSON.stringify(msg) + "\n");
-        } catch (e) {
-          log(`Error writing to CLI socket: ${e.message}`);
-        }
+        sendSocket(socket, msg).catch((error) => log(`Error writing to CLI socket: ${error.message}`));
         pendingRequests.delete(msg.id);
       }
     } catch (e) {
@@ -1633,15 +1622,10 @@ const connectedSockets = new Set();
 process.stdin.on("end", () => {
   log("stdin ended (extension disconnected), notifying clients");
   for (const socket of Array.from(connectedSockets)) {
-    try {
-      socket.write(JSON.stringify({ 
-        type: "extension_disconnected",
-        message: "Surf extension was reloaded. Restart your command."
-      }) + "\n");
-      socket.end();
-    } catch (e) {
-      // Socket may already be closed
-    }
+    sendSocket(socket, {
+      type: "extension_disconnected",
+      message: "Surf extension was reloaded. Restart your command."
+    }).finally(() => socket.end()).catch(() => socket.end());
   }
   shutdown(0);
 });
@@ -1655,96 +1639,212 @@ process.stdout.on("error", (err) => {
 });
 
 const handleClient = (socket) => {
+  const isRemote = Boolean(socket.remoteAddress && socket.remotePort);
+  let transferState;
+  let transferReady;
+  let transferCleanupPromise;
+  const cleanupTransfers = () => {
+    if (!transferCleanupPromise) {
+      transferCleanupPromise = transferReady
+        ? transferReady.then((state) => state?.cleanup())
+        : Promise.resolve();
+    }
+    return transferCleanupPromise;
+  };
+  socket.transferCleanup = cleanupTransfers;
+  const ensureTransferState = () => {
+    if (context?.closed || socket.destroyed) throw transferError("transfer connection is closed", "SURF_TRANSFER_CLOSED");
+    if (!transferReady) {
+      transferCleanupPromise = undefined;
+      transferReady = createStagingDirectory(SURF_TMP)
+        .then(async (directory) => {
+          if (context?.closed || socket.destroyed) {
+            await fs.promises.rm(directory, { recursive: true, force: true }).catch(() => {});
+            throw transferError("transfer connection is closed", "SURF_TRANSFER_CLOSED");
+          }
+          try {
+            return createTransferState({ directory, writer: { send: (frame) => sendSocket(socket, frame) }, onActivity: () => sessionManager.touch(socketContexts.get(socket)) });
+          } catch (error) {
+            return fs.promises.rm(directory, { recursive: true, force: true }).catch(() => {}).then(() => { throw error; });
+          }
+        })
+        .catch((error) => { transferReady = undefined; throw error; });
+    }
+    return transferReady;
+  };
+  let context;
+  try {
+    context = sessionManager.admit(socket, isRemote);
+  } catch (error) {
+    sendSocket(socket, { error: error.message }).finally(() => socket.destroy()).catch(() => socket.destroy());
+    return;
+  }
+  const writer = createSocketWriter(socket, {
+    maxPendingBytes: 4 * 1024 * 1024,
+    onOverflow: ({ stream, error }) => {
+      auditSession({ event: stream ? "stream" : "writer", context, outcome: "overflow", request: context.activeRequest });
+      sessionManager.stopStream(context);
+      socket.destroy(error);
+    },
+  });
+  socketContexts.set(socket, context);
+  socketWriters.set(socket, writer);
   log("CLI client connected");
   connectedSockets.add(socket);
   socket.on("close", () => connectedSockets.delete(socket));
   
-  let dataBuffer = Buffer.alloc(0);
-
-  socket.on("data", (data) => {
-    dataBuffer = Buffer.concat([dataBuffer, data]);
-    let newline;
-    while ((newline = dataBuffer.indexOf(0x0a)) !== -1) {
-      const frame = dataBuffer.subarray(0, newline);
-      dataBuffer = dataBuffer.subarray(newline + 1);
-      if (frame.length > MAX_CLIENT_FRAME_BYTES) { log("CLI frame exceeds byte limit"); socket.destroy(); return; }
-      let line;
+  const stateDir = getStateDir();
+  let principal = null;
+  const authSession = isRemote ? createServerAuthSession({
+    socket,
+    stateDir,
+    send: (value) => sendSocket(socket, value),
+    async onAuthenticated(authenticatedPrincipal) {
+      sessionManager.authenticate(context, authenticatedPrincipal);
+      principal = authenticatedPrincipal;
+      log(`Remote client authenticated: ${authenticatedPrincipal.label} (${authenticatedPrincipal.clientId})`);
+    },
+    onError(error) {
+      log(`Remote authentication rejected: ${error.message}`);
+      sendSocket(socket, { type: "auth_error", message: error.message }).finally(() => socket.destroy()).catch(() => socket.destroy());
+    },
+  }) : null;
+  let messageChain = Promise.resolve();
+  const processMessage = async (msg) => {
+    if (context.closed) return;
+    if (isRemote && !authSession.authenticated) {
+      await authSession.handle(msg);
+      return;
+    }
+    if (isRemote) {
+      let authorized = false;
       try {
-        // Frames are independently encoded values.  Do not carry UTF-8 state
-        // from one newline-delimited frame into the next.
-        line = new TextDecoder("utf-8", { fatal: true }).decode(frame);
-      } catch {
-        log("CLI frame contains invalid UTF-8");
+        authorized = Boolean(principal && isClientAuthorized(stateDir, principal.clientId));
+      } catch (error) {
+        log(`Remote authorization registry check failed: ${error.message}`);
+      }
+      if (!authorized) {
+        await sendSocket(socket, { error: "remote client authorization is unavailable or revoked" }).catch(() => {});
         socket.destroy();
         return;
       }
-      if (!line.trim()) continue;
-      try {
-        const msg = JSON.parse(line);
-        
-        if (msg.type === "tool_request") {
-          log("Handling tool_request: " + msg.method + " " + (msg.params?.tool || ""));
-          try {
-            handleToolRequest(msg, socket);
-          } catch (e) {
-            socket.write(JSON.stringify({ error: e.message || "Request failed" }) + "\n");
-          }
-          continue;
-        }
-        
-        if (msg.type === "stream_request") {
-          if (msg.streamType !== "STREAM_CONSOLE" && msg.streamType !== "STREAM_NETWORK") {
-            log(`Rejecting unsupported stream type: ${msg.streamType}`);
-            socket.write(JSON.stringify({ error: `Unsupported stream type: ${msg.streamType}` }) + "\n");
-            continue;
-          }
-          log("Handling stream_request: " + msg.streamType);
-          handleStreamRequest(msg, socket);
-          continue;
-        }
-        
-        if (msg.type === "stream_stop") {
-          log("Handling stream_stop");
-          for (const [streamId, stream] of activeStreams.entries()) {
-            if (stream.socket === socket) {
-              writeMessage({ type: "STREAM_STOP", streamId });
-              activeStreams.delete(streamId);
-            }
-          }
-          continue;
-        }
-        
-        log(`Rejecting unsupported socket request type: ${msg.type}`);
-        socket.write(JSON.stringify({ error: `Unsupported request type: ${msg.type}` }) + "\n");
-      } catch (e) {
-        log(`Error parsing CLI request: ${e.message}`);
-        socket.write(JSON.stringify({ error: "Invalid request" }) + "\n");
-      }
     }
-    if (dataBuffer.length > MAX_CLIENT_FRAME_BYTES) { log("CLI frame exceeds byte limit"); socket.destroy(); }
+
+    if (isRemote && msg.type && msg.type.startsWith("transfer_")) {
+      transferState ||= await ensureTransferState();
+      await transferState.handle(msg);
+      return;
+    }
+
+    if (msg.type === "tool_request") {
+      const tool = msg.params?.tool || "unknown";
+      let request;
+      try {
+        const deadlineMs = TEST_REQUEST_DEADLINE_MS || resolveRequestDeadlineMs(tool, msg.params?.args);
+        request = await sessionManager.beginRequest(context, { id: msg.id, tool, deadlineMs });
+        request.context = context;
+      } catch (error) {
+        if (transferState) await discardRequestTransfers(msg, transferState);
+        await sendSocket(socket, { type: "tool_response", id: msg.id || null, error: { content: [{ type: "text", text: error.message }] } }).catch(() => {});
+        return;
+      }
+      log(`Handling tool_request: ${msg.method} ${tool}${principal ? ` for ${principal.label}` : ""}`);
+      try {
+        if (isRemote) {
+          await applyRequestTransfers(msg, request, transferState, ensureTransferState);
+        }
+        throwIfAborted(request.signal, "Request cancelled");
+        requestStorage.run(request, () => handleToolRequest(msg, socket, request));
+      } catch (e) {
+        await discardRequestTransfers(msg, transferState);
+        sendToolResponse(socket, msg.id || null, null, e.message || "Request failed");
+      }
+      return;
+    }
+
+    if (msg.type === "stream_request") {
+      if (msg.streamType !== "STREAM_CONSOLE" && msg.streamType !== "STREAM_NETWORK") {
+        log(`Rejecting unsupported stream type: ${msg.streamType}`);
+        await sendSocket(socket, { error: `Unsupported stream type: ${msg.streamType}` }).catch(() => {});
+        return;
+      }
+      if (!sessionManager.canStartStream(context)) {
+        await sendSocket(socket, { error: "stream limit reached or connection is not stream-only" }).catch(() => {});
+        socket.destroy();
+        return;
+      }
+      log(`Handling stream_request: ${msg.streamType}`);
+      handleStreamRequest(msg, socket);
+      return;
+    }
+
+    if (msg.type === "stream_stop") {
+      log("Handling stream_stop");
+      for (const [streamId, stream] of activeStreams.entries()) {
+        if (stream.socket === socket) stopActiveStream(streamId);
+      }
+      return;
+    }
+
+    log(`Rejecting unsupported socket request type: ${msg.type}`);
+    await sendSocket(socket, { error: `Unsupported request type: ${msg.type}` }).catch(() => {});
+  };
+
+  const parser = createFrameParser({
+    onFrame(msg) {
+      messageChain = messageChain.then(() => processMessage(msg)).catch((error) => {
+        log(`Error handling CLI request: ${error.message}`);
+        if (isRemote && msg.type && msg.type.startsWith("transfer_")) {
+          sendSocket(socket, { type: "transfer_error", version: 1, transferId: msg.transferId, error: error.message || "Transfer failed" })
+            .finally(() => socket.destroy()).catch(() => socket.destroy());
+        } else {
+          sendSocket(socket, { error: error.message || "Request failed" }).catch(() => {});
+        }
+      });
+    },
+    onError(error) {
+      log(`CLI frame rejected: ${error.message}`);
+      if (isRemote && !authSession.authenticated) {
+        sendSocket(socket, { type: "auth_error", message: error.message }).finally(() => socket.destroy()).catch(() => socket.destroy());
+      } else {
+        socket.destroy();
+      }
+    },
+    maxFrameBytes: MAX_CLIENT_FRAME_BYTES,
   });
+
+  socket.on("data", (data) => parser.push(data));
 
   socket.on("error", (err) => {
     log(`CLI socket error: ${err.message}`);
   });
   
   socket.on("close", () => {
+    parser.close();
+    authSession?.close();
+    const activeRequest = context.activeRequest;
+    let cleanupPendingId;
+    if (activeRequest && !activeRequest.queued) {
+      cleanupPendingId = `transfer-cleanup-${++requestCounter}`;
+      pendingToolRequests.set(cleanupPendingId, {
+        request: activeRequest,
+        cleanup: true,
+        tool: "transfer_cleanup",
+        resolve: () => {},
+        reject: () => {},
+      });
+      completeOwnedRequest(context, activeRequest.id, "cleanup-settled");
+    }
+    const cleanupPromise = cleanupTransfers();
+    cleanupPromise.finally(() => {
+      if (cleanupPendingId) pendingToolRequests.delete(cleanupPendingId);
+    }).catch(() => {});
+    writer.close();
+    sessionManager.close(context);
+    if (activeRequest) pendingToolRequests.tombstoneAfterAbort(activeRequest);
     log("CLI client disconnected");
-    for (const [id, pending] of pendingRequests.entries()) {
-      if (pending.socket === socket) {
-        pendingRequests.delete(id);
-      }
-    }
-    for (const [id, pending] of pendingToolRequests.entries()) {
-      if (pending.socket === socket && !pending.autoScreenshot) {
-        pendingToolRequests.delete(id);
-      }
-    }
     for (const [streamId, stream] of activeStreams.entries()) {
-      if (stream.socket === socket) {
-        writeMessage({ type: "STREAM_STOP", streamId });
-        activeStreams.delete(streamId);
-      }
+      if (stream.socket === socket) stopActiveStream(streamId);
     }
   });
 };
@@ -1762,9 +1862,10 @@ function shutdown(code = 0) {
   exitCode = Math.max(exitCode, code);
   if (shuttingDown) return;
   shuttingDown = true;
+  const cleanupPromises = [...connectedSockets].map((socket) => socket.transferCleanup?.() || Promise.resolve());
   for (const socket of connectedSockets) socket.destroy();
   pendingRequests.clear(); pendingToolRequests.clear(); activeStreams.clear();
-  Promise.resolve(listenerLifecycle?.shutdown()).finally(scheduleExit);
+  Promise.allSettled([...cleanupPromises, Promise.resolve(listenerLifecycle?.shutdown())]).finally(scheduleExit);
 }
 function failStartup(error, endpoint) {
   log(`Listener startup failed (${endpoint}): ${error.message}`);

--- a/native/host.cjs
+++ b/native/host.cjs
@@ -16,7 +16,68 @@ const { mapToolToMessage, mapComputerAction, formatToolContent, buildProviderUpl
 
 const IS_WIN = process.platform === "win32";
 const { SOCKET_PATH, SURF_TMP } = require("./socket-path.cjs");
+const { parseListenEndpoint } = require("./listener.cjs");
+const MAX_CLIENT_FRAME_BYTES = 1024 * 1024;
 if (IS_WIN) { try { fs.mkdirSync(SURF_TMP, { recursive: true }); } catch {} }
+
+// The endpoint passed here is already validated by the caller. Keeping this
+// lifecycle separate lets tests use an ephemeral loopback port without adding
+// a localhost escape hatch to SURF_LISTEN parsing.
+function createListenerLifecycle({ localPath, tcpEndpoint, handler, onReady, onFatal }) {
+  const localServer = net.createServer(handler);
+  const tcpServer = tcpEndpoint ? net.createServer(handler) : null;
+  let shuttingDown = false;
+  let startPromise = null;
+  const close = (server) => {
+    if (!server) return;
+    try { server.close(); } catch (error) {
+      if (error.code !== "ERR_SERVER_NOT_RUNNING") throw error;
+    }
+  };
+  const unlink = () => { if (!IS_WIN) { try { fs.unlinkSync(localPath); } catch {} } };
+  const listen = (server, options) => new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(options, () => {
+      server.removeListener("error", reject);
+      if (shuttingDown) { close(server); unlink(); }
+      resolve();
+    });
+  });
+  const start = () => {
+    if (startPromise) return startPromise;
+    startPromise = (async () => {
+      try {
+        await listen(localServer, localPath);
+        if (shuttingDown) return false;
+        if (!IS_WIN) { try { fs.chmodSync(localPath, 0o600); } catch {} }
+        if (tcpServer) {
+          await listen(tcpServer, tcpEndpoint);
+          if (shuttingDown) return false;
+        }
+        onReady();
+        return true;
+      } catch (error) {
+        if (!shuttingDown) onFatal(error);
+        close(localServer); close(tcpServer); unlink();
+        return false;
+      } finally {
+        if (shuttingDown) { close(localServer); close(tcpServer); unlink(); }
+      }
+    })();
+    return startPromise;
+  };
+  return {
+    localServer,
+    tcpServer,
+    start,
+    async shutdown() {
+      shuttingDown = true;
+      close(localServer); close(tcpServer); unlink();
+      if (startPromise) await startPromise;
+      unlink();
+    },
+  };
+}
 
 // Cross-platform image resize (macOS: sips, Linux: ImageMagick)
 function resizeImage(filePath, maxSize) {
@@ -291,6 +352,7 @@ const log = (msg) => {
   fs.appendFileSync(LOG_FILE, `${new Date().toISOString()} ${msg}\n`);
 };
 
+if (require.main === module) {
 log("Host starting...");
 
 if (!IS_WIN) { try { fs.unlinkSync(SOCKET_PATH); } catch {} }
@@ -1581,7 +1643,7 @@ process.stdin.on("end", () => {
       // Socket may already be closed
     }
   }
-  process.exit(0);
+  shutdown(0);
 });
 
 process.stdin.on("error", (err) => {
@@ -1592,50 +1654,33 @@ process.stdout.on("error", (err) => {
   log(`stdout error: ${err.message}`);
 });
 
-const server = net.createServer((socket) => {
+const handleClient = (socket) => {
   log("CLI client connected");
   connectedSockets.add(socket);
   socket.on("close", () => connectedSockets.delete(socket));
   
-  let dataBuffer = "";
+  let dataBuffer = Buffer.alloc(0);
 
   socket.on("data", (data) => {
-    dataBuffer += data.toString();
-    const lines = dataBuffer.split("\n");
-    dataBuffer = lines.pop() || "";
-
-    for (const line of lines) {
+    dataBuffer = Buffer.concat([dataBuffer, data]);
+    let newline;
+    while ((newline = dataBuffer.indexOf(0x0a)) !== -1) {
+      const frame = dataBuffer.subarray(0, newline);
+      dataBuffer = dataBuffer.subarray(newline + 1);
+      if (frame.length > MAX_CLIENT_FRAME_BYTES) { log("CLI frame exceeds byte limit"); socket.destroy(); return; }
+      let line;
+      try {
+        // Frames are independently encoded values.  Do not carry UTF-8 state
+        // from one newline-delimited frame into the next.
+        line = new TextDecoder("utf-8", { fatal: true }).decode(frame);
+      } catch {
+        log("CLI frame contains invalid UTF-8");
+        socket.destroy();
+        return;
+      }
       if (!line.trim()) continue;
       try {
         const msg = JSON.parse(line);
-        
-        if (msg.type === "GET_AUTH") {
-          log("Handling GET_AUTH locally");
-          try {
-            if (fs.existsSync(AUTH_FILE)) {
-              const authData = JSON.parse(fs.readFileSync(AUTH_FILE, "utf8"));
-              socket.write(JSON.stringify({ 
-                id: msg.id || 0,
-                auth: authData,
-                hint: null
-              }) + "\n");
-            } else {
-              socket.write(JSON.stringify({ 
-                id: msg.id || 0,
-                auth: null,
-                hint: "No OAuth credentials found. Run 'pi --login anthropic' in terminal to authenticate with Claude Max."
-              }) + "\n");
-            }
-          } catch (e) {
-            log(`Error reading auth file: ${e.message}`);
-            socket.write(JSON.stringify({ 
-              id: msg.id || 0,
-              auth: null,
-              hint: "Failed to read auth credentials. Run 'pi --login anthropic' in terminal to authenticate."
-            }) + "\n");
-          }
-          continue;
-        }
         
         if (msg.type === "tool_request") {
           log("Handling tool_request: " + msg.method + " " + (msg.params?.tool || ""));
@@ -1648,6 +1693,11 @@ const server = net.createServer((socket) => {
         }
         
         if (msg.type === "stream_request") {
+          if (msg.streamType !== "STREAM_CONSOLE" && msg.streamType !== "STREAM_NETWORK") {
+            log(`Rejecting unsupported stream type: ${msg.streamType}`);
+            socket.write(JSON.stringify({ error: `Unsupported stream type: ${msg.streamType}` }) + "\n");
+            continue;
+          }
           log("Handling stream_request: " + msg.streamType);
           handleStreamRequest(msg, socket);
           continue;
@@ -1664,15 +1714,14 @@ const server = net.createServer((socket) => {
           continue;
         }
         
-        const id = ++requestCounter;
-        log(`Forwarding to extension: id=${id} type=${msg.type}`);
-        pendingRequests.set(id, { socket });
-        writeMessage({ ...msg, id });
+        log(`Rejecting unsupported socket request type: ${msg.type}`);
+        socket.write(JSON.stringify({ error: `Unsupported request type: ${msg.type}` }) + "\n");
       } catch (e) {
         log(`Error parsing CLI request: ${e.message}`);
         socket.write(JSON.stringify({ error: "Invalid request" }) + "\n");
       }
     }
+    if (dataBuffer.length > MAX_CLIENT_FRAME_BYTES) { log("CLI frame exceeds byte limit"); socket.destroy(); }
   });
 
   socket.on("error", (err) => {
@@ -1698,36 +1747,66 @@ const server = net.createServer((socket) => {
       }
     }
   });
-});
+};
 
-server.listen(SOCKET_PATH, () => {
-  log("Socket server listening on " + SOCKET_PATH);
-  if (!IS_WIN) { try { fs.chmodSync(SOCKET_PATH, 0o600); } catch {} }
-  writeMessage({ type: "HOST_READY" });
-  log("Sent HOST_READY to extension");
-});
-
-server.on("error", (err) => {
-  log(`Server error: ${err.message}`);
-});
+let listenerLifecycle = null;
+let shuttingDown = false;
+let exitCode = 0;
+let exitScheduled = false;
+function scheduleExit() {
+  if (exitScheduled) return;
+  exitScheduled = true;
+  setTimeout(() => process.exit(exitCode), 50);
+}
+function shutdown(code = 0) {
+  exitCode = Math.max(exitCode, code);
+  if (shuttingDown) return;
+  shuttingDown = true;
+  for (const socket of connectedSockets) socket.destroy();
+  pendingRequests.clear(); pendingToolRequests.clear(); activeStreams.clear();
+  Promise.resolve(listenerLifecycle?.shutdown()).finally(scheduleExit);
+}
+function failStartup(error, endpoint) {
+  log(`Listener startup failed (${endpoint}): ${error.message}`);
+  shutdown(1);
+}
+async function startListeners() {
+  let endpoint;
+  try {
+    endpoint = process.env.SURF_LISTEN ? parseListenEndpoint(process.env.SURF_LISTEN) : null;
+    listenerLifecycle = createListenerLifecycle({
+      localPath: SOCKET_PATH,
+      tcpEndpoint: endpoint && { host: endpoint.host, port: endpoint.port },
+      handler: handleClient,
+      onReady: () => {
+        if (endpoint) log(`TCP listener listening on ${endpoint.display}`);
+        writeMessage({ type: "HOST_READY" });
+        log("Sent HOST_READY to extension");
+      },
+      onFatal: (error) => failStartup(error, endpoint?.display || process.env.SURF_LISTEN || SOCKET_PATH),
+    });
+    if (shuttingDown) await listenerLifecycle.shutdown();
+    await listenerLifecycle.start();
+  } catch (error) { failStartup(error, endpoint?.display || process.env.SURF_LISTEN || SOCKET_PATH); }
+}
+startListeners();
 
 process.on("SIGTERM", () => {
   log("SIGTERM received");
-  server.close();
-  if (!IS_WIN) { try { fs.unlinkSync(SOCKET_PATH); } catch {} }
-  process.exit(0);
+  shutdown();
 });
 
 process.on("SIGINT", () => {
   log("SIGINT received");
-  server.close();
-  if (!IS_WIN) { try { fs.unlinkSync(SOCKET_PATH); } catch {} }
-  process.exit(0);
+  shutdown();
 });
 
 process.on("uncaughtException", (err) => {
   log(`Uncaught exception: ${err.message}\n${err.stack}`);
-  process.exit(1);
+  shutdown(1);
 });
 
 log("Host initialization complete, waiting for connections...");
+} else {
+  module.exports = { createListenerLifecycle, MAX_CLIENT_FRAME_BYTES };
+}

--- a/native/listener.cjs
+++ b/native/listener.cjs
@@ -1,0 +1,20 @@
+const net = require("net");
+
+function parseListenEndpoint(value) {
+  const v6 = typeof value === "string" && value.match(/^\[([^\]]+)\]:(\d+)$/);
+  const v4 = typeof value === "string" && value.match(/^([^:]+):(\d+)$/);
+  const host = v6 ? v6[1] : v4?.[1];
+  const port = Number(v6 ? v6[2] : v4?.[2]);
+  if (!host || !Number.isInteger(port) || port < 1 || port > 65535) throw new Error("SURF_LISTEN must be a Tailnet IP and port 1..65535");
+  if (v6) {
+    if (net.isIP(host) !== 6) throw new Error("SURF_LISTEN must use a Tailscale IPv6 address");
+    const canonical = new URL(`http://[${host}]`).hostname.slice(1, -1);
+    if (!canonical.startsWith("fd7a:115c:a1e0:")) throw new Error("SURF_LISTEN must use a Tailscale IPv6 address");
+    return { host: canonical, port, display: `[${canonical}]:${port}` };
+  }
+  const parts = host.split(".").map(Number);
+  if (net.isIP(host) !== 4 || parts[0] !== 100 || parts[1] < 64 || parts[1] > 127) throw new Error("SURF_LISTEN must use a Tailscale IPv4 address");
+  return { host, port, display: `${host}:${port}` };
+}
+
+module.exports = { parseListenEndpoint };

--- a/native/mcp-server.cjs
+++ b/native/mcp-server.cjs
@@ -3,9 +3,10 @@ const { McpServer } = require("@modelcontextprotocol/sdk/server/mcp.js");
 const { StdioServerTransport } = require("@modelcontextprotocol/sdk/server/stdio.js");
 const { z } = require("zod");
 const { formatSocketError } = require("./socket-path.cjs");
-const { connectEndpoint, selectEndpoint, formatEndpointError } = require("./endpoint.cjs");
-
-const REQUEST_TIMEOUT = 30000;
+const { selectEndpoint } = require("./endpoint.cjs");
+const { openClientTransport } = require("./client-transport.cjs");
+const { resolveRequestDeadlineMs } = require("./host-sessions.cjs");
+const { prepareRemoteTool, validateLocalToolPaths } = require("./file-transfer.cjs");
 
 const TOOL_SCHEMAS = {
   navigate: {
@@ -263,63 +264,56 @@ const TOOL_SCHEMAS = {
       query: z.string().describe("Question about the page"),
       mode: z.enum(["find", "summary", "extract"]).optional().describe("Query mode")
     }
+  },
+  chatgpt: {
+    desc: "Ask ChatGPT through the browser session",
+    schema: {
+      query: z.string().describe("Question or prompt"),
+      model: z.string().optional().describe("ChatGPT model"),
+      "with-page": z.boolean().optional().describe("Include current page context"),
+      file: z.string().optional().describe("One attachment path"),
+      timeout: z.number().optional().describe("Timeout in seconds")
+    }
+  },
+  gemini: {
+    desc: "Ask Gemini or generate/edit one image",
+    schema: {
+      query: z.string().optional().describe("Question or image prompt"),
+      model: z.string().optional().describe("Gemini model"),
+      "with-page": z.boolean().optional().describe("Include current page context"),
+      file: z.string().optional().describe("One attachment path"),
+      "edit-image": z.string().optional().describe("One image input path"),
+      "generate-image": z.string().optional().describe("One generated image output path"),
+      output: z.string().optional().describe("Edited image output path"),
+      youtube: z.string().optional().describe("YouTube URL"),
+      "aspect-ratio": z.string().optional().describe("Image aspect ratio"),
+      timeout: z.number().optional().describe("Timeout in seconds")
+    }
+  },
+  "network.export": {
+    desc: "Export captured network requests",
+    schema: {
+      output: z.string().optional().describe("Output file path"),
+      jsonl: z.boolean().optional().describe("Write JSONL"),
+      har: z.boolean().optional().describe("Write HAR 1.2")
+    }
   }
 };
 
-function sendSocketRequest(tool, args = {}, endpoint = selectEndpoint([]).endpoint) {
-  return new Promise((resolve, reject) => {
-    const sock = connectEndpoint(endpoint, () => {
-      const req = {
-        type: "tool_request",
-        method: "execute_tool",
-        params: { tool, args },
-        id: "mcp-" + Date.now() + "-" + Math.random()
-      };
-      sock.write(JSON.stringify(req) + "\n");
-    });
-
-    let buf = "";
-    let settled = false;
-    const timeout = setTimeout(() => {
-      settled = true;
-      sock.destroy();
-      reject(new Error("Request timeout"));
-    }, REQUEST_TIMEOUT);
-
-    sock.on("data", (d) => {
-      buf += d.toString();
-      const lines = buf.split("\n");
-      buf = lines.pop();
-      for (const line of lines) {
-        if (!line.trim()) continue;
-        try {
-          settled = true;
-          clearTimeout(timeout);
-          const resp = JSON.parse(line);
-          sock.end();
-          resolve(resp);
-        } catch {
-          settled = true;
-          clearTimeout(timeout);
-          sock.end();
-          reject(new Error("Invalid JSON response"));
-        }
-      }
-    });
-
-    sock.on("error", (e) => {
-      settled = true;
-      clearTimeout(timeout);
-      reject(new Error(formatEndpointError(e, endpoint, formatSocketError)));
-    });
-
-    sock.on("close", () => {
-      clearTimeout(timeout);
-      if (!settled) {
-        reject(new Error(`Connection closed unexpectedly\nAttempted endpoint: ${endpoint.display}`));
-      }
-    });
-  });
+async function sendSocketRequest(tool, args = {}, endpoint = selectEndpoint([]).endpoint) {
+  const requestTimeoutMs = resolveRequestDeadlineMs(tool, args);
+  const transport = await openClientTransport(endpoint, { requestTimeoutMs });
+  try {
+    const prepared = endpoint.kind === "remote" ? prepareRemoteTool(tool, args) : (() => { const normalized = validateLocalToolPaths(tool, args); return { args: normalized, uploads: [], downloads: [] }; })();
+    return await transport.request({
+      type: "tool_request",
+      method: "execute_tool",
+      params: { tool, args: prepared.args },
+      id: "mcp-" + Date.now() + "-" + Math.random(),
+    }, requestTimeoutMs, prepared);
+  } finally {
+    await transport.close();
+  }
 }
 
 function formatResult(resp) {
@@ -512,4 +506,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { PiChromeMcpServer };
+module.exports = { PiChromeMcpServer, TOOL_SCHEMAS };

--- a/native/mcp-server.cjs
+++ b/native/mcp-server.cjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
-const net = require("net");
 const { McpServer } = require("@modelcontextprotocol/sdk/server/mcp.js");
 const { StdioServerTransport } = require("@modelcontextprotocol/sdk/server/stdio.js");
 const { z } = require("zod");
-const { SOCKET_PATH, formatSocketError } = require("./socket-path.cjs");
+const { formatSocketError } = require("./socket-path.cjs");
+const { connectEndpoint, selectEndpoint, formatEndpointError } = require("./endpoint.cjs");
 
 const REQUEST_TIMEOUT = 30000;
 
@@ -266,9 +266,9 @@ const TOOL_SCHEMAS = {
   }
 };
 
-function sendSocketRequest(tool, args = {}) {
+function sendSocketRequest(tool, args = {}, endpoint = selectEndpoint([]).endpoint) {
   return new Promise((resolve, reject) => {
-    const sock = net.createConnection(SOCKET_PATH, () => {
+    const sock = connectEndpoint(endpoint, () => {
       const req = {
         type: "tool_request",
         method: "execute_tool",
@@ -310,13 +310,13 @@ function sendSocketRequest(tool, args = {}) {
     sock.on("error", (e) => {
       settled = true;
       clearTimeout(timeout);
-      reject(new Error(formatSocketError(e)));
+      reject(new Error(formatEndpointError(e, endpoint, formatSocketError)));
     });
 
     sock.on("close", () => {
       clearTimeout(timeout);
       if (!settled) {
-        reject(new Error(`Socket closed unexpectedly\nAttempted socket: ${SOCKET_PATH}`));
+        reject(new Error(`Connection closed unexpectedly\nAttempted endpoint: ${endpoint.display}`));
       }
     });
   });
@@ -351,7 +351,8 @@ function formatResult(resp) {
 }
 
 class PiChromeMcpServer {
-  constructor() {
+  constructor(endpoint = selectEndpoint([]).endpoint) {
+    this.endpoint = endpoint;
     this.server = new McpServer({
       name: "surf",
       version: "1.0.0"
@@ -373,7 +374,7 @@ class PiChromeMcpServer {
         schemaObj,
         async (args) => {
           try {
-            const resp = await sendSocketRequest(name, args);
+            const resp = await sendSocketRequest(name, args, this.endpoint);
             return formatResult(resp);
           } catch (err) {
             return {
@@ -392,7 +393,7 @@ class PiChromeMcpServer {
       "page://current",
       async (uri) => {
         try {
-          const resp = await sendSocketRequest("page.read", {});
+          const resp = await sendSocketRequest("page.read", {}, this.endpoint);
           const text = resp.result?.content?.[0]?.text || "No content";
           return {
             contents: [{
@@ -418,7 +419,7 @@ class PiChromeMcpServer {
       "tabs://list",
       async (uri) => {
         try {
-          const resp = await sendSocketRequest("tab.list", {});
+          const resp = await sendSocketRequest("tab.list", {}, this.endpoint);
           const text = resp.result?.content?.[0]?.text || "[]";
           return {
             contents: [{
@@ -444,7 +445,7 @@ class PiChromeMcpServer {
       "console://messages",
       async (uri) => {
         try {
-          const resp = await sendSocketRequest("console", {});
+          const resp = await sendSocketRequest("console", {}, this.endpoint);
           const text = resp.result?.content?.[0]?.text || "No messages";
           return {
             contents: [{
@@ -470,7 +471,7 @@ class PiChromeMcpServer {
       "network://requests",
       async (uri) => {
         try {
-          const resp = await sendSocketRequest("network", {});
+          const resp = await sendSocketRequest("network", {}, this.endpoint);
           const text = resp.result?.content?.[0]?.text || "No requests";
           return {
             contents: [{

--- a/native/network-export.cjs
+++ b/native/network-export.cjs
@@ -1,0 +1,113 @@
+const crypto = require("crypto");
+const fs = require("fs");
+const path = require("path");
+const { version: PACKAGE_VERSION } = require("../package.json");
+
+const MAX_NETWORK_EXPORT_FILE_BYTES = 256 * 1024 * 1024;
+const INTERNAL_FIELDS = new Set(["_requestId", "_responseReceived", "_loadingFinished"]);
+
+function publicEntry(entry) {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    throw new Error("network export entries must be objects");
+  }
+  const result = Object.create(null);
+  for (const [key, value] of Object.entries(entry)) {
+    if (!INTERNAL_FIELDS.has(key)) result[key] = value;
+  }
+  return result;
+}
+
+function headerList(headers) {
+  if (!headers || typeof headers !== "object" || Array.isArray(headers)) return [];
+  return Object.entries(headers).map(([name, value]) => ({ name, value: String(value) }));
+}
+
+function harEntry(entry) {
+  const requestBody = entry.requestBody;
+  const responseBody = entry.responseBody;
+  const requestHeaders = entry.requestHeaders;
+  const responseHeaders = entry.responseHeaders;
+  const duration = Number.isFinite(entry.duration) ? Math.max(0, entry.duration) : 0;
+  const ttfb = Number.isFinite(entry.ttfb) ? Math.max(0, entry.ttfb) : duration;
+  return {
+    startedDateTime: new Date(Number(entry.ts) || Date.now()).toISOString(),
+    time: duration,
+    request: {
+      method: entry.method || "GET",
+      url: entry.url || "",
+      httpVersion: "HTTP/1.1",
+      headers: headerList(requestHeaders),
+      queryString: [],
+      cookies: [],
+      headersSize: -1,
+      bodySize: Number.isFinite(entry.requestBodySize) ? entry.requestBodySize : requestBody ? Buffer.byteLength(String(requestBody)) : -1,
+      ...(requestBody !== undefined ? { postData: { mimeType: "application/octet-stream", text: String(requestBody) } } : {}),
+    },
+    response: {
+      status: Number.isFinite(entry.status) ? entry.status : 0,
+      statusText: entry.statusText || "",
+      httpVersion: "HTTP/1.1",
+      headers: headerList(responseHeaders),
+      cookies: [],
+      content: {
+        size: Number.isFinite(entry.responseBodySize) ? entry.responseBodySize : responseBody ? Buffer.byteLength(String(responseBody)) : 0,
+        mimeType: entry.mimeType || "",
+        ...(responseBody !== undefined ? { text: String(responseBody) } : {}),
+      },
+      redirectURL: "",
+      headersSize: -1,
+      bodySize: Number.isFinite(entry.responseBodySize) ? entry.responseBodySize : responseBody ? Buffer.byteLength(String(responseBody)) : -1,
+    },
+    cache: {},
+    timings: { send: 0, wait: ttfb, receive: Math.max(0, duration - ttfb) },
+    ...(entry.comment ? { comment: String(entry.comment) } : {}),
+  };
+}
+
+function serializeNetworkExport(entries, format = "json") {
+  if (!Array.isArray(entries)) throw new Error("network export entries must be an array");
+  if (format !== "json" && format !== "jsonl" && format !== "har") throw new Error(`unsupported network export format: ${format}`);
+  const publicEntries = entries.map(publicEntry);
+  if (format === "jsonl") return `${publicEntries.map((entry) => JSON.stringify(entry)).join("\n")}\n`;
+  if (format === "har") {
+    return JSON.stringify({
+      log: {
+        version: "1.2",
+        creator: { name: "surf-cli", version: PACKAGE_VERSION },
+        entries: publicEntries.map(harEntry),
+      },
+    });
+  }
+  return JSON.stringify(publicEntries, null, 2);
+}
+
+function writeNetworkExport(outputPath, entries, format = "json") {
+  if (typeof outputPath !== "string" || !path.isAbsolute(outputPath)) throw new Error("network export output must be an absolute path");
+  const content = serializeNetworkExport(entries, format);
+  const bytes = Buffer.byteLength(content);
+  if (bytes > MAX_NETWORK_EXPORT_FILE_BYTES) throw new Error("network export exceeds the 256 MiB file limit");
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  const temporaryPath = path.join(path.dirname(outputPath), `.${path.basename(outputPath)}.surf-${crypto.randomBytes(12).toString("hex")}.tmp`);
+  try {
+    const fd = fs.openSync(temporaryPath, "wx", 0o600);
+    try {
+      fs.writeFileSync(fd, content, "utf8");
+      fs.fchmodSync(fd, 0o600);
+    } finally {
+      fs.closeSync(fd);
+    }
+    fs.renameSync(temporaryPath, outputPath);
+  } catch (error) {
+    try { fs.rmSync(temporaryPath, { force: true }); } catch {}
+    throw error;
+  }
+  return { path: outputPath, format, count: entries.length, bytes };
+}
+
+module.exports = {
+  INTERNAL_FIELDS,
+  MAX_NETWORK_EXPORT_FILE_BYTES,
+  publicEntry,
+  serializeNetworkExport,
+  writeNetworkExport,
+};

--- a/native/perplexity-client.cjs
+++ b/native/perplexity-client.cjs
@@ -5,14 +5,16 @@
  * Similar approach to the ChatGPT client.
  */
 
+const { abortableDelay, raceAbort, throwIfAborted } = require("./abort.cjs");
+
 const PERPLEXITY_URL = "https://www.perplexity.ai/";
 
 // ============================================================================
 // Helpers
 // ============================================================================
 
-function delay(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
+function delay(ms, signal) {
+  return abortableDelay(ms, signal);
 }
 
 function buildClickDispatcher() {
@@ -390,7 +392,8 @@ function extractPerplexityResponseText() {
   return '';
 }
 
-async function waitForResponse(cdp, timeoutMs = 120000) {
+async function waitForResponse(cdp, timeoutMs = 120000, signal) {
+  throwIfAborted(signal);
   const deadline = Date.now() + timeoutMs;
   let previousText = '';
   let stableCycles = 0;
@@ -405,11 +408,11 @@ async function waitForResponse(cdp, timeoutMs = 120000) {
     if (url && url.includes('/search/')) {
       break;
     }
-    await delay(200);
+    await delay(200, signal);
   }
   
   // Wait a bit for the response area to render
-  await delay(1000);
+  await delay(1000, signal);
   
   // Now poll for response completion
   while (Date.now() < deadline) {
@@ -430,7 +433,7 @@ async function waitForResponse(cdp, timeoutMs = 120000) {
     })()`);
     
     if (!snapshot) {
-      await delay(300);
+      await delay(300, signal);
       continue;
     }
     
@@ -472,7 +475,7 @@ async function waitForResponse(cdp, timeoutMs = 120000) {
       };
     }
     
-    await delay(300);
+    await delay(300, signal);
   }
   
   // Timeout - return whatever we have
@@ -503,13 +506,15 @@ async function query(options) {
     cdpEvaluate,
     cdpCommand,
     log = () => {},
+    signal,
   } = options;
+  throwIfAborted(signal);
   
   const startTime = Date.now();
   log("Starting Perplexity query");
   
   // Create tab
-  const tabInfo = await createTab();
+  const tabInfo = await raceAbort(createTab, signal);
   log(`createTab returned: ${JSON.stringify(tabInfo)}`);
   const { tabId } = tabInfo || {};
   
@@ -518,8 +523,8 @@ async function query(options) {
   }
   log(`Created tab ${tabId}`);
   
-  const cdp = (expr) => cdpEvaluate(tabId, expr);
-  const inputCdp = (method, params) => cdpCommand(tabId, method, params);
+  const cdp = (expr) => raceAbort(() => cdpEvaluate(tabId, expr), signal);
+  const inputCdp = (method, params) => raceAbort(() => cdpCommand(tabId, method, params), signal);
   
   try {
     // Wait for page load
@@ -540,6 +545,7 @@ async function query(options) {
         const selectedMode = await selectMode(cdp, mode);
         log(`Mode: ${selectedMode}`);
       } catch (e) {
+        if (signal?.aborted) throw e;
         log(`Mode selection failed: ${e.message}`);
       }
     }
@@ -550,6 +556,7 @@ async function query(options) {
         const selectedModel = await selectModel(cdp, model);
         log(`Model: ${selectedModel}`);
       } catch (e) {
+        if (signal?.aborted) throw e;
         log(`Model selection failed: ${e.message}`);
       }
     }
@@ -563,7 +570,7 @@ async function query(options) {
     log("Submitted, waiting for response...");
     
     // Wait for response
-    const response = await waitForResponse(cdp, timeout);
+    const response = await waitForResponse(cdp, timeout, signal);
     log(`Response: ${response.text.length} chars, ${response.sources} sources${response.partial ? ' (partial)' : ''}`);
     
     return {
@@ -576,7 +583,11 @@ async function query(options) {
       tookMs: Date.now() - startTime,
     };
   } finally {
-    await closeTab(tabId).catch(() => {});
+    try {
+      await closeTab(tabId);
+    } catch (error) {
+      log(`Failed to close Perplexity tab ${tabId}: ${error?.message || error}`);
+    }
   }
 }
 

--- a/native/remote-auth.cjs
+++ b/native/remote-auth.cjs
@@ -1,0 +1,279 @@
+const crypto = require("crypto");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const PROTOCOL_VERSION = 1;
+const NONCE_BYTES = 32;
+const LABEL_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+const CLIENT_ID_PATTERN = /^[a-f0-9]{32}$/;
+const STATE_DIR_MODE = 0o700;
+const STATE_FILE_MODE = 0o600;
+const DEFAULT_STATE_DIR = path.join(os.homedir(), ".surf", "remote");
+const HOST_IDENTITY_FILE = "host-identity.json";
+const CLIENT_REGISTRY_FILE = "remote-clients.json";
+const AUTH_DOMAIN = "surf-cli-remote-auth-v1";
+
+function getStateDir(env = process.env) {
+  return env.SURF_REMOTE_STATE_DIR || DEFAULT_STATE_DIR;
+}
+
+function assertSafeLabel(label) {
+  if (typeof label !== "string" || !LABEL_PATTERN.test(label)) {
+    throw new Error("remote client label must be 1-64 characters using letters, numbers, dot, underscore, or hyphen");
+  }
+  return label;
+}
+
+function assertClientId(clientId) {
+  if (typeof clientId !== "string" || !CLIENT_ID_PATTERN.test(clientId)) throw new Error("remote client ID is invalid");
+}
+
+function statePaths(stateDir = getStateDir()) {
+  return {
+    stateDir,
+    hostIdentity: path.join(stateDir, HOST_IDENTITY_FILE),
+    registry: path.join(stateDir, CLIENT_REGISTRY_FILE),
+  };
+}
+
+function assertNotSymlink(filePath, allowMissing = true) {
+  try {
+    const stat = fs.lstatSync(filePath);
+    if (stat.isSymbolicLink()) throw new Error(`refusing symbolic link: ${filePath}`);
+    return stat;
+  } catch (error) {
+    if (allowMissing && error?.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function ensureStateDir(stateDir) {
+  assertNotSymlink(stateDir, true);
+  fs.mkdirSync(stateDir, { recursive: true, mode: STATE_DIR_MODE });
+  const stat = assertNotSymlink(stateDir, false);
+  if (!stat.isDirectory()) throw new Error(`remote state path is not a directory: ${stateDir}`);
+  fs.chmodSync(stateDir, STATE_DIR_MODE);
+}
+
+function assertPrivateFile(filePath) {
+  const stat = assertNotSymlink(filePath, false);
+  if (!stat.isFile()) throw new Error(`remote state path is not a file: ${filePath}`);
+  if ((stat.mode & 0o077) !== 0) throw new Error(`remote state file permissions are too broad: ${filePath}`);
+  return stat;
+}
+
+function atomicWriteJson(filePath, value) {
+  const dir = path.dirname(filePath);
+  assertNotSymlink(dir, true);
+  fs.mkdirSync(dir, { recursive: true, mode: STATE_DIR_MODE });
+  assertNotSymlink(dir, false);
+  assertNotSymlink(filePath, true);
+  const tempPath = path.join(dir, `.${path.basename(filePath)}.${process.pid}.${crypto.randomBytes(8).toString("hex")}.tmp`);
+  let created = false;
+  try {
+    const fd = fs.openSync(tempPath, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL, STATE_FILE_MODE);
+    created = true;
+    try {
+      fs.writeFileSync(fd, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+      fs.fsyncSync(fd);
+    } finally {
+      fs.closeSync(fd);
+    }
+    fs.renameSync(tempPath, filePath);
+    fs.chmodSync(filePath, STATE_FILE_MODE);
+  } finally {
+    if (created) {
+      try { fs.unlinkSync(tempPath); } catch {}
+    }
+  }
+}
+
+function readJson(filePath, fallback) {
+  const stat = assertNotSymlink(filePath, true);
+  if (!stat) return fallback;
+  assertPrivateFile(filePath);
+  const value = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  return value;
+}
+
+function exportKey(keyObject, type) {
+  return keyObject.export({ type, format: "der" }).toString("base64");
+}
+
+function importPublicKey(value) {
+  if (typeof value !== "string" || !value) throw new Error("remote public key is missing");
+  return crypto.createPublicKey({ key: Buffer.from(value, "base64"), type: "spki", format: "der" });
+}
+
+function importPrivateKey(value) {
+  if (typeof value !== "string" || !value) throw new Error("remote private key is missing");
+  return crypto.createPrivateKey({ key: Buffer.from(value, "base64"), type: "pkcs8", format: "der" });
+}
+
+function loadHostIdentity(stateDir = getStateDir()) {
+  const { hostIdentity } = statePaths(stateDir);
+  const value = readJson(hostIdentity, null);
+  if (!value || value.version !== 1 || typeof value.publicKey !== "string" || typeof value.privateKey !== "string") {
+    throw new Error("remote host identity is invalid");
+  }
+  const privateKey = importPrivateKey(value.privateKey);
+  const publicKey = importPublicKey(value.publicKey);
+  return { stateDir, path: hostIdentity, publicKey: value.publicKey, privateKey, publicKeyObject: publicKey };
+}
+
+function ensureHostIdentity(stateDir = getStateDir()) {
+  ensureStateDir(stateDir);
+  const { hostIdentity } = statePaths(stateDir);
+  const existing = readJson(hostIdentity, null);
+  if (existing) return loadHostIdentity(stateDir);
+  const pair = crypto.generateKeyPairSync("ed25519");
+  const value = { version: 1, publicKey: exportKey(pair.publicKey, "spki"), privateKey: exportKey(pair.privateKey, "pkcs8"), createdAt: new Date().toISOString() };
+  atomicWriteJson(hostIdentity, value);
+  return loadHostIdentity(stateDir);
+}
+
+function loadRegistry(stateDir = getStateDir()) {
+  ensureStateDir(stateDir);
+  const { registry } = statePaths(stateDir);
+  const value = readJson(registry, null);
+  if (!value) return { version: 1, clients: [] };
+  if (value.version !== 1 || !Array.isArray(value.clients)) throw new Error("remote client registry is invalid");
+  for (const client of value.clients) {
+    assertClientId(client.id);
+    assertSafeLabel(client.label);
+    importPublicKey(client.publicKey);
+  }
+  return value;
+}
+
+function saveRegistry(stateDir, registry) {
+  const { registry: registryPath } = statePaths(stateDir);
+  atomicWriteJson(registryPath, registry);
+}
+
+function authorizeClient(label, outputPath, stateDir = getStateDir()) {
+  assertSafeLabel(label);
+  if (typeof outputPath !== "string" || !outputPath) throw new Error("--output is required for remote authorize");
+  ensureStateDir(stateDir);
+  const host = ensureHostIdentity(stateDir);
+  const registry = loadRegistry(stateDir);
+  if (registry.clients.some((client) => client.label === label)) throw new Error(`remote client label already exists: ${label}`);
+  const output = path.resolve(outputPath);
+  assertNotSymlink(output, true);
+  if (fs.existsSync(output)) throw new Error(`credential output already exists: ${output}`);
+  const pair = crypto.generateKeyPairSync("ed25519");
+  const client = {
+    id: crypto.randomBytes(16).toString("hex"),
+    label,
+    publicKey: exportKey(pair.publicKey, "spki"),
+    createdAt: new Date().toISOString(),
+  };
+  const credential = {
+    version: 1,
+    clientId: client.id,
+    label,
+    privateKey: exportKey(pair.privateKey, "pkcs8"),
+    publicKey: client.publicKey,
+    hostPublicKey: host.publicKey,
+  };
+  registry.clients.push(client);
+  saveRegistry(stateDir, registry);
+  try {
+    atomicWriteJson(output, credential);
+  } catch (error) {
+    registry.clients = registry.clients.filter((entry) => entry.id !== client.id);
+    saveRegistry(stateDir, registry);
+    throw error;
+  }
+  return { ...client, output, hostPublicKey: host.publicKey };
+}
+
+function listClients(stateDir = getStateDir()) {
+  return loadRegistry(stateDir).clients.map(({ id, label, createdAt }) => ({ id, label, createdAt }));
+}
+
+function revokeClient(label, stateDir = getStateDir()) {
+  assertSafeLabel(label);
+  const registry = loadRegistry(stateDir);
+  const before = registry.clients.length;
+  registry.clients = registry.clients.filter((client) => client.label !== label);
+  if (registry.clients.length === before) throw new Error(`remote client not found: ${label}`);
+  saveRegistry(stateDir, registry);
+  return { label };
+}
+
+function loadCredential(credentialPath) {
+  if (typeof credentialPath !== "string" || !credentialPath) throw new Error("remote credential path is required");
+  const resolved = path.resolve(credentialPath);
+  assertPrivateFile(resolved);
+  const value = JSON.parse(fs.readFileSync(resolved, "utf8"));
+  if (value.version !== 1 || typeof value.clientId !== "string" || typeof value.label !== "string" || typeof value.publicKey !== "string" || typeof value.hostPublicKey !== "string") {
+    throw new Error("remote credential is invalid");
+  }
+  assertClientId(value.clientId);
+  assertSafeLabel(value.label);
+  const privateKey = importPrivateKey(value.privateKey);
+  const publicKey = importPublicKey(value.publicKey);
+  importPublicKey(value.hostPublicKey);
+  return { ...value, path: resolved, privateKey, publicKeyObject: publicKey };
+}
+
+function canonicalTranscript(role, clientId, clientNonce, serverNonce, clientPublicKey, hostPublicKey) {
+  assertClientId(clientId);
+  for (const [name, value] of [["clientNonce", clientNonce], ["serverNonce", serverNonce], ["clientPublicKey", clientPublicKey], ["hostPublicKey", hostPublicKey]]) {
+    if (typeof value !== "string" || !/^[A-Za-z0-9+/]+={0,2}$/.test(value)) throw new Error(`${name} is invalid`);
+  }
+  if (role !== "server" && role !== "client") throw new Error("authentication role is invalid");
+  return Buffer.from([AUTH_DOMAIN, String(PROTOCOL_VERSION), role, clientId, clientNonce, serverNonce, clientPublicKey, hostPublicKey].join("\0"), "utf8");
+}
+
+function verifySignature(publicKey, data, signature) {
+  return crypto.verify(null, data, publicKey, Buffer.from(signature, "base64"));
+}
+
+function signChallenge(host, clientId, clientNonce, serverNonce, clientPublicKey) {
+  const data = canonicalTranscript("server", clientId, clientNonce, serverNonce, clientPublicKey, host.publicKey);
+  return crypto.sign(null, data, host.privateKey).toString("base64");
+}
+
+function signProof(credential, clientNonce, serverNonce) {
+  const data = canonicalTranscript("client", credential.clientId, clientNonce, serverNonce, credential.publicKey, credential.hostPublicKey);
+  return crypto.sign(null, data, credential.privateKey).toString("base64");
+}
+
+function verifyChallenge(credential, challenge) {
+  if (challenge.version !== PROTOCOL_VERSION || challenge.clientId !== credential.clientId || challenge.hostPublicKey !== credential.hostPublicKey) return false;
+  const data = canonicalTranscript("server", credential.clientId, challenge.clientNonce, challenge.serverNonce, credential.publicKey, credential.hostPublicKey);
+  return verifySignature(importPublicKey(credential.hostPublicKey), data, challenge.signature);
+}
+
+function verifyProof(client, hostPublicKey, clientNonce, serverNonce, proof) {
+  const data = canonicalTranscript("client", client.id, clientNonce, serverNonce, client.publicKey, hostPublicKey);
+  return verifySignature(importPublicKey(client.publicKey), data, proof);
+}
+
+module.exports = {
+  AUTH_DOMAIN,
+  CLIENT_ID_PATTERN,
+  LABEL_PATTERN,
+  NONCE_BYTES,
+  PROTOCOL_VERSION,
+  STATE_DIR_MODE,
+  STATE_FILE_MODE,
+  authorizeClient,
+  canonicalTranscript,
+  ensureHostIdentity,
+  getStateDir,
+  listClients,
+  loadCredential,
+  loadHostIdentity,
+  loadRegistry,
+  revokeClient,
+  signChallenge,
+  signProof,
+  statePaths,
+  verifyChallenge,
+  verifyProof,
+  importPublicKey,
+};

--- a/native/remote-transport.cjs
+++ b/native/remote-transport.cjs
@@ -1,0 +1,337 @@
+const net = require("net");
+const crypto = require("crypto");
+const { loadCredential, loadHostIdentity, loadRegistry, NONCE_BYTES, PROTOCOL_VERSION, signProof, signChallenge, verifyChallenge, verifyProof } = require("./remote-auth.cjs");
+
+const MAX_FRAME_BYTES = 1024 * 1024;
+const DEFAULT_FRAME_TIMEOUT_MS = 10000;
+const DEFAULT_AUTH_TIMEOUT_MS = 5000;
+
+function writeFrame(socket, value) {
+  const encoded = Buffer.from(`${JSON.stringify(value)}\n`, "utf8");
+  if (encoded.length - 1 > MAX_FRAME_BYTES) return Promise.reject(new Error("frame exceeds byte limit"));
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let drainListener;
+    const cleanup = () => {
+      socket.removeListener("error", fail);
+      socket.removeListener("close", close);
+      if (drainListener) socket.removeListener("drain", drainListener);
+    };
+    const fail = (error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve();
+    };
+    const close = () => fail(new Error("socket closed while writing frame"));
+    socket.once("error", fail);
+    socket.once("close", close);
+    if (socket.write(encoded)) {
+      done();
+    } else {
+      drainListener = done;
+      socket.once("drain", drainListener);
+    }
+  });
+}
+
+function createSocketWriter(socket, { maxPendingBytes = 4 * 1024 * 1024, onOverflow = () => {} } = {}) {
+  const queue = [];
+  let pendingBytes = 0;
+  let writing = false;
+  let current;
+  let currentErrorListener;
+  let closed = false;
+  let drainListener;
+  const failQueue = (error) => {
+    while (queue.length) queue.shift().reject(error);
+    pendingBytes = 0;
+  };
+  const close = (error = new Error("socket writer closed")) => {
+    if (closed) return;
+    closed = true;
+    if (drainListener) socket.removeListener("drain", drainListener);
+    if (current) {
+      const item = current;
+      current = undefined;
+      writing = false;
+      if (currentErrorListener) socket.removeListener("error", currentErrorListener);
+      currentErrorListener = undefined;
+      item.reject(error);
+    }
+    failQueue(error);
+  };
+  const pump = () => {
+    if (writing || closed || queue.length === 0) return;
+    writing = true;
+    const item = queue.shift();
+    current = item;
+    const finish = (error) => {
+      if (!writing) return;
+      writing = false;
+      current = undefined;
+      pendingBytes -= item.bytes;
+      socket.removeListener("error", finish);
+      if (currentErrorListener === finish) currentErrorListener = undefined;
+      if (drainListener) {
+        socket.removeListener("drain", drainListener);
+        drainListener = undefined;
+      }
+      if (error) item.reject(error);
+      else item.resolve();
+      pump();
+    };
+    currentErrorListener = finish;
+    socket.once("error", finish);
+    try {
+      if (socket.write(item.encoded)) {
+        socket.removeListener("error", finish);
+        finish();
+      } else {
+        drainListener = () => {
+          drainListener = undefined;
+          socket.removeListener("error", finish);
+          finish();
+        };
+        socket.once("drain", drainListener);
+      }
+    } catch (error) {
+      socket.removeListener("error", finish);
+      finish(error);
+    }
+  };
+  const send = (value, { stream = false } = {}) => {
+    if (closed) return Promise.reject(new Error("socket writer is closed"));
+    const encoded = Buffer.from(`${JSON.stringify(value)}\n`, "utf8");
+    if (encoded.length - 1 > MAX_FRAME_BYTES) return Promise.reject(new Error("frame exceeds byte limit"));
+    if (pendingBytes + encoded.length > maxPendingBytes) {
+      const error = new Error("socket writer queue is full");
+      onOverflow({ stream, error });
+      return Promise.reject(error);
+    }
+    return new Promise((resolve, reject) => {
+      queue.push({ encoded, bytes: encoded.length, resolve, reject });
+      pendingBytes += encoded.length;
+      pump();
+    });
+  };
+  return { send, close, get pendingBytes() { return pendingBytes; } };
+}
+
+function createFrameParser({ onFrame, onError, maxFrameBytes = MAX_FRAME_BYTES, frameTimeoutMs = DEFAULT_FRAME_TIMEOUT_MS }) {
+  let buffer = Buffer.alloc(0);
+  let timer = null;
+  let closed = false;
+  const fail = (error) => {
+    if (closed) return;
+    closed = true;
+    if (timer) clearTimeout(timer);
+    onError(error);
+  };
+  const armDeadline = () => {
+    if (timer || buffer.length === 0) return;
+    timer = setTimeout(() => fail(new Error("incomplete frame timed out")), frameTimeoutMs);
+  };
+  const clearDeadline = () => {
+    if (buffer.length === 0 && timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+  return {
+    push(chunk) {
+      if (closed) return;
+      buffer = Buffer.concat([buffer, chunk]);
+      if (buffer.length > maxFrameBytes + 1 && buffer.indexOf(0x0a) === -1) {
+        fail(new Error("frame exceeds byte limit"));
+        return;
+      }
+      let newline;
+      while ((newline = buffer.indexOf(0x0a)) !== -1) {
+        const frame = buffer.subarray(0, newline);
+        buffer = buffer.subarray(newline + 1);
+        if (frame.length > maxFrameBytes) {
+          fail(new Error("frame exceeds byte limit"));
+          return;
+        }
+        if (frame.length === 0) continue;
+        let line;
+        try {
+          line = new TextDecoder("utf-8", { fatal: true }).decode(frame);
+        } catch {
+          fail(new Error("frame contains invalid UTF-8"));
+          return;
+        }
+        let value;
+        try {
+          value = JSON.parse(line);
+        } catch {
+          fail(new Error("frame contains invalid JSON"));
+          return;
+        }
+        onFrame(value);
+        if (closed) return;
+      }
+      if (buffer.length > maxFrameBytes) {
+        fail(new Error("frame exceeds byte limit"));
+        return;
+      }
+      clearDeadline();
+      armDeadline();
+    },
+    close() {
+      closed = true;
+      if (timer) clearTimeout(timer);
+      timer = null;
+      buffer = Buffer.alloc(0);
+    },
+  };
+}
+
+function waitForFrame(socket, timeoutMs = DEFAULT_AUTH_TIMEOUT_MS) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const parser = createFrameParser({
+      onFrame(value) {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve(value);
+      },
+      onError(error) {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(error);
+      },
+      frameTimeoutMs: timeoutMs,
+    });
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(new Error("authentication timed out"));
+    }, timeoutMs);
+    const onData = (chunk) => parser.push(chunk);
+    const onError = (error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const onClose = () => onError(new Error("connection closed during authentication"));
+    const cleanup = () => {
+      clearTimeout(timer);
+      parser.close();
+      socket.removeListener("data", onData);
+      socket.removeListener("error", onError);
+      socket.removeListener("close", onClose);
+    };
+    socket.on("data", onData);
+    socket.once("error", onError);
+    socket.once("close", onClose);
+  });
+}
+
+async function authenticateClient(socket, credentialPathOrValue, options = {}) {
+  const credential = typeof credentialPathOrValue === "string" ? loadCredential(credentialPathOrValue) : credentialPathOrValue;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_AUTH_TIMEOUT_MS;
+  const clientNonce = crypto.randomBytes(NONCE_BYTES).toString("base64");
+  await writeFrame(socket, { type: "auth_hello", version: PROTOCOL_VERSION, clientId: credential.clientId, clientNonce });
+  const challenge = await waitForFrame(socket, timeoutMs);
+  if (challenge.type === "auth_error") throw new Error(challenge.message || "remote authentication rejected");
+  if (challenge.type !== "auth_challenge") throw new Error("remote authentication protocol error");
+  if (!verifyChallenge(credential, challenge)) throw new Error("remote server identity verification failed");
+  const proof = signProof(credential, clientNonce, challenge.serverNonce);
+  await writeFrame(socket, { type: "auth_proof", version: PROTOCOL_VERSION, clientId: credential.clientId, proof });
+  const result = await waitForFrame(socket, timeoutMs);
+  if (result.type !== "auth_ok" || result.clientId !== credential.clientId) throw new Error(result.message || "remote authentication failed");
+  return { clientId: credential.clientId, label: credential.label };
+}
+
+function createServerAuthSession({ socket, stateDir, send = (value) => writeFrame(socket, value), timeoutMs = DEFAULT_AUTH_TIMEOUT_MS, onAuthenticated, onError }) {
+  let state = "pending";
+  let timer = setTimeout(() => fail(new Error("authentication timed out")), timeoutMs);
+  let clientNonce;
+  let serverNonce;
+  let client;
+  let host;
+  const fail = (error) => {
+    if (state === "authenticated" || state === "failed") return;
+    state = "failed";
+    clearTimeout(timer);
+    onError(error);
+  };
+  const handle = async (message) => {
+    if (state !== "pending") return false;
+    try {
+      if (message.type !== "auth_hello") throw new Error("authentication required before requests");
+      if (message.version !== PROTOCOL_VERSION || typeof message.clientNonce !== "string" || Buffer.from(message.clientNonce, "base64").length !== NONCE_BYTES) throw new Error("invalid authentication hello");
+      const registry = loadRegistry(stateDir);
+      client = registry.clients.find((entry) => entry.id === message.clientId);
+      if (!client) throw new Error("remote client is not authorized");
+      host = loadHostIdentity(stateDir);
+      clientNonce = message.clientNonce;
+      serverNonce = crypto.randomBytes(NONCE_BYTES).toString("base64");
+      const signature = signChallenge(host, client.id, clientNonce, serverNonce, client.publicKey);
+      await send({ type: "auth_challenge", version: PROTOCOL_VERSION, clientId: client.id, clientNonce, serverNonce, hostPublicKey: host.publicKey, signature });
+      state = "proof";
+      return true;
+    } catch (error) {
+      fail(error);
+      return false;
+    }
+  };
+  const handleProof = async (message) => {
+    if (state !== "proof") return false;
+    try {
+      if (message.type !== "auth_proof" || message.version !== PROTOCOL_VERSION || message.clientId !== client.id || typeof message.proof !== "string") throw new Error("invalid authentication proof");
+      if (!verifyProof(client, host.publicKey, clientNonce, serverNonce, message.proof)) throw new Error("remote client proof verification failed");
+      await onAuthenticated({ clientId: client.id, label: client.label });
+      state = "authenticated";
+      clearTimeout(timer);
+      await send({ type: "auth_ok", version: PROTOCOL_VERSION, clientId: client.id, label: client.label });
+      return true;
+    } catch (error) {
+      fail(error);
+      return false;
+    }
+  };
+  return {
+    get authenticated() { return state === "authenticated"; },
+    get failed() { return state === "failed"; },
+    get principal() { return state === "authenticated" ? { clientId: client.id, label: client.label } : null; },
+    handle(message) {
+      if (state === "pending") return handle(message);
+      if (state === "proof") return handleProof(message);
+      return Promise.resolve(false);
+    },
+    close() {
+      clearTimeout(timer);
+      if (state !== "authenticated") state = "failed";
+    },
+  };
+}
+
+function isClientAuthorized(stateDir, clientId) {
+  return loadRegistry(stateDir).clients.some((entry) => entry.id === clientId);
+}
+
+module.exports = {
+  DEFAULT_AUTH_TIMEOUT_MS,
+  DEFAULT_FRAME_TIMEOUT_MS,
+  MAX_FRAME_BYTES,
+  createSocketWriter,
+  authenticateClient,
+  createFrameParser,
+  createServerAuthSession,
+  isClientAuthorized,
+  waitForFrame,
+  writeFrame,
+};

--- a/native/request-pending.cjs
+++ b/native/request-pending.cjs
@@ -1,0 +1,148 @@
+const { abortError } = require("./abort.cjs");
+
+class RequestPendingMap extends Map {
+  constructor({ getRequest = () => undefined } = {}) {
+    super();
+    this.getRequest = getRequest;
+    this.drainWaiters = new Map();
+  }
+
+  set(id, data) {
+    const request = data.request || this.getRequest();
+    const cleanup = Boolean(data.cleanup || data.tool === "close_tab");
+    const entry = { ...data, id, request, cleanup, aborted: false, settled: false };
+    if (request) {
+      if (!request.pendingEntries) request.pendingEntries = new Set();
+      request.pendingEntries.add(entry);
+      if (cleanup) entry.abortCleanup = null;
+      else {
+        const onAbort = () => {
+          if (entry.abortNotified || entry.settled) return;
+          entry.abortNotified = true;
+          entry.aborted = true;
+          const error = abortError(request.signal);
+          if (entry.reject) entry.reject(error);
+          else entry.onAbort?.(error);
+          if (!entry.reject && !entry.onAbort) entry.onComplete?.({ error: error.message, cancelled: true });
+        };
+        entry.abortCleanup = () => request.signal.removeEventListener("abort", onAbort);
+        request.signal.addEventListener("abort", onAbort, { once: true });
+        if (request.signal.aborted) onAbort();
+      }
+    }
+    super.set(id, entry);
+    return this;
+  }
+
+  get(id) {
+    return super.get(id);
+  }
+
+  delete(id) {
+    const entry = super.get(id);
+    if (!entry) return false;
+    this.#removeEntry(entry);
+    return true;
+  }
+
+  #removeEntry(entry, notify = true) {
+    super.delete(entry.id);
+    entry.abortCleanup?.();
+    if (entry.tombstoneTimer) clearTimeout(entry.tombstoneTimer);
+    entry.request?.pendingEntries?.delete(entry);
+    if (notify) this.#notifyDrain(entry.request);
+  }
+
+  #notifyDrain(request) {
+    if (!request || request.pendingEntries?.size) return;
+    const waiters = this.drainWaiters.get(request);
+    if (!waiters) return;
+    this.drainWaiters.delete(request);
+    for (const waiter of waiters) waiter();
+  }
+
+  onDrain(request, callback) {
+    if (!request?.pendingEntries?.size) {
+      callback();
+      return;
+    }
+    const waiters = this.drainWaiters.get(request) || [];
+    waiters.push(callback);
+    this.drainWaiters.set(request, waiters);
+  }
+
+  resolve(id, value) {
+    const entry = this.get(id);
+    if (!entry) return false;
+    this.#removeEntry(entry, false);
+    try {
+      if (!entry.aborted && !entry.hardBoundary && !entry.settled) {
+        entry.settled = true;
+        if (entry.resolve) entry.resolve(value);
+        else if (entry.onComplete) entry.onComplete(value);
+      }
+    } finally {
+      this.#notifyDrain(entry.request);
+    }
+    return true;
+  }
+
+  expire(id, error) {
+    const entry = this.get(id);
+    if (!entry) return false;
+    if (!entry.settled) {
+      entry.settled = true;
+      entry.aborted = true;
+      entry.reject?.(error);
+      const request = entry.request;
+      const remaining = request ? Math.max(0, request.startedAt + request.deadlineMs - Date.now()) : 0;
+      entry.tombstoneTimer = setTimeout(() => this.delete(entry.id), remaining);
+    }
+    return true;
+  }
+
+  reject(id, error) {
+    const entry = this.get(id);
+    if (!entry) return false;
+    this.#removeEntry(entry, false);
+    try {
+      if (!entry.settled) {
+        entry.settled = true;
+        entry.reject?.(error);
+      }
+    } finally {
+      this.#notifyDrain(entry.request);
+    }
+    return true;
+  }
+
+  tombstoneAfterAbort(request) {
+    if (!request?.pendingEntries) return;
+    for (const entry of request.pendingEntries) {
+      if (entry.cleanup || entry.tombstoneTimer) continue;
+      const remaining = Math.max(0, request.startedAt + request.deadlineMs - Date.now());
+      entry.tombstoneTimer = setTimeout(() => this.delete(entry.id), remaining);
+    }
+  }
+
+  hardDeadline(request) {
+    if (!request) return;
+    request.hardBoundary = true;
+    for (const entry of [...(request.pendingEntries || [])]) {
+      entry.hardBoundary = true;
+      this.#removeEntry(entry);
+      if (!entry.settled) {
+        entry.settled = true;
+        entry.reject?.(abortError(request.signal, "Request timed out"));
+      }
+    }
+  }
+
+  clear() {
+    for (const entry of this.values()) this.#removeEntry(entry);
+    this.drainWaiters.clear();
+    super.clear();
+  }
+}
+
+module.exports = { RequestPendingMap };

--- a/native/socket-path.cjs
+++ b/native/socket-path.cjs
@@ -4,7 +4,7 @@ const os = require("os");
 const IS_WIN = process.platform === "win32";
 const DEFAULT_SOCKET_PATH = IS_WIN ? "//./pipe/surf" : "/tmp/surf.sock";
 const SOCKET_PATH = process.env.SURF_SOCKET || DEFAULT_SOCKET_PATH;
-const SURF_TMP = IS_WIN ? path.join(os.tmpdir(), "surf") : "/tmp";
+const SURF_TMP = process.env.SURF_TMP || (IS_WIN ? path.join(os.tmpdir(), "surf") : "/tmp");
 
 function getSocketTroubleshootingHint() {
   const lines = [

--- a/scripts/install-native-host.cjs
+++ b/scripts/install-native-host.cjs
@@ -4,6 +4,7 @@ const path = require("path");
 const os = require("os");
 const { execFileSync, execSync } = require("child_process");
 const { parseListenEndpoint } = require("../native/listener.cjs");
+const { getStateDir, loadHostIdentity, loadRegistry } = require("../native/remote-auth.cjs");
 
 const HOST_NAME = "surf.browser.host";
 
@@ -318,7 +319,8 @@ Options:
   --target        Install target: auto, linux, windows
                   On WSL2, auto installs for Windows Chrome. Use linux for WSLg/Linux browsers.
   --listen <tailscale-ip>:<port>
-                  Persist a Tailnet-only listener endpoint for the native host.
+                  Persist an authenticated Tailnet-only listener endpoint.
+                  Requires at least one surf remote authorize client first.
                   Supports Tailscale IPv4 or IPv6 addresses; POSIX wrappers only.
 
 Examples:
@@ -348,7 +350,16 @@ function main() {
     process.exit(1);
   }
   let listener;
-  try { listener = listen ? parseListenEndpoint(listen).display : undefined; } catch (error) { console.error(`Error: ${error.message}`); process.exit(1); }
+  try {
+    listener = listen ? parseListenEndpoint(listen).display : undefined;
+    if (listener) {
+      const stateDir = getStateDir();
+      loadHostIdentity(stateDir);
+      if (loadRegistry(stateDir).clients.length === 0) {
+        throw new Error("--listen requires at least one authorized remote client; run `surf remote authorize <label> --output <path>` first");
+      }
+    }
+  } catch (error) { console.error(`Error: ${error.message}`); process.exit(1); }
 
   if (!["auto", "linux", "windows"].includes(target)) {
     console.error("Error: Invalid --target value. Expected auto, linux, or windows");

--- a/scripts/install-native-host.cjs
+++ b/scripts/install-native-host.cjs
@@ -3,6 +3,7 @@ const fs = require("fs");
 const path = require("path");
 const os = require("os");
 const { execFileSync, execSync } = require("child_process");
+const { parseListenEndpoint } = require("../native/listener.cjs");
 
 const HOST_NAME = "surf.browser.host";
 
@@ -164,7 +165,7 @@ function wslPathToWindowsPath(wslPath) {
   }
 }
 
-function createWrapper(wrapperDir, nodePath, hostPath, target = process.platform) {
+function createWrapper(wrapperDir, nodePath, hostPath, target = process.platform, listen) {
   fs.mkdirSync(wrapperDir, { recursive: true });
 
   if (target === "wsl-windows") {
@@ -186,11 +187,17 @@ function createWrapper(wrapperDir, nodePath, hostPath, target = process.platform
   const hostDir = path.dirname(hostPath);
   const content = `#!/usr/bin/env bash
 cd "${hostDir}"
-exec "${nodePath}" "${hostPath}" "$@"
+${listen ? `: "\${SURF_LISTEN:=${listen}}"\nexport SURF_LISTEN\n` : ""}exec "${nodePath}" "${hostPath}" "$@"
 `;
   fs.writeFileSync(shPath, content);
   fs.chmodSync(shPath, "755");
   return shPath;
+}
+
+function assertListenTargetSupported(listen, target) {
+  if (listen && (target === "win32" || target === "wsl-windows")) {
+    throw new Error("--listen is not supported for Windows native-host wrappers");
+  }
 }
 
 function readExistingManifest(manifestPath) {
@@ -268,7 +275,7 @@ function installWindowsRegistry(browser, extensionId, wrapperPath) {
 
 function parseArgs() {
   const args = process.argv.slice(2);
-  const result = { extensionId: null, browsers: ["chrome"], target: "auto" };
+  const result = { extensionId: null, browsers: ["chrome"], target: "auto", listen: undefined };
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -281,6 +288,9 @@ function parseArgs() {
       }
     } else if (arg === "--target") {
       result.target = args[++i];
+    } else if (arg === "--listen") {
+      result.listen = args[++i];
+      if (!result.listen || result.listen.startsWith("--")) throw new Error("--listen requires a Tailnet IP and port");
     } else if (arg === "--help" || arg === "-h") {
       printHelp();
       process.exit(0);
@@ -307,17 +317,23 @@ Options:
                   Multiple: --browser chrome,brave
   --target        Install target: auto, linux, windows
                   On WSL2, auto installs for Windows Chrome. Use linux for WSLg/Linux browsers.
+  --listen <tailscale-ip>:<port>
+                  Persist a Tailnet-only listener endpoint for the native host.
+                  Supports Tailscale IPv4 or IPv6 addresses; POSIX wrappers only.
 
 Examples:
   node install-native-host.cjs abcdefghijklmnopabcdefghijklmnop
   node install-native-host.cjs abcdefghijklmnop --browser brave
   node install-native-host.cjs abcdefghijklmnop --browser all
   node install-native-host.cjs abcdefghijklmnop --target linux
+  node install-native-host.cjs abcdefghijklmnop --listen 100.64.1.2:4321
 `);
 }
 
 function main() {
-  const { extensionId, browsers, target } = parseArgs();
+  let parsed;
+  try { parsed = parseArgs(); } catch (error) { console.error(`Error: ${error.message}`); process.exit(1); }
+  const { extensionId, browsers, target, listen } = parsed;
 
   if (!extensionId) {
     console.error("Error: Extension ID required");
@@ -331,6 +347,8 @@ function main() {
     console.error("Expected 32 lowercase letters (a-p)");
     process.exit(1);
   }
+  let listener;
+  try { listener = listen ? parseListenEndpoint(listen).display : undefined; } catch (error) { console.error(`Error: ${error.message}`); process.exit(1); }
 
   if (!["auto", "linux", "windows"].includes(target)) {
     console.error("Error: Invalid --target value. Expected auto, linux, or windows");
@@ -349,6 +367,7 @@ function main() {
   }
 
   const effectiveTarget = runningInWsl && target !== "linux" ? "wsl-windows" : process.platform;
+  try { assertListenTargetSupported(listen, effectiveTarget); } catch (error) { console.error(`Error: ${error.message}`); process.exit(1); }
 
   const nodePath = findNode();
   if (!nodePath) {
@@ -377,7 +396,7 @@ function main() {
   console.log(`Wrapper dir: ${wrapperDir}`);
   console.log("");
 
-  const wrapperPath = createWrapper(wrapperDir, nodePath, hostPath, effectiveTarget);
+  const wrapperPath = createWrapper(wrapperDir, nodePath, hostPath, effectiveTarget, listener);
   console.log(`Created wrapper: ${wrapperPath}`);
   console.log("");
 
@@ -419,4 +438,5 @@ if (require.main === module) {
 module.exports = {
   createWrapper,
   writeManifest,
+  assertListenTargetSupported,
 };

--- a/skills/surf/SKILL.md
+++ b/skills/surf/SKILL.md
@@ -15,6 +15,28 @@ On macOS, Chrome reads the native messaging manifest at `~/Library/Application S
 
 If a command reports `Socket connect failed`, run `surf doctor` first, then check the `Attempted socket:` line. Default sockets are `/tmp/surf.sock` on macOS/Linux/WSL2 and `//./pipe/surf` on Windows. If `SURF_SOCKET` is set, the browser-launched host and the shell running `surf` must use the same value.
 
+## Remote Surf
+
+Remote clients require a per-client credential; Tailnet reachability alone is not authorization. On the POSIX browser host, authorize the client before installing the listener:
+
+```bash
+surf remote authorize agent-macbook --output ~/agent-macbook.surf-credential.json
+surf install <extension-id> --listen 100.101.102.103:4321
+surf remote list
+```
+
+Move the mode-0600 credential to the client through a secure channel. It grants full trusted Surf authority. Use it explicitly or through `SURF_REMOTE` and `SURF_REMOTE_CREDENTIAL`:
+
+```bash
+surf --remote 100.101.102.103:4321 \
+  --remote-credential ~/.config/surf/agent-macbook.json \
+  page.read
+
+surf remote revoke agent-macbook  # Run on the browser host
+```
+
+Remote paths are client-local by default. `local:./file` is explicit client-local syntax; only `remote:/absolute/path` accesses the browser host directly. Remote transfer supports one upload or ChatGPT/Gemini input and one screenshot, network-export, or Gemini image output. Limits are 256 MiB per file, 512 MiB and 32 files per connection, and 256 KiB decoded chunks. `record`, `aistudio.build`, smoke screenshot directories, directories, and multi-file inputs are not supported remotely. Successful action screenshots and failure `--auto-capture` diagnostics are transferred back to client-local paths.
+
 ## CLI Quick Reference
 
 ```bash

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -2323,6 +2323,20 @@ export async function handleMessage(
       };
     }
 
+    case "EXPORT_NETWORK_REQUESTS": {
+      if (!tabId) throw new Error("No tabId provided");
+      if (message.har && message.jsonl) throw new Error("network export cannot combine HAR and JSONL");
+      try {
+        await cdp.enableNetworkTracking(tabId);
+      } catch (e) {}
+      const entries = cdp.getNetworkEntries(tabId, {});
+      const serializedSize = new TextEncoder().encode(JSON.stringify(entries)).byteLength;
+      if (serializedSize > 16 * 1024 * 1024) {
+        throw new Error("network export source exceeds the 16 MiB native-message limit");
+      }
+      return { entries, har: Boolean(message.har), jsonl: Boolean(message.jsonl) };
+    }
+
     case "CLEAR_NETWORK_REQUESTS": {
       if (!tabId) throw new Error("No tabId provided");
       cdp.clearNetworkRequests(tabId);

--- a/test/integration/native-host-protocol.test.ts
+++ b/test/integration/native-host-protocol.test.ts
@@ -4,6 +4,7 @@ declare const Buffer: {
   alloc(size: number): BufferLike;
   byteLength(value: string): number;
   concat(values: BufferLike[]): BufferLike;
+  from(values: number[] | string): BufferLike;
 };
 declare const process: {
   cwd(): string;
@@ -17,7 +18,9 @@ declare const require: (moduleName: string) => unknown;
 type BufferLike = {
   length: number;
   readUInt32LE(offset: number): number;
+  indexOf(value: number): number;
   slice(start: number, end?: number): BufferLike;
+  subarray(start: number, end?: number): BufferLike;
   toString(encoding?: string): string;
   write(value: string, offset?: number): number;
   writeUInt32LE(value: number, offset: number): number;
@@ -61,9 +64,12 @@ const fs = require("node:fs") as {
   existsSync(targetPath: string): boolean;
   mkdtempSync(prefix: string): string;
   rmSync(targetPath: string, options: { recursive: boolean; force: boolean }): void;
+  writeFileSync(targetPath: string, content: string): void;
 };
 const os = require("node:os") as { tmpdir(): string };
 const path = require("node:path") as { join(...paths: string[]): string };
+const net = require("node:net") as any;
+const { createListenerLifecycle, MAX_CLIENT_FRAME_BYTES } = require("../../native/host.cjs") as any;
 
 const tempDirs: string[] = [];
 const children: ChildProcessLike[] = [];
@@ -180,12 +186,28 @@ type HostHarness = {
   ): Promise<NativeMessage>;
 };
 
-async function startHostHarness(): Promise<HostHarness> {
+async function startHostHarness(env: Record<string, string | undefined> = {}, tcpPort?: number): Promise<HostHarness> {
   const socketPath = createSocketPath();
   const hostPath = path.join(process.cwd(), "native", "host.cjs");
+  const preloadedListener = tcpPort === undefined ? undefined : (() => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "surf-host-listener-preload-"));
+    tempDirs.push(tempDir);
+    const preloadPath = path.join(tempDir, "listener-preload.cjs");
+    const listenerPath = path.join(process.cwd(), "native", "listener.cjs");
+    fs.writeFileSync(preloadPath, `const listener = require(${JSON.stringify(listenerPath)}); listener.parseListenEndpoint = () => ({ host: "127.0.0.1", port: ${tcpPort}, display: "127.0.0.1:${tcpPort}" });`);
+    return preloadPath;
+  })();
   const child = spawn(process.execPath, [hostPath], {
     cwd: process.cwd(),
-    env: { ...process.env, SURF_SOCKET: socketPath },
+    // Do not accidentally expose a developer's Tailnet listener to these
+    // local protocol tests. Callers must opt in explicitly.
+    env: {
+      ...process.env,
+      SURF_SOCKET: socketPath,
+      SURF_LISTEN: tcpPort === undefined ? undefined : `100.64.1.1:${tcpPort}`,
+      NODE_OPTIONS: preloadedListener ? `${process.env.NODE_OPTIONS || ""} --require ${preloadedListener}`.trim() : process.env.NODE_OPTIONS,
+      ...env,
+    },
     stdio: ["pipe", "pipe", "pipe"],
   });
   children.push(child);
@@ -282,6 +304,161 @@ afterEach(async () => {
 });
 
 describe("native host protocol integration", () => {
+  it("starts local and TCP listeners together, forwards both, and only then reports ready", async () => {
+    const localPath = createSocketPath();
+    const received: string[] = [];
+    let ready = false;
+    const lifecycle = createListenerLifecycle({
+      localPath,
+      tcpEndpoint: { host: "127.0.0.1", port: 0 },
+      handler(socket: any) {
+        socket.on("data", (data: any) => {
+          received.push(data.toString("utf8"));
+          socket.write('{"type":"tool_response","error":"Unknown method: unknown"}\n');
+        });
+      },
+      onReady() { ready = true; },
+      onFatal(error: Error) { throw error; },
+    });
+    expect(await lifecycle.start()).toBe(true);
+    expect(ready).toBe(true);
+    const tcpAddress = lifecycle.tcpServer.address();
+    expect(tcpAddress.port).toBeGreaterThan(0);
+
+    const request = '{"type":"tool_request","method":"unknown","id":"shared"}\n';
+    const requestReply = async (socket: any) => await new Promise<string>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error("Timed out waiting for listener reply")), 1000);
+      socket.once("data", (data: any) => { clearTimeout(timeout); resolve(data.toString("utf8")); });
+    });
+    const local = net.createConnection(localPath);
+    await new Promise<void>((resolve) => local.once("connect", resolve));
+    const localReply = requestReply(local); local.write(request);
+    expect(await localReply).toContain("Unknown method: unknown");
+    const tcp = net.createConnection({ host: "127.0.0.1", port: tcpAddress.port });
+    await new Promise<void>((resolve) => tcp.once("connect", resolve));
+    const tcpReply = requestReply(tcp); tcp.write(request);
+    expect(await tcpReply).toContain("Unknown method: unknown");
+    expect(received).toEqual([request, request]);
+    local.end(); tcp.end();
+    await lifecycle.shutdown();
+    expect(fs.existsSync(localPath)).toBe(false);
+  });
+
+  it("cleans up local listener when the TCP bind conflicts", async () => {
+    const localPath = createSocketPath();
+    const blocker = net.createServer();
+    await new Promise<void>((resolve) => blocker.listen({ host: "127.0.0.1", port: 0 }, resolve));
+    const address = blocker.address();
+    let ready = false;
+    let fatal: Error | undefined;
+    const lifecycle = createListenerLifecycle({
+      localPath, tcpEndpoint: { host: "127.0.0.1", port: address.port }, handler() {},
+      onReady() { ready = true; }, onFatal(error: Error) { fatal = error; },
+    });
+    expect(await lifecycle.start()).toBe(false);
+    expect(ready).toBe(false);
+    expect(fatal).toBeInstanceOf(Error);
+    expect(fs.existsSync(localPath)).toBe(false);
+    await new Promise<void>((resolve) => blocker.close(resolve));
+  });
+
+  it("closes both listeners and unlinks local socket during shutdown", async () => {
+    const localPath = createSocketPath();
+    const lifecycle = createListenerLifecycle({
+      localPath, tcpEndpoint: { host: "127.0.0.1", port: 0 }, handler() {}, onReady() {}, onFatal(error: Error) { throw error; },
+    });
+    await lifecycle.start();
+    const address = lifecycle.tcpServer.address();
+    await lifecycle.shutdown();
+    expect(fs.existsSync(localPath)).toBe(false);
+    await new Promise<void>((resolve) => {
+      const socket = net.createConnection({ host: "127.0.0.1", port: address.port });
+      socket.once("error", () => resolve());
+    });
+  });
+
+  it("uses the production TCP handler for a UTF-8 code point split across writes", async () => {
+    const reservation = net.createServer();
+    await new Promise<void>((resolve) => reservation.listen({ host: "127.0.0.1", port: 0 }, resolve));
+    const tcpPort = reservation.address().port;
+    await new Promise<void>((resolve) => reservation.close(resolve));
+    const host = await startHostHarness({}, tcpPort);
+    const socket = net.createConnection({ host: "127.0.0.1", port: tcpPort });
+    await new Promise<void>((resolve) => socket.once("connect", resolve));
+    const response = new Promise<string>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error("Timed out waiting for production TCP response")), 1000);
+      socket.once("data", (chunk: any) => { clearTimeout(timeout); resolve(chunk.toString("utf8")); });
+    });
+    const beforeCheckmark = '{"type":"tool_request","method":"unknown","id":"';
+    const frame = Buffer.from(`${beforeCheckmark}✓"}\n`);
+    const checkmarkByteIndex = Buffer.byteLength(beforeCheckmark);
+    // ✓ is three UTF-8 bytes; write its first byte separately from the rest.
+    socket.write(frame.slice(0, checkmarkByteIndex + 1));
+    socket.write(frame.slice(checkmarkByteIndex + 1));
+    expect(await response).toContain("Unknown method: unknown");
+    socket.end();
+  });
+  it("handles fragmented and multiple local frames, while rejecting malformed UTF-8 and oversized frames", async () => {
+    const host = await startHostHarness();
+    const socket = net.createConnection(host.socketPath);
+    await new Promise<void>((resolve) => socket.once("connect", resolve));
+
+    const readResponse = (client: any) => new Promise<string>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error("Timed out waiting for socket response")), 1000);
+      client.once("data", (chunk: any) => {
+        clearTimeout(timeout);
+        resolve(chunk.toString("utf8"));
+      });
+    });
+
+    // One request split across writes, followed by a second complete frame.
+    const firstResponse = readResponse(socket);
+    socket.write('{"type":"tool_request","method":"unknown","id":"first"');
+    socket.write("}\n");
+    expect(await firstResponse).toContain("Unknown method: unknown");
+    const secondResponse = readResponse(socket);
+    socket.write('{"type":"tool_request","method":"unknown","id":"second"}\n');
+    expect(await secondResponse).toContain("Unknown method: unknown");
+
+    const rejectedResponse = readResponse(socket);
+    socket.write('{"type":"GET_AUTH","id":"auth"}\n');
+    expect(await rejectedResponse).toContain("Unsupported request type: GET_AUTH");
+
+    const rejectedStream = readResponse(socket);
+    socket.write('{"type":"stream_request","streamType":"ARBITRARY_EXTENSION_MESSAGE","id":"stream"}\n');
+    expect(await rejectedStream).toContain("Unsupported stream type: ARBITRARY_EXTENSION_MESSAGE");
+
+    const unicodeResponse = readResponse(socket);
+    const unicodeFrame = Buffer.from('{"type":"tool_request","method":"unknown","id":"✓"}\n');
+    // Deliberately split inside the three-byte UTF-8 encoding of ✓.
+    socket.write(unicodeFrame.slice(0, unicodeFrame.length - 3));
+    socket.write(unicodeFrame.slice(unicodeFrame.length - 3));
+    expect(await unicodeResponse).toContain("Unknown method: unknown");
+
+    const malformed = net.createConnection(host.socketPath);
+    await new Promise<void>((resolve) => malformed.once("connect", resolve));
+    const malformedClosed = new Promise<void>((resolve) => malformed.once("close", resolve));
+    malformed.write(Buffer.from([0xc3, 0x0a])); // incomplete UTF-8 before frame delimiter
+    await malformedClosed;
+
+    const exact = net.createConnection(host.socketPath);
+    await new Promise<void>((resolve) => exact.once("connect", resolve));
+    const exactResponse = readResponse(exact);
+    const prefix = '{"type":"tool_request","method":"unknown","id":"exact","padding":"';
+    const frame = `${prefix}${"x".repeat(1024 * 1024 - Buffer.byteLength(prefix) - 2)}"}`;
+    expect(Buffer.byteLength(frame)).toBe(1024 * 1024);
+    exact.write(`${frame}\n`);
+    expect(await exactResponse).toContain("Unknown method: unknown");
+    exact.end();
+
+    const oversized = net.createConnection(host.socketPath);
+    await new Promise<void>((resolve) => oversized.once("connect", resolve));
+    const oversizedClosed = new Promise<void>((resolve) => oversized.once("close", resolve));
+    oversized.write(`${"x".repeat(1024 * 1024 + 1)}\n`);
+    await oversizedClosed;
+    socket.end();
+  });
+
   it("forwards a real CLI request to the extension and returns the extension response", async () => {
     const host = await startHostHarness();
     const cliPromise = runCli(["tab.list"], host.socketPath);

--- a/test/integration/native-host-protocol.test.ts
+++ b/test/integration/native-host-protocol.test.ts
@@ -1,4 +1,7 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: runtime CJS doubles are intentionally untyped.
 import { afterEach, describe, expect, it } from "vitest";
+
+// Native protocol CJS doubles intentionally use runtime-shaped values because this project does not include Node typings.
 
 declare const Buffer: {
   alloc(size: number): BufferLike;
@@ -64,12 +67,19 @@ const fs = require("node:fs") as {
   existsSync(targetPath: string): boolean;
   mkdtempSync(prefix: string): string;
   rmSync(targetPath: string, options: { recursive: boolean; force: boolean }): void;
+  readdirSync(targetPath: string): string[];
   writeFileSync(targetPath: string, content: string): void;
+  readFileSync(targetPath: string, encoding: string): string;
 };
 const os = require("node:os") as { tmpdir(): string };
 const path = require("node:path") as { join(...paths: string[]): string };
 const net = require("node:net") as any;
-const { createListenerLifecycle, MAX_CLIENT_FRAME_BYTES } = require("../../native/host.cjs") as any;
+const { createListenerLifecycle } = require("../../native/host.cjs") as any;
+const remoteAuth = require("../../native/remote-auth.cjs") as any;
+const remoteTransport = require("../../native/remote-transport.cjs") as any;
+const { openClientTransport } = require("../../native/client-transport.cjs") as any;
+const fileTransfer = require("../../native/file-transfer.cjs") as any;
+const crypto = require("node:crypto") as any;
 
 const tempDirs: string[] = [];
 const children: ChildProcessLike[] = [];
@@ -179,24 +189,50 @@ type HostHarness = {
   child: ChildProcessLike;
   send(message: NativeMessage): void;
   socketPath: string;
+  remoteCredentialPath?: string;
+  remoteStateDir?: string;
   stderr(): string;
   waitForMessage(
     predicate: (message: NativeMessage) => boolean,
     label: string,
   ): Promise<NativeMessage>;
+  expectNoMessage(
+    predicate: (message: NativeMessage) => boolean,
+    label: string,
+    timeoutMs?: number,
+  ): Promise<void>;
 };
 
-async function startHostHarness(env: Record<string, string | undefined> = {}, tcpPort?: number): Promise<HostHarness> {
+async function startHostHarness(
+  env: Record<string, string | undefined> = {},
+  tcpPort?: number,
+): Promise<HostHarness> {
   const socketPath = createSocketPath();
+  const remoteStateDir =
+    tcpPort === undefined
+      ? undefined
+      : fs.mkdtempSync(path.join(os.tmpdir(), "surf-host-remote-state-"));
+  const remoteCredentialPath =
+    remoteStateDir === undefined ? undefined : path.join(remoteStateDir, "client.json");
+  if (remoteStateDir && remoteCredentialPath) {
+    tempDirs.push(remoteStateDir);
+    remoteAuth.authorizeClient("integration-client", remoteCredentialPath, remoteStateDir);
+  }
   const hostPath = path.join(process.cwd(), "native", "host.cjs");
-  const preloadedListener = tcpPort === undefined ? undefined : (() => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "surf-host-listener-preload-"));
-    tempDirs.push(tempDir);
-    const preloadPath = path.join(tempDir, "listener-preload.cjs");
-    const listenerPath = path.join(process.cwd(), "native", "listener.cjs");
-    fs.writeFileSync(preloadPath, `const listener = require(${JSON.stringify(listenerPath)}); listener.parseListenEndpoint = () => ({ host: "127.0.0.1", port: ${tcpPort}, display: "127.0.0.1:${tcpPort}" });`);
-    return preloadPath;
-  })();
+  const preloadedListener =
+    tcpPort === undefined
+      ? undefined
+      : (() => {
+          const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "surf-host-listener-preload-"));
+          tempDirs.push(tempDir);
+          const preloadPath = path.join(tempDir, "listener-preload.cjs");
+          const listenerPath = path.join(process.cwd(), "native", "listener.cjs");
+          fs.writeFileSync(
+            preloadPath,
+            `const listener = require(${JSON.stringify(listenerPath)}); listener.parseListenEndpoint = () => ({ host: "127.0.0.1", port: ${tcpPort}, display: "127.0.0.1:${tcpPort}" });`,
+          );
+          return preloadPath;
+        })();
   const child = spawn(process.execPath, [hostPath], {
     cwd: process.cwd(),
     // Do not accidentally expose a developer's Tailnet listener to these
@@ -205,7 +241,10 @@ async function startHostHarness(env: Record<string, string | undefined> = {}, tc
       ...process.env,
       SURF_SOCKET: socketPath,
       SURF_LISTEN: tcpPort === undefined ? undefined : `100.64.1.1:${tcpPort}`,
-      NODE_OPTIONS: preloadedListener ? `${process.env.NODE_OPTIONS || ""} --require ${preloadedListener}`.trim() : process.env.NODE_OPTIONS,
+      SURF_REMOTE_STATE_DIR: remoteStateDir,
+      NODE_OPTIONS: preloadedListener
+        ? `${process.env.NODE_OPTIONS || ""} --require ${preloadedListener}`.trim()
+        : process.env.NODE_OPTIONS,
       ...env,
     },
     stdio: ["pipe", "pipe", "pipe"],
@@ -268,6 +307,19 @@ async function startHostHarness(env: Record<string, string | undefined> = {}, tc
     });
   };
 
+  const expectNoMessage = async (
+    predicate: (message: NativeMessage) => boolean,
+    label: string,
+    timeoutMs = 50,
+  ): Promise<void> => {
+    await new Promise((resolve) => setTimeout(resolve, timeoutMs));
+    const unexpectedIndex = messages.findIndex(predicate);
+    if (unexpectedIndex !== -1) {
+      const unexpected = messages.splice(unexpectedIndex, 1)[0];
+      throw new Error(`Unexpected native host message for ${label}: ${JSON.stringify(unexpected)}`);
+    }
+  };
+
   child.on("error", (error) => {
     throw error instanceof Error ? error : new Error(String(error));
   });
@@ -282,6 +334,8 @@ async function startHostHarness(env: Record<string, string | undefined> = {}, tc
 
   return {
     child,
+    remoteCredentialPath,
+    remoteStateDir,
     send(message) {
       child.stdin.write(encodeNativeMessage(message));
     },
@@ -290,6 +344,7 @@ async function startHostHarness(env: Record<string, string | undefined> = {}, tc
       return stderr;
     },
     waitForMessage,
+    expectNoMessage,
   };
 }
 
@@ -317,8 +372,12 @@ describe("native host protocol integration", () => {
           socket.write('{"type":"tool_response","error":"Unknown method: unknown"}\n');
         });
       },
-      onReady() { ready = true; },
-      onFatal(error: Error) { throw error; },
+      onReady() {
+        ready = true;
+      },
+      onFatal(error: Error) {
+        throw error;
+      },
     });
     expect(await lifecycle.start()).toBe(true);
     expect(ready).toBe(true);
@@ -326,20 +385,30 @@ describe("native host protocol integration", () => {
     expect(tcpAddress.port).toBeGreaterThan(0);
 
     const request = '{"type":"tool_request","method":"unknown","id":"shared"}\n';
-    const requestReply = async (socket: any) => await new Promise<string>((resolve, reject) => {
-      const timeout = setTimeout(() => reject(new Error("Timed out waiting for listener reply")), 1000);
-      socket.once("data", (data: any) => { clearTimeout(timeout); resolve(data.toString("utf8")); });
-    });
+    const requestReply = async (socket: any) =>
+      await new Promise<string>((resolve, reject) => {
+        const timeout = setTimeout(
+          () => reject(new Error("Timed out waiting for listener reply")),
+          1000,
+        );
+        socket.once("data", (data: any) => {
+          clearTimeout(timeout);
+          resolve(data.toString("utf8"));
+        });
+      });
     const local = net.createConnection(localPath);
     await new Promise<void>((resolve) => local.once("connect", resolve));
-    const localReply = requestReply(local); local.write(request);
+    const localReply = requestReply(local);
+    local.write(request);
     expect(await localReply).toContain("Unknown method: unknown");
     const tcp = net.createConnection({ host: "127.0.0.1", port: tcpAddress.port });
     await new Promise<void>((resolve) => tcp.once("connect", resolve));
-    const tcpReply = requestReply(tcp); tcp.write(request);
+    const tcpReply = requestReply(tcp);
+    tcp.write(request);
     expect(await tcpReply).toContain("Unknown method: unknown");
     expect(received).toEqual([request, request]);
-    local.end(); tcp.end();
+    local.end();
+    tcp.end();
     await lifecycle.shutdown();
     expect(fs.existsSync(localPath)).toBe(false);
   });
@@ -352,8 +421,17 @@ describe("native host protocol integration", () => {
     let ready = false;
     let fatal: Error | undefined;
     const lifecycle = createListenerLifecycle({
-      localPath, tcpEndpoint: { host: "127.0.0.1", port: address.port }, handler() {},
-      onReady() { ready = true; }, onFatal(error: Error) { fatal = error; },
+      localPath,
+      tcpEndpoint: { host: "127.0.0.1", port: address.port },
+      handler() {
+        return undefined;
+      },
+      onReady() {
+        ready = true;
+      },
+      onFatal(error: Error) {
+        fatal = error;
+      },
     });
     expect(await lifecycle.start()).toBe(false);
     expect(ready).toBe(false);
@@ -365,7 +443,17 @@ describe("native host protocol integration", () => {
   it("closes both listeners and unlinks local socket during shutdown", async () => {
     const localPath = createSocketPath();
     const lifecycle = createListenerLifecycle({
-      localPath, tcpEndpoint: { host: "127.0.0.1", port: 0 }, handler() {}, onReady() {}, onFatal(error: Error) { throw error; },
+      localPath,
+      tcpEndpoint: { host: "127.0.0.1", port: 0 },
+      handler() {
+        return undefined;
+      },
+      onReady() {
+        return undefined;
+      },
+      onFatal(error: Error) {
+        throw error;
+      },
     });
     await lifecycle.start();
     const address = lifecycle.tcpServer.address();
@@ -379,15 +467,24 @@ describe("native host protocol integration", () => {
 
   it("uses the production TCP handler for a UTF-8 code point split across writes", async () => {
     const reservation = net.createServer();
-    await new Promise<void>((resolve) => reservation.listen({ host: "127.0.0.1", port: 0 }, resolve));
+    await new Promise<void>((resolve) =>
+      reservation.listen({ host: "127.0.0.1", port: 0 }, resolve),
+    );
     const tcpPort = reservation.address().port;
     await new Promise<void>((resolve) => reservation.close(resolve));
     const host = await startHostHarness({}, tcpPort);
     const socket = net.createConnection({ host: "127.0.0.1", port: tcpPort });
     await new Promise<void>((resolve) => socket.once("connect", resolve));
+    await remoteTransport.authenticateClient(socket, host.remoteCredentialPath);
     const response = new Promise<string>((resolve, reject) => {
-      const timeout = setTimeout(() => reject(new Error("Timed out waiting for production TCP response")), 1000);
-      socket.once("data", (chunk: any) => { clearTimeout(timeout); resolve(chunk.toString("utf8")); });
+      const timeout = setTimeout(
+        () => reject(new Error("Timed out waiting for production TCP response")),
+        1000,
+      );
+      socket.once("data", (chunk: any) => {
+        clearTimeout(timeout);
+        resolve(chunk.toString("utf8"));
+      });
     });
     const beforeCheckmark = '{"type":"tool_request","method":"unknown","id":"';
     const frame = Buffer.from(`${beforeCheckmark}✓"}\n`);
@@ -403,13 +500,17 @@ describe("native host protocol integration", () => {
     const socket = net.createConnection(host.socketPath);
     await new Promise<void>((resolve) => socket.once("connect", resolve));
 
-    const readResponse = (client: any) => new Promise<string>((resolve, reject) => {
-      const timeout = setTimeout(() => reject(new Error("Timed out waiting for socket response")), 1000);
-      client.once("data", (chunk: any) => {
-        clearTimeout(timeout);
-        resolve(chunk.toString("utf8"));
+    const readResponse = (client: any) =>
+      new Promise<string>((resolve, reject) => {
+        const timeout = setTimeout(
+          () => reject(new Error("Timed out waiting for socket response")),
+          1000,
+        );
+        client.once("data", (chunk: any) => {
+          clearTimeout(timeout);
+          resolve(chunk.toString("utf8"));
+        });
       });
-    });
 
     // One request split across writes, followed by a second complete frame.
     const firstResponse = readResponse(socket);
@@ -425,7 +526,9 @@ describe("native host protocol integration", () => {
     expect(await rejectedResponse).toContain("Unsupported request type: GET_AUTH");
 
     const rejectedStream = readResponse(socket);
-    socket.write('{"type":"stream_request","streamType":"ARBITRARY_EXTENSION_MESSAGE","id":"stream"}\n');
+    socket.write(
+      '{"type":"stream_request","streamType":"ARBITRARY_EXTENSION_MESSAGE","id":"stream"}\n',
+    );
     expect(await rejectedStream).toContain("Unsupported stream type: ARBITRARY_EXTENSION_MESSAGE");
 
     const unicodeResponse = readResponse(socket);
@@ -434,6 +537,7 @@ describe("native host protocol integration", () => {
     socket.write(unicodeFrame.slice(0, unicodeFrame.length - 3));
     socket.write(unicodeFrame.slice(unicodeFrame.length - 3));
     expect(await unicodeResponse).toContain("Unknown method: unknown");
+    socket.end();
 
     const malformed = net.createConnection(host.socketPath);
     await new Promise<void>((resolve) => malformed.once("connect", resolve));
@@ -456,7 +560,6 @@ describe("native host protocol integration", () => {
     const oversizedClosed = new Promise<void>((resolve) => oversized.once("close", resolve));
     oversized.write(`${"x".repeat(1024 * 1024 + 1)}\n`);
     await oversizedClosed;
-    socket.end();
   });
 
   it("forwards a real CLI request to the extension and returns the extension response", async () => {
@@ -480,6 +583,1107 @@ describe("native host protocol integration", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("123\tExample\thttps://example.test/\n");
     expect(host.stderr()).toBe("");
+  });
+
+  it("stages authenticated remote uploads before fake extension dispatch", async () => {
+    const reservation = net.createServer();
+    await new Promise<void>((resolve) => reservation.listen(0, "127.0.0.1", resolve));
+    const tcpPort = reservation.address().port;
+    await new Promise<void>((resolve) => reservation.close(resolve));
+    const host = await startHostHarness({}, tcpPort);
+    const socket = net.createConnection({ host: "127.0.0.1", port: tcpPort });
+    await new Promise<void>((resolve) => socket.once("connect", resolve));
+    await remoteTransport.authenticateClient(socket, host.remoteCredentialPath);
+    const _buffer = Buffer.alloc(0);
+    const messages: NativeMessage[] = [];
+    const waiters: Array<{
+      predicate: (message: NativeMessage) => boolean;
+      resolve: (message: NativeMessage) => void;
+    }> = [];
+    const publish = (message: NativeMessage) => {
+      const index = waiters.findIndex((waiter) => waiter.predicate(message));
+      if (index === -1) {
+        messages.push(message);
+      } else {
+        waiters.splice(index, 1)[0].resolve(message);
+      }
+    };
+    const parser = remoteTransport.createFrameParser({
+      onFrame: publish,
+      onError: () => undefined,
+    });
+    socket.on("data", (chunk: any) => parser.push(chunk));
+    const waitRemote = async (predicate: (message: NativeMessage) => boolean) => {
+      const queued = messages.findIndex(predicate);
+      if (queued !== -1) {
+        return Promise.resolve(messages.splice(queued, 1)[0]);
+      }
+      return new Promise<NativeMessage>((resolve) => waiters.push({ predicate, resolve }));
+    };
+    const data = Buffer.from("abc");
+    const transferId = "upload-integration";
+    const sha256 = crypto.createHash("sha256").update(data).digest("hex");
+    remoteTransport.writeFrame(socket, {
+      type: "transfer_begin",
+      version: 1,
+      direction: "upload",
+      transferId,
+      size: data.length,
+      sha256,
+    });
+    await waitRemote((message) => message.type === "transfer_ready");
+    remoteTransport.writeFrame(socket, {
+      type: "transfer_chunk",
+      version: 1,
+      transferId,
+      sequence: 0,
+      data: data.toString("base64"),
+    });
+    remoteTransport.writeFrame(socket, { type: "transfer_end", version: 1, transferId });
+    const transferComplete = await waitRemote((message) => message.type === "transfer_complete");
+    expect(transferComplete.path).toBeUndefined();
+    remoteTransport.writeFrame(socket, {
+      type: "tool_request",
+      method: "execute_tool",
+      params: { tool: "upload", args: { ref: "e5", files: ["client.txt"] } },
+      _surfPaths: [
+        {
+          field: "files",
+          kind: "input",
+          original: "client.txt",
+          path: "client.txt",
+          pathKind: "local",
+        },
+      ],
+      _surfTransfers: {
+        uploads: [{ transferId, field: "files", original: "client.txt", kind: "upload" }],
+        downloads: [],
+      },
+      id: "upload-integration-request",
+    });
+    const extensionRequest = await host.waitForMessage(
+      (message) => message.type === "UPLOAD_FILE",
+      "remote UPLOAD_FILE",
+    );
+    const extensionFiles = extensionRequest.files as string[];
+    expect(extensionFiles).toHaveLength(1);
+    expect(extensionFiles[0]).not.toBe("client.txt");
+    expect(extensionFiles[0]).toMatch(host.remoteCredentialPath ? /[A-Za-z0-9]/ : /never/);
+    const stagedPath = extensionFiles[0];
+    host.send({
+      id: extensionRequest.id,
+      success: true,
+      path: stagedPath,
+      message: `stored ${stagedPath}`,
+      nested: [stagedPath],
+    });
+    const response = await waitRemote((message) => message.id === "upload-integration-request");
+    expect(response.error).toBeUndefined();
+    const responseText = JSON.stringify(response);
+    expect(responseText).toContain("client.txt");
+    expect(responseText).not.toContain("surf-transfer-");
+    expect(responseText).not.toContain(stagedPath);
+    socket.destroy();
+  });
+
+  it("dispatches direct remote upload and screenshot paths without staging", async () => {
+    const reservation = net.createServer();
+    await new Promise<void>((resolve) => reservation.listen(0, "127.0.0.1", resolve));
+    const tcpPort = reservation.address().port;
+    await new Promise<void>((resolve) => reservation.close(resolve));
+    const transferRoot = fs.mkdtempSync(path.join(os.tmpdir(), "surf-direct-transfer-root-"));
+    tempDirs.push(transferRoot);
+    const host = await startHostHarness({ SURF_TMP: transferRoot }, tcpPort);
+    expect(
+      fs.readdirSync(transferRoot).filter((entry) => entry.startsWith("surf-transfer-")).length,
+    ).toBe(0);
+    const directFile = path.join(os.tmpdir(), `surf-direct-${process.pid}-${Date.now()}.txt`);
+    const directShot = path.join(os.tmpdir(), `surf-direct-shot-${process.pid}-${Date.now()}.png`);
+    fs.writeFileSync(directFile, "direct");
+    const transport = await openClientTransport({
+      kind: "remote",
+      connectionOptions: { host: "127.0.0.1", port: tcpPort },
+      credentialPath: host.remoteCredentialPath,
+    });
+    try {
+      const uploadResponse = transport.request(
+        {
+          type: "tool_request",
+          method: "execute_tool",
+          params: { tool: "upload", args: { ref: "e5", files: [`remote:${directFile}`] } },
+          id: "direct-upload",
+        },
+        30000,
+        {
+          pathRefs: [
+            {
+              field: "files",
+              kind: "input",
+              original: `remote:${directFile}`,
+              path: directFile,
+              pathKind: "remote",
+            },
+          ],
+          uploads: [],
+          downloads: [],
+        },
+      );
+      const uploadMessage = await host.waitForMessage(
+        (message) => message.type === "UPLOAD_FILE",
+        "direct upload",
+      );
+      expect(uploadMessage.files).toEqual([directFile]);
+      host.send({ id: uploadMessage.id, success: true });
+      expect((await uploadResponse).error).toBeUndefined();
+      expect(
+        fs.readdirSync(transferRoot).filter((entry) => entry.startsWith("surf-transfer-")).length,
+      ).toBe(0);
+
+      const screenshotResponse = transport.request(
+        {
+          type: "tool_request",
+          method: "execute_tool",
+          params: { tool: "screenshot", args: { savePath: `remote:${directShot}` } },
+          id: "direct-screenshot",
+        },
+        30000,
+        {
+          pathRefs: [
+            {
+              field: "savePath",
+              kind: "output",
+              original: `remote:${directShot}`,
+              path: directShot,
+              pathKind: "remote",
+            },
+          ],
+          uploads: [],
+          downloads: [],
+        },
+      );
+      const screenshotMessage = await host.waitForMessage(
+        (message) => message.type === "EXECUTE_SCREENSHOT",
+        "direct screenshot",
+      );
+      expect(screenshotMessage.savePath).toBe(directShot);
+      host.send({
+        id: screenshotMessage.id,
+        base64: Buffer.from("direct-shot").toString("base64"),
+        width: 1,
+        height: 1,
+      });
+      const screenshotResult = await screenshotResponse;
+      expect(screenshotResult.error).toBeUndefined();
+      expect(fs.readFileSync(directShot, "utf8")).toBe("direct-shot");
+      expect(screenshotResult.result.content[0].text).toContain(`remote:${directShot}`);
+      expect(screenshotResult.result.content[0].text).not.toContain("surf-transfer-");
+      expect(
+        fs.readdirSync(transferRoot).filter((entry) => entry.startsWith("surf-transfer-")).length,
+      ).toBe(0);
+    } finally {
+      await transport.close();
+      expect(
+        fs.readdirSync(transferRoot).filter((entry) => entry.startsWith("surf-transfer-")).length,
+      ).toBe(0);
+      fs.rmSync(directFile, { recursive: false, force: true });
+      fs.rmSync(directShot, { recursive: false, force: true });
+    }
+  });
+
+  it("downloads remote screenshots atomically and hides host staging paths", async () => {
+    const reservation = net.createServer();
+    await new Promise<void>((resolve) => reservation.listen(0, "127.0.0.1", resolve));
+    const tcpPort = reservation.address().port;
+    await new Promise<void>((resolve) => reservation.close(resolve));
+    const host = await startHostHarness({}, tcpPort);
+    const destination = path.join(os.tmpdir(), `surf-remote-shot-${process.pid}-${Date.now()}.png`);
+    const errorDestination = path.join(
+      os.tmpdir(),
+      `surf-remote-shot-error-${process.pid}-${Date.now()}.png`,
+    );
+    const endpoint = {
+      kind: "remote",
+      connectionOptions: { host: "127.0.0.1", port: tcpPort },
+      credentialPath: host.remoteCredentialPath,
+    };
+    const transport = await openClientTransport(endpoint);
+    try {
+      const responsePromise = transport.request(
+        {
+          type: "tool_request",
+          method: "execute_tool",
+          params: { tool: "screenshot", args: { savePath: destination } },
+          id: "screenshot-download",
+        },
+        30000,
+        {
+          pathRefs: [
+            {
+              field: "savePath",
+              kind: "output",
+              original: destination,
+              path: destination,
+              pathKind: "local",
+            },
+          ],
+          downloads: [
+            {
+              transferId: "screenshot-download-file",
+              field: "savePath",
+              original: destination,
+              destination,
+            },
+          ],
+          uploads: [],
+        },
+      );
+      const extensionRequest = await host.waitForMessage(
+        (message) => message.type === "EXECUTE_SCREENSHOT",
+        "remote screenshot",
+      );
+      host.send({
+        id: extensionRequest.id,
+        base64: Buffer.from("fake-png").toString("base64"),
+        width: 10,
+        height: 10,
+      });
+      const response = await responsePromise;
+      expect(response.error).toBeUndefined();
+      expect(await fs.readFileSync(destination, "utf8")).toBe("fake-png");
+      const text = response.result.content[0].text;
+      expect(text).toContain(destination);
+      expect(text).not.toContain("surf-transfer-");
+
+      const failed = fileTransfer.prepareRemoteTool("screenshot", { savePath: errorDestination });
+      const failedResponsePromise = transport.request(
+        {
+          type: "tool_request",
+          method: "execute_tool",
+          params: { tool: "screenshot", args: failed.args },
+          id: "screenshot-download-error",
+        },
+        30000,
+        failed,
+      );
+      const failedExtensionRequest = await host.waitForMessage(
+        (message) => message.type === "EXECUTE_SCREENSHOT",
+        "failed remote screenshot",
+      );
+      host.send({
+        id: failedExtensionRequest.id,
+        error: `cannot write ${failedExtensionRequest.savePath}`,
+      });
+      const failedResponse = await failedResponsePromise;
+      expect(failedResponse.error.content[0].text).toContain(errorDestination);
+      expect(failedResponse.error.content[0].text).not.toContain("surf-transfer-");
+      expect(fs.existsSync(errorDestination)).toBe(false);
+    } finally {
+      await transport.close();
+      fs.rmSync(destination, { recursive: false, force: true });
+      fs.rmSync(errorDestination, { recursive: false, force: true });
+    }
+  });
+
+  it("exports remote network data through transferred and direct outputs", async () => {
+    const reservation = net.createServer();
+    await new Promise<void>((resolve) => reservation.listen(0, "127.0.0.1", resolve));
+    const tcpPort = reservation.address().port;
+    await new Promise<void>((resolve) => reservation.close(resolve));
+    const host = await startHostHarness({}, tcpPort);
+    const destination = path.join(
+      os.tmpdir(),
+      `surf-network-export-${process.pid}-${Date.now()}.json`,
+    );
+    const directDestination = path.join(
+      os.tmpdir(),
+      `surf-network-export-direct-${process.pid}-${Date.now()}.json`,
+    );
+    const transport = await openClientTransport({
+      kind: "remote",
+      connectionOptions: { host: "127.0.0.1", port: tcpPort },
+      credentialPath: host.remoteCredentialPath,
+    });
+    const entries = [{ id: "r1", url: "https://example.test", _requestId: "hidden" }];
+    try {
+      const prepared = fileTransfer.prepareRemoteTool("network.export", { output: destination });
+      const transferredResponse = transport.request(
+        {
+          type: "tool_request",
+          method: "execute_tool",
+          params: { tool: "network.export", args: prepared.args },
+          id: "network-export-transferred",
+        },
+        30000,
+        prepared,
+      );
+      const extensionRequest = await host.waitForMessage(
+        (message) => message.type === "EXPORT_NETWORK_REQUESTS",
+        "network export transfer",
+      );
+      expect(extensionRequest.output).toBeUndefined();
+      host.send({ id: extensionRequest.id, entries, jsonl: false, har: false });
+      const transferred = await transferredResponse;
+      expect(transferred.error).toBeUndefined();
+      const exported = JSON.parse(fs.readFileSync(destination, "utf8"));
+      expect(exported).toEqual([{ id: "r1", url: "https://example.test" }]);
+
+      const direct = fileTransfer.prepareRemoteTool("network.export", {
+        output: `remote:${directDestination}`,
+      });
+      const directResponse = transport.request(
+        {
+          type: "tool_request",
+          method: "execute_tool",
+          params: { tool: "network.export", args: direct.args },
+          id: "network-export-direct",
+        },
+        30000,
+        direct,
+      );
+      const directRequest = await host.waitForMessage(
+        (message) => message.type === "EXPORT_NETWORK_REQUESTS",
+        "direct network export",
+      );
+      expect(directRequest.output).toBeUndefined();
+      host.send({ id: directRequest.id, entries, jsonl: false, har: false });
+      expect((await directResponse).error).toBeUndefined();
+      expect(JSON.parse(fs.readFileSync(directDestination, "utf8"))).toEqual([
+        { id: "r1", url: "https://example.test" },
+      ]);
+    } finally {
+      await transport.close();
+      fs.rmSync(destination, { recursive: false, force: true });
+      fs.rmSync(directDestination, { recursive: false, force: true });
+    }
+  });
+
+  it("transfers successful remote auto-screenshots without inline image data", async () => {
+    const reservation = net.createServer();
+    await new Promise<void>((resolve) => reservation.listen(0, "127.0.0.1", resolve));
+    const tcpPort = reservation.address().port;
+    await new Promise<void>((resolve) => reservation.close(resolve));
+    const transferRoot = fs.mkdtempSync(path.join(os.tmpdir(), "surf-auto-transfer-root-"));
+    tempDirs.push(transferRoot);
+    const host = await startHostHarness({ SURF_TMP: transferRoot }, tcpPort);
+    const transport = await openClientTransport({
+      kind: "remote",
+      connectionOptions: { host: "127.0.0.1", port: tcpPort },
+      credentialPath: host.remoteCredentialPath,
+    });
+    const prepared = fileTransfer.prepareRemoteTool("click", {
+      selector: "#go",
+      autoScreenshot: true,
+    });
+    try {
+      const responsePromise = transport.request(
+        {
+          type: "tool_request",
+          method: "execute_tool",
+          params: { tool: "click", args: prepared.args },
+          tabId: 1,
+          id: "auto-screenshot-transfer",
+        },
+        30000,
+        prepared,
+      );
+      const click = await host.waitForMessage(
+        (message) => message.type === "CLICK_SELECTOR",
+        "auto screenshot click",
+      );
+      host.send({ id: click.id, success: true });
+      const screenshot = await host.waitForMessage(
+        (message) => message.type === "EXECUTE_SCREENSHOT",
+        "auto screenshot capture",
+      );
+      host.send({
+        id: screenshot.id,
+        base64: Buffer.from("auto-png").toString("base64"),
+        width: 1,
+        height: 1,
+      });
+      const response = await responsePromise;
+      expect(response.error).toBeUndefined();
+      expect(response.result.content).toHaveLength(1);
+      expect(response.result.content[0].type).toBe("text");
+      expect(response.result.content[0].text).toContain(prepared.downloads[0].destination);
+      expect(response.result.content[0].text).not.toContain("surf-transfer-");
+      expect(JSON.stringify(response)).not.toContain("auto-png");
+      const stagingDirectories = fs
+        .readdirSync(transferRoot)
+        .filter((entry) => entry.startsWith("surf-transfer-"));
+      expect(stagingDirectories).toHaveLength(1);
+      expect(fs.readdirSync(path.join(transferRoot, stagingDirectories[0]))).toEqual([]);
+    } finally {
+      await transport.close();
+      fs.rmSync(prepared.downloads[0].destination, { recursive: false, force: true });
+    }
+  });
+
+  it("fails remote auto-screenshot downloads without hanging or leaking staging", async () => {
+    const reservation = net.createServer();
+    await new Promise<void>((resolve) => reservation.listen(0, "127.0.0.1", resolve));
+    const tcpPort = reservation.address().port;
+    await new Promise<void>((resolve) => reservation.close(resolve));
+    const transferRoot = fs.mkdtempSync(path.join(os.tmpdir(), "surf-auto-failure-root-"));
+    tempDirs.push(transferRoot);
+    const host = await startHostHarness({ SURF_TMP: transferRoot }, tcpPort);
+    const transport = await openClientTransport({
+      kind: "remote",
+      connectionOptions: { host: "127.0.0.1", port: tcpPort },
+      credentialPath: host.remoteCredentialPath,
+    });
+    try {
+      const runFailure = async (id: string, screenshotResponse: NativeMessage) => {
+        const prepared = fileTransfer.prepareRemoteTool("click", {
+          selector: "#go",
+          autoScreenshot: true,
+        });
+        const responsePromise = transport.request(
+          {
+            type: "tool_request",
+            method: "execute_tool",
+            params: { tool: "click", args: prepared.args },
+            tabId: 1,
+            id,
+          },
+          30000,
+          prepared,
+        );
+        const click = await host.waitForMessage(
+          (message) => message.type === "CLICK_SELECTOR",
+          `${id} click`,
+        );
+        host.send({ id: click.id, success: true });
+        const screenshot = await host.waitForMessage(
+          (message) => message.type === "EXECUTE_SCREENSHOT",
+          `${id} screenshot`,
+        );
+        host.send({ id: screenshot.id, ...screenshotResponse });
+        const response = await responsePromise;
+        expect(response.error).toBeTruthy();
+        expect(fs.existsSync(prepared.downloads[0].destination)).toBe(false);
+        expect(JSON.stringify(response)).not.toContain("surf-transfer-");
+        expect(JSON.stringify(response)).not.toContain("auto-png");
+      };
+
+      await runFailure("auto-missing-base64", {});
+      await runFailure("auto-nested-error", { error: "capture failed" });
+
+      const primaryFailure = fileTransfer.prepareRemoteTool("click", {
+        selector: "#go",
+        autoScreenshot: true,
+      });
+      const primaryFailureResponse = transport.request(
+        {
+          type: "tool_request",
+          method: "execute_tool",
+          params: { tool: "click", args: primaryFailure.args },
+          tabId: 1,
+          id: "auto-primary-error",
+        },
+        30000,
+        primaryFailure,
+      );
+      const failedClick = await host.waitForMessage(
+        (message) => message.type === "CLICK_SELECTOR",
+        "auto primary-error click",
+      );
+      host.send({ id: failedClick.id, error: "primary click failure" });
+      await host.expectNoMessage(
+        (message) => message.type === "EXECUTE_SCREENSHOT",
+        "screenshot after primary action failure",
+      );
+      expect((await primaryFailureResponse).error.content[0].text).toContain(
+        "primary click failure",
+      );
+      expect(fs.existsSync(primaryFailure.downloads[0].destination)).toBe(false);
+
+      const nextPromise = transport.request({
+        type: "tool_request",
+        method: "execute_tool",
+        params: { tool: "tab.list", args: {} },
+        id: "auto-after-failure",
+      });
+      const next = await host.waitForMessage(
+        (message) => message.type === "LIST_TABS",
+        "auto after failure",
+      );
+      host.send({ id: next.id, tabs: [] });
+      expect((await nextPromise).error).toBeUndefined();
+    } finally {
+      await transport.close();
+    }
+  });
+
+  it("rejects transfer frames after remote credential revocation", async () => {
+    const reservation = net.createServer();
+    await new Promise<void>((resolve) => reservation.listen(0, "127.0.0.1", resolve));
+    const tcpPort = reservation.address().port;
+    await new Promise<void>((resolve) => reservation.close(resolve));
+    const host = await startHostHarness({}, tcpPort);
+    const socket = net.createConnection({ host: "127.0.0.1", port: tcpPort });
+    await new Promise<void>((resolve) => socket.once("connect", resolve));
+    await remoteTransport.authenticateClient(socket, host.remoteCredentialPath);
+    if (!host.remoteStateDir) {
+      throw new Error("remote state directory missing");
+    }
+    remoteAuth.revokeClient("integration-client", host.remoteStateDir);
+    let sawReady = false;
+    const parser = remoteTransport.createFrameParser({
+      onFrame: (message: NativeMessage) => {
+        if (message.type === "transfer_ready") {
+          sawReady = true;
+        }
+      },
+      onError: () => undefined,
+    });
+    socket.on("data", (chunk: any) => parser.push(chunk));
+    const data = Buffer.from("revoked");
+    remoteTransport.writeFrame(socket, {
+      type: "transfer_begin",
+      version: 1,
+      direction: "upload",
+      transferId: "revoked-transfer",
+      size: data.length,
+      sha256: crypto.createHash("sha256").update(data).digest("hex"),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(sawReady).toBe(false);
+    expect(socket.destroyed || socket.writableEnded).toBe(true);
+    socket.destroy();
+  });
+
+  it("cleans a timed-out staged upload before the next lease dispatch", async () => {
+    const reservation = net.createServer();
+    await new Promise<void>((resolve) => reservation.listen(0, "127.0.0.1", resolve));
+    const tcpPort = reservation.address().port;
+    await new Promise<void>((resolve) => reservation.close(resolve));
+    const transferRoot = fs.mkdtempSync(path.join(os.tmpdir(), "surf-transfer-timeout-"));
+    tempDirs.push(transferRoot);
+    const host = await startHostHarness(
+      { SURF_TMP: transferRoot, SURF_TEST_MODE: "1", SURF_TEST_REQUEST_DEADLINE_MS: "100" },
+      tcpPort,
+    );
+    const source = path.join(transferRoot, "client-upload.txt");
+    fs.writeFileSync(source, "staged before timeout");
+    const endpoint = {
+      kind: "remote",
+      connectionOptions: { host: "127.0.0.1", port: tcpPort },
+      credentialPath: host.remoteCredentialPath,
+    };
+    const transport = await openClientTransport(endpoint);
+    const prepared = fileTransfer.prepareRemoteTool("upload", { ref: "e5", files: [source] });
+    const timeoutPromise = transport.request(
+      {
+        type: "tool_request",
+        method: "execute_tool",
+        id: "timeout-upload",
+        params: { tool: "upload", args: prepared.args },
+      },
+      5000,
+      prepared,
+    );
+    const upload = await host.waitForMessage(
+      (message) => message.type === "UPLOAD_FILE",
+      "timed upload",
+    );
+    const stagedPath = (upload.files as string[])[0];
+    expect(fs.existsSync(stagedPath)).toBe(true);
+    expect((await timeoutPromise).error).toBeTruthy();
+
+    const nextPromise = transport.request({
+      type: "tool_request",
+      method: "execute_tool",
+      id: "after-timeout",
+      params: { tool: "tab.list", args: {} },
+    });
+    const next = await host.waitForMessage(
+      (message) => message.type === "LIST_TABS",
+      "after timeout LIST_TABS",
+    );
+    expect(fs.existsSync(stagedPath)).toBe(false);
+    const stagingDirectories = fs
+      .readdirSync(transferRoot)
+      .filter((entry) => entry.startsWith("surf-transfer-"));
+    expect(stagingDirectories).toHaveLength(1);
+    expect(fs.readdirSync(path.join(transferRoot, stagingDirectories[0]))).toEqual([]);
+    host.send({ id: next.id, tabs: [] });
+    expect((await nextPromise).error).toBeUndefined();
+    await transport.close();
+  });
+
+  it("awaits staged transfer cleanup before host shutdown exits", async () => {
+    const reservation = net.createServer();
+    await new Promise<void>((resolve) => reservation.listen(0, "127.0.0.1", resolve));
+    const tcpPort = reservation.address().port;
+    await new Promise<void>((resolve) => reservation.close(resolve));
+    const transferRoot = fs.mkdtempSync(path.join(os.tmpdir(), "surf-transfer-shutdown-"));
+    tempDirs.push(transferRoot);
+    const host = await startHostHarness({ SURF_TMP: transferRoot }, tcpPort);
+    const source = path.join(os.tmpdir(), `surf-shutdown-source-${process.pid}-${Date.now()}.txt`);
+    fs.writeFileSync(source, "shutdown cleanup");
+    const transport = await openClientTransport({
+      kind: "remote",
+      connectionOptions: { host: "127.0.0.1", port: tcpPort },
+      credentialPath: host.remoteCredentialPath,
+    });
+    try {
+      const prepared = fileTransfer.prepareRemoteTool("upload", { ref: "e5", files: [source] });
+      const requestPromise = transport.request(
+        {
+          type: "tool_request",
+          method: "execute_tool",
+          params: { tool: "upload", args: prepared.args },
+          id: "shutdown-upload",
+        },
+        30000,
+        prepared,
+      );
+      requestPromise.catch(() => undefined);
+      const extensionRequest = await host.waitForMessage(
+        (message) => message.type === "UPLOAD_FILE",
+        "shutdown upload",
+      );
+      const stagedPath = (extensionRequest.files as string[])[0];
+      expect(fs.existsSync(stagedPath)).toBe(true);
+      host.child.kill("SIGTERM");
+      await waitForExit(host.child, 2000);
+      expect(fs.existsSync(stagedPath)).toBe(false);
+      expect(
+        fs.readdirSync(transferRoot).filter((entry) => entry.startsWith("surf-transfer-")).length,
+      ).toBe(0);
+      await requestPromise.catch(() => undefined);
+    } finally {
+      await transport.close();
+      fs.rmSync(source, { recursive: false, force: true });
+    }
+  });
+
+  it("does not create transfer staging for unauthenticated TCP sockets", async () => {
+    const reservation = net.createServer();
+    await new Promise<void>((resolve) => reservation.listen(0, "127.0.0.1", resolve));
+    const tcpPort = reservation.address().port;
+    await new Promise<void>((resolve) => reservation.close(resolve));
+    const transferRoot = fs.mkdtempSync(path.join(os.tmpdir(), "surf-transfer-lazy-"));
+    tempDirs.push(transferRoot);
+    const _host = await startHostHarness({ SURF_TMP: transferRoot }, tcpPort);
+    const socket = net.createConnection({ host: "127.0.0.1", port: tcpPort });
+    await new Promise<void>((resolve) => socket.once("connect", resolve));
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(
+      fs.readdirSync(transferRoot).filter((entry) => entry.startsWith("surf-transfer-")).length,
+    ).toBe(0);
+    socket.destroy();
+  });
+
+  it("rejects forged and prototype-like path metadata before dispatch", async () => {
+    const reservation = net.createServer();
+    await new Promise<void>((resolve) => reservation.listen(0, "127.0.0.1", resolve));
+    const tcpPort = reservation.address().port;
+    await new Promise<void>((resolve) => reservation.close(resolve));
+    const transferRoot = fs.mkdtempSync(path.join(os.tmpdir(), "surf-transfer-malformed-"));
+    tempDirs.push(transferRoot);
+    const host = await startHostHarness({ SURF_TMP: transferRoot }, tcpPort);
+    const socket = net.createConnection({ host: "127.0.0.1", port: tcpPort });
+    await new Promise<void>((resolve) => socket.once("connect", resolve));
+    await remoteTransport.authenticateClient(socket, host.remoteCredentialPath);
+    const responses = new Map<string, NativeMessage>();
+    const responseWaiters = new Map<string, (message: NativeMessage) => void>();
+    const responseParser = remoteTransport.createFrameParser({
+      onFrame: (message: NativeMessage) => {
+        if (typeof message.id === "string" && responseWaiters.has(message.id)) {
+          responseWaiters.get(message.id)?.(message);
+        } else if (typeof message.id === "string") {
+          responses.set(message.id, message);
+        }
+      },
+      onError: () => undefined,
+    });
+    socket.on("data", (chunk: any) => responseParser.push(chunk));
+    const waitResponse = async (id: string) => {
+      const queued = responses.get(id);
+      if (queued) {
+        responses.delete(id);
+        return queued;
+      }
+      return new Promise<NativeMessage>((resolve) => responseWaiters.set(id, resolve));
+    };
+    const expectRejected = async (message: NativeMessage, extensionType: string, label: string) => {
+      remoteTransport.writeFrame(socket, message);
+      await host.expectNoMessage((candidate) => candidate.type === extensionType, label);
+      expect((await waitResponse(message.id as string)).error).toBeTruthy();
+    };
+    remoteTransport.writeFrame(socket, {
+      type: "tool_request",
+      method: "execute_tool",
+      id: "forged-path",
+      params: { tool: "upload", args: { ref: "e5", files: ["/etc/passwd"] } },
+      _surfPaths: [
+        {
+          field: "files",
+          kind: "input",
+          original: "client.txt",
+          path: "client.txt",
+          pathKind: "local",
+        },
+      ],
+      _surfTransfers: {
+        uploads: [
+          { transferId: "missing", field: "files", original: "client.txt", kind: "upload" },
+        ],
+        downloads: [],
+      },
+    });
+    await host.expectNoMessage((message) => message.type === "UPLOAD_FILE", "forged upload");
+    expect((await waitResponse("forged-path")).error).toBeTruthy();
+    await expectRejected(
+      {
+        type: "tool_request",
+        method: "execute_tool",
+        id: "auto-disallowed-tool",
+        params: { tool: "tab.list", args: { autoScreenshot: true } },
+      },
+      "LIST_TABS",
+      "auto screenshot disallowed tool",
+    );
+    await expectRejected(
+      {
+        type: "tool_request",
+        method: "execute_tool",
+        id: "auto-non-boolean",
+        params: { tool: "click", args: { selector: "#go", autoScreenshot: "yes" } },
+      },
+      "CLICK_SELECTOR",
+      "auto screenshot non-boolean",
+    );
+    const validRemoteScreenshot = (
+      id: string,
+      descriptor: Record<string, unknown>,
+      transfers: Record<string, unknown> = { uploads: [], downloads: [] },
+      descriptors = [descriptor],
+    ) => ({
+      type: "tool_request",
+      method: "execute_tool",
+      id,
+      params: { tool: "screenshot", args: { savePath: "remote:/tmp/raw.png" } },
+      _surfPaths: descriptors,
+      _surfTransfers: transfers,
+    });
+    const unknownDescriptor = JSON.parse(
+      '{"field":"savePath","kind":"output","original":"remote:/tmp/raw.png","path":"/tmp/raw.png","pathKind":"remote","__proto__":"reject"}',
+    );
+    await expectRejected(
+      validRemoteScreenshot("prototype-path", unknownDescriptor),
+      "EXECUTE_SCREENSHOT",
+      "prototype screenshot",
+    );
+    await expectRejected(
+      validRemoteScreenshot("path-kind", {
+        field: "savePath",
+        kind: "output",
+        original: "remote:/tmp/raw.png",
+        path: "/tmp/raw.png",
+        pathKind: "local",
+      }),
+      "EXECUTE_SCREENSHOT",
+      "path kind mismatch",
+    );
+    await expectRejected(
+      validRemoteScreenshot("path-value", {
+        field: "savePath",
+        kind: "output",
+        original: "remote:/tmp/raw.png",
+        path: "/tmp/other.png",
+        pathKind: "remote",
+      }),
+      "EXECUTE_SCREENSHOT",
+      "path value mismatch",
+    );
+    await expectRejected(
+      validRemoteScreenshot(
+        "extra-meta",
+        {
+          field: "savePath",
+          kind: "output",
+          original: "remote:/tmp/raw.png",
+          path: "/tmp/raw.png",
+          pathKind: "remote",
+        },
+        { uploads: [], downloads: [], extra: true },
+      ),
+      "EXECUTE_SCREENSHOT",
+      "extra transfer metadata",
+    );
+    const duplicate = {
+      field: "savePath",
+      kind: "output",
+      original: "remote:/tmp/raw.png",
+      path: "/tmp/raw.png",
+      pathKind: "remote",
+    };
+    await expectRejected(
+      validRemoteScreenshot("duplicate-path", duplicate, { uploads: [], downloads: [] }, [
+        duplicate,
+        { ...duplicate },
+      ]),
+      "EXECUTE_SCREENSHOT",
+      "duplicate path descriptor",
+    );
+    await expectRejected(
+      validRemoteScreenshot("multiple-transfers", duplicate, {
+        uploads: [
+          { transferId: "a", field: "files", original: "a", kind: "upload" },
+          { transferId: "b", field: "files", original: "b", kind: "upload" },
+        ],
+        downloads: [],
+      }),
+      "EXECUTE_SCREENSHOT",
+      "multiple transfer metadata",
+    );
+    await expectRejected(
+      {
+        type: "tool_request",
+        method: "execute_tool",
+        id: "invalid-local-transfer-id",
+        params: { tool: "screenshot", args: { savePath: "local:shot.png" } },
+        _surfPaths: [
+          {
+            field: "savePath",
+            kind: "output",
+            original: "local:shot.png",
+            path: "local:shot.png",
+            pathKind: "local",
+          },
+        ],
+        _surfTransfers: {
+          uploads: [],
+          downloads: [
+            {
+              transferId: 7,
+              field: "savePath",
+              original: "local:shot.png",
+              kind: "download",
+            },
+          ],
+        },
+      },
+      "EXECUTE_SCREENSHOT",
+      "invalid local transfer ID",
+    );
+    await expectRejected(
+      {
+        type: "tool_request",
+        method: "execute_tool",
+        id: "forged-local-descriptor-path",
+        params: { tool: "screenshot", args: { savePath: "local:shot.png" } },
+        _surfPaths: [
+          {
+            field: "savePath",
+            kind: "output",
+            original: "local:shot.png",
+            path: "/forged/client/path.png",
+            pathKind: "local",
+          },
+        ],
+        _surfTransfers: {
+          uploads: [],
+          downloads: [
+            {
+              transferId: "valid-download-id",
+              field: "savePath",
+              original: "local:shot.png",
+              kind: "download",
+            },
+          ],
+        },
+      },
+      "EXECUTE_SCREENSHOT",
+      "forged local descriptor path",
+    );
+    expect(
+      fs.readdirSync(transferRoot).filter((entry) => entry.startsWith("surf-transfer-")).length,
+    ).toBe(0);
+    socket.destroy();
+  });
+
+  it("serializes local and authenticated remote requests through one host lease", async () => {
+    const reservation = net.createServer();
+    await new Promise<void>((resolve) => reservation.listen(0, "127.0.0.1", resolve));
+    const tcpPort = reservation.address().port;
+    await new Promise<void>((resolve) => reservation.close(resolve));
+    const host = await startHostHarness({}, tcpPort);
+    const local = net.createConnection(host.socketPath);
+    await new Promise<void>((resolve) => local.once("connect", resolve));
+    const remote = net.createConnection({ host: "127.0.0.1", port: tcpPort });
+    await new Promise<void>((resolve) => remote.once("connect", resolve));
+    await remoteTransport.authenticateClient(remote, host.remoteCredentialPath);
+    const readRemote = new Promise<string>((resolve) =>
+      remote.once("data", (chunk: any) => resolve(chunk.toString("utf8"))),
+    );
+
+    remoteTransport.writeFrame(local, {
+      type: "tool_request",
+      method: "execute_tool",
+      params: { tool: "tab.list", args: {} },
+      id: "local",
+    });
+    const firstExtensionRequest = await host.waitForMessage(
+      (message) => message.type === "LIST_TABS",
+      "first LIST_TABS",
+    );
+    remoteTransport.writeFrame(remote, {
+      type: "tool_request",
+      method: "execute_tool",
+      params: { tool: "page.text", args: {} },
+      id: "remote",
+    });
+    await host.expectNoMessage(
+      (message) => message.type === "GET_PAGE_TEXT",
+      "remote request before local lease release",
+    );
+    host.send({ id: firstExtensionRequest.id, tabs: [] });
+    await new Promise<void>((resolve) => local.once("data", () => resolve()));
+    local.end();
+    const secondExtensionRequest = await host.waitForMessage(
+      (message) => message.type === "GET_PAGE_TEXT",
+      "second GET_PAGE_TEXT",
+    );
+    host.send({ id: secondExtensionRequest.id, text: "remote result" });
+    expect(await readRemote).toContain('"id":"remote"');
+    remote.destroy();
+  });
+
+  it("keeps a disconnected active request leased until extension settlement", async () => {
+    const host = await startHostHarness();
+    const first = net.createConnection(host.socketPath);
+    await new Promise<void>((resolve) => first.once("connect", resolve));
+    remoteTransport.writeFrame(first, {
+      type: "tool_request",
+      method: "execute_tool",
+      params: { tool: "tab.list", args: {} },
+      id: "abandoned",
+    });
+    const extensionRequest = await host.waitForMessage(
+      (message) => message.type === "LIST_TABS",
+      "abandoned LIST_TABS",
+    );
+    first.destroy();
+    const second = net.createConnection(host.socketPath);
+    await new Promise<void>((resolve) => second.once("connect", resolve));
+    remoteTransport.writeFrame(second, {
+      type: "tool_request",
+      method: "execute_tool",
+      params: { tool: "tab.list", args: {} },
+      id: "queued",
+    });
+    await host.expectNoMessage(
+      (message) => message.type === "LIST_TABS",
+      "queued request before abandoned operation settles",
+    );
+    host.send({ id: extensionRequest.id, tabs: [] });
+    const secondExtensionRequest = await host.waitForMessage(
+      (message) => message.type === "LIST_TABS",
+      "queued LIST_TABS",
+    );
+    host.send({ id: secondExtensionRequest.id, tabs: [] });
+    second.destroy();
+  });
+
+  it("retains a nested provider tombstone until its late page response", async () => {
+    const host = await startHostHarness();
+    const first = net.createConnection(host.socketPath);
+    await new Promise<void>((resolve) => first.once("connect", resolve));
+    remoteTransport.writeFrame(first, {
+      type: "tool_request",
+      method: "execute_tool",
+      params: { tool: "chatgpt", args: { query: "nested", "with-page": true } },
+      id: "nested-abandoned",
+    });
+    const pageRequest = await host.waitForMessage(
+      (message) => message.type === "GET_PAGE_TEXT",
+      "nested provider page request",
+    );
+    first.destroy();
+    const second = net.createConnection(host.socketPath);
+    await new Promise<void>((resolve) => second.once("connect", resolve));
+    remoteTransport.writeFrame(second, {
+      type: "tool_request",
+      method: "execute_tool",
+      params: { tool: "tab.list", args: {} },
+      id: "nested-next",
+    });
+    await host.expectNoMessage(
+      (message) => message.type === "LIST_TABS",
+      "next request before nested tombstone drains",
+    );
+    host.send({ id: pageRequest.id, text: "late page" });
+    const nextRequest = await host.waitForMessage(
+      (message) => message.type === "LIST_TABS",
+      "next request after nested tombstone drains",
+    );
+    host.send({ id: nextRequest.id, tabs: [] });
+    second.destroy();
+  });
+
+  it("holds the lease until provider tombstones and tab cleanup both drain", async () => {
+    const host = await startHostHarness();
+    const first = net.createConnection(host.socketPath);
+    await new Promise<void>((resolve) => first.once("connect", resolve));
+    remoteTransport.writeFrame(first, {
+      type: "tool_request",
+      method: "execute_tool",
+      params: { tool: "chatgpt", args: { query: "cancel me" } },
+      id: "provider-abandoned",
+    });
+
+    const cookieRequest = await host.waitForMessage(
+      (message) => message.type === "GET_CHATGPT_COOKIES",
+      "ChatGPT cookies",
+    );
+    host.send({
+      id: cookieRequest.id,
+      cookies: [{ name: "__Secure-next-auth.session-token", value: "token" }],
+    });
+    const tabRequest = await host.waitForMessage(
+      (message) => message.type === "CHATGPT_NEW_TAB",
+      "ChatGPT tab",
+    );
+    host.send({ id: tabRequest.id, tabId: 42 });
+    const evaluateRequest = await host.waitForMessage(
+      (message) => message.type === "CHATGPT_EVALUATE",
+      "ChatGPT page evaluation",
+    );
+
+    first.destroy();
+    const closeRequest = await host.waitForMessage(
+      (message) => message.type === "CHATGPT_CLOSE_TAB",
+      "ChatGPT cleanup",
+    );
+    const second = net.createConnection(host.socketPath);
+    await new Promise<void>((resolve) => second.once("connect", resolve));
+    remoteTransport.writeFrame(second, {
+      type: "tool_request",
+      method: "execute_tool",
+      params: { tool: "tab.list", args: {} },
+      id: "after-provider-cleanup",
+    });
+
+    await host.expectNoMessage(
+      (message) => message.type === "LIST_TABS",
+      "next request before provider tombstone drains",
+    );
+    host.send({ id: evaluateRequest.id, result: { value: "complete" } });
+    await host.expectNoMessage(
+      (message) => message.type === "LIST_TABS",
+      "next request before provider tab cleanup drains",
+    );
+    host.send({ id: closeRequest.id, success: true });
+    const nextRequest = await host.waitForMessage(
+      (message) => message.type === "LIST_TABS",
+      "next request after provider cleanup",
+    );
+    host.send({ id: nextRequest.id, tabs: [] });
+    second.destroy();
   });
 
   it("propagates extension errors through the native host to CLI stderr", async () => {

--- a/test/unit/ai-queue.test.ts
+++ b/test/unit/ai-queue.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { BoundedAiQueue } = require("../../native/ai-queue.cjs") as {
+  BoundedAiQueue: new (
+    options?: Record<string, unknown>,
+  ) => {
+    enqueue(handler: () => Promise<unknown>, request?: { signal: AbortSignal }): Promise<unknown>;
+    get queued(): number;
+  };
+};
+
+describe("bounded AI queue", () => {
+  it("caps queued work and removes aborted items before start", async () => {
+    const queue = new BoundedAiQueue({ maxQueued: 2, spacingMs: 0 });
+    let release!: () => void;
+    const active = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const first = queue.enqueue(() => active);
+    const secondController = new AbortController();
+    const second = queue.enqueue(() => Promise.resolve("second"), {
+      signal: secondController.signal,
+    });
+    const third = queue.enqueue(() => Promise.resolve("third"));
+    secondController.abort();
+    await expect(second).rejects.toMatchObject({ code: "SURF_REQUEST_ABORTED" });
+    release();
+    await first;
+    await expect(third).resolves.toBe("third");
+  });
+
+  it("rejects beyond the queue cap", async () => {
+    const queue = new BoundedAiQueue({ maxQueued: 1, spacingMs: 0 });
+    const release = vi.fn();
+    const active = queue.enqueue(
+      () => new Promise((resolve) => release.mockImplementation(resolve)),
+    );
+    const queued = queue.enqueue(() => Promise.resolve("queued"));
+    await expect(queue.enqueue(() => Promise.resolve("overflow"))).rejects.toThrow("queue is full");
+    release();
+    await active;
+    await expect(queued).resolves.toBe("queued");
+  });
+});

--- a/test/unit/cli-args.test.ts
+++ b/test/unit/cli-args.test.ts
@@ -40,6 +40,7 @@ function createCliEnv(socketPath?: string) {
   const env = { ...process.env };
   env.SURF_NO_LOCK = undefined;
   env.SURF_LOCK_TIMEOUT_MS = undefined;
+  env.SURF_REMOTE = undefined;
 
   if (socketPath) {
     env.SURF_SOCKET = socketPath;
@@ -201,6 +202,127 @@ describe("CLI argument parsing", () => {
     expect(code).toBe(0);
     expect(stderr).toBe("");
     expect(stdout).toContain("surf --llm-context");
+    expect(stdout).toContain("--remote <host>:<port>");
+  });
+
+  it("rejects remote record before attempting a connection", async () => {
+    const { code, stdout, stderr } = await runCliWithoutSocket([
+      "record",
+      "--remote",
+      "browser.tailnet:4321",
+    ]);
+
+    expect(code).toBe(1);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("record is not supported with remote endpoint browser.tailnet:4321");
+    expect(stderr).not.toContain("/tmp/surf.sock");
+  });
+
+  it("routes normal, script, and workflow requests to TCP remote without forwarding --remote", async () => {
+    const requests: any[] = [];
+    const server = net.createServer((socket: any) => {
+      let buffer = "";
+      socket.on("data", (chunk: { toString(): string }) => {
+        buffer += chunk.toString();
+        const line = buffer.split("\n")[0];
+        if (!line) return;
+        requests.push(JSON.parse(line));
+        socket.end(`${JSON.stringify({ result: { content: [{ type: "text", text: "OK" }] } })}\n`);
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.on("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const port = (server.address() as any).port;
+    const remote = `127.0.0.1:${port}`;
+    const scriptPath = path.join(os.tmpdir(), `surf-remote-script-${process.pid}-${Date.now()}.json`);
+    fs.writeFileSync(scriptPath, JSON.stringify({ steps: [{ tool: "page.state" }] }));
+    const invoke = (args: string[]) => new Promise<number | null>((resolve, reject) => {
+      const child = spawn(process.execPath, ["native/cli.cjs", ...args, "--remote", remote, "--no-lock"], {
+        cwd: process.cwd(), env: createCliEnv(), stdio: ["ignore", "ignore", "pipe"],
+      });
+      child.on("error", reject);
+      child.on("close", resolve);
+    });
+    try {
+      expect(await invoke(["page.read"])).toBe(0);
+      expect(await invoke(["--script", scriptPath])).toBe(0);
+      expect(await invoke(["do", "page.text"])).toBe(0);
+      expect(requests.map((request) => request.params.tool)).toEqual(["page.read", "page.state", "page.text"]);
+      expect(requests.every((request) => request.params.args.remote === undefined)).toBe(true);
+    } finally {
+      fs.rmSync(scriptPath, { force: true });
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("sends stream requests over the selected TCP endpoint without forwarding remote", async () => {
+    let request: any;
+    let receivedRequest!: () => void;
+    const requestReceived = new Promise<void>((resolve) => { receivedRequest = resolve; });
+    const server = net.createServer((socket: any) => socket.once("data", (chunk: { toString(): string }) => {
+      request = JSON.parse(chunk.toString().trim());
+      receivedRequest();
+      socket.write('{"type":"stream_started"}\n');
+    }));
+    await new Promise<void>((resolve, reject) => { server.on("error", reject); server.listen(0, "127.0.0.1", resolve); });
+    const remote = `127.0.0.1:${(server.address() as any).port}`;
+    const child = spawn(process.execPath, ["native/cli.cjs", "console", "--stream", "--remote", remote, "--no-lock"], {
+      cwd: process.cwd(), env: createCliEnv(), stdio: ["ignore", "ignore", "pipe"],
+    });
+    try {
+      await waitFor(requestReceived, 1000, "stream request");
+      expect(request).toMatchObject({ type: "stream_request", streamType: "STREAM_CONSOLE" });
+      expect(JSON.stringify(request)).not.toContain("remote");
+    } finally {
+      child.kill("SIGINT");
+      await new Promise<void>((resolve) => child.once("close", () => resolve()));
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("routes MCP tool calls over the selected TCP endpoint", async () => {
+    let request: any;
+    let receivedRequest!: () => void;
+    const requestReceived = new Promise<void>((resolve) => { receivedRequest = resolve; });
+    const server = net.createServer((socket: any) => {
+      socket.on("error", () => {});
+      socket.once("data", (chunk: { toString(): string }) => {
+        request = JSON.parse(chunk.toString().trim());
+        receivedRequest();
+        socket.end('{"result":{"content":[{"type":"text","text":"OK"}]}}\n');
+      });
+    });
+    await new Promise<void>((resolve, reject) => { server.on("error", reject); server.listen(0, "127.0.0.1", resolve); });
+    const remote = `127.0.0.1:${(server.address() as any).port}`;
+    const child = spawn(process.execPath, ["native/cli.cjs", "server", "--remote", remote], {
+      cwd: process.cwd(), env: createCliEnv(), stdio: ["pipe", "pipe", "pipe"],
+    });
+    let initialized!: () => void;
+    const initializationComplete = new Promise<void>((resolve) => { initialized = resolve; });
+    let completed!: () => void;
+    const toolCallComplete = new Promise<void>((resolve) => { completed = resolve; });
+    child.stdout.on("data", (chunk: { toString(): string }) => {
+      const output = chunk.toString();
+      if (output.includes('"id":1')) initialized();
+      if (output.includes('"id":2')) completed();
+    });
+    const send = (message: object) => child.stdin.write(`${JSON.stringify(message)}\n`);
+    try {
+      send({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "test", version: "1" } } });
+      await waitFor(initializationComplete, 1000, "MCP initialization");
+      send({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "page.text", arguments: {} } });
+      await waitFor(requestReceived, 1000, "MCP TCP request");
+      expect(request.params.tool).toBe("page.text");
+      expect(JSON.stringify(request)).not.toContain("remote");
+      await waitFor(toolCallComplete, 1000, "MCP tool response");
+    } finally {
+      child.stdin.end();
+      child.kill("SIGTERM");
+      await new Promise<void>((resolve) => child.once("close", () => resolve()));
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 
   it("maps resize positional width and height", async () => {

--- a/test/unit/cli-args.test.ts
+++ b/test/unit/cli-args.test.ts
@@ -12,8 +12,56 @@ const fs = require("node:fs");
 const net = require("node:net");
 const os = require("node:os");
 const path = require("node:path");
+const remoteAuth = require("../../native/remote-auth.cjs");
+const remoteTransport = require("../../native/remote-transport.cjs");
 
 let socketCounter = 0;
+
+function createRemoteCredential() {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "surf-cli-remote-test-"));
+  const credentialPath = path.join(stateDir, "client.json");
+  remoteAuth.authorizeClient("test-client", credentialPath, stateDir);
+  return { stateDir, credentialPath };
+}
+
+function attachAuthenticatedServer(
+  socket: any,
+  stateDir: string,
+  onRequest: (message: any, clientSocket: any) => void,
+) {
+  socket.on("error", () => undefined);
+  const session = remoteTransport.createServerAuthSession({
+    socket,
+    stateDir,
+    onAuthenticated: () => undefined,
+    onError: (error: Error) => {
+      remoteTransport
+        .writeFrame(socket, { type: "auth_error", message: error.message })
+        .finally(() => socket.destroy())
+        .catch(() => socket.destroy());
+    },
+  });
+  let messageChain = Promise.resolve();
+  const parser = remoteTransport.createFrameParser({
+    onFrame: (message: any) => {
+      messageChain = messageChain
+        .then(async () => {
+          if (!session.authenticated) {
+            await session.handle(message);
+            return;
+          }
+          onRequest(message, socket);
+        })
+        .catch(() => socket.destroy());
+    },
+    onError: () => socket.destroy(),
+  });
+  socket.on("data", (chunk: any) => parser.push(chunk));
+  socket.on("close", () => {
+    parser.close();
+    session.close();
+  });
+}
 
 function createSocketPath() {
   socketCounter++;
@@ -54,6 +102,7 @@ function createCliEnv(socketPath?: string) {
 
 function runCliWithoutSocket(
   args: string[],
+  overrides: Record<string, string | undefined> = {},
 ): Promise<{ code: number | null; stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
     let stdout = "";
@@ -61,7 +110,7 @@ function runCliWithoutSocket(
 
     const child = spawn(process.execPath, ["native/cli.cjs", ...args], {
       cwd: process.cwd(),
-      env: createCliEnv(),
+      env: { ...createCliEnv(), ...overrides },
       stdio: ["ignore", "pipe", "pipe"],
     });
 
@@ -76,6 +125,21 @@ function runCliWithoutSocket(
       resolve({ code, stdout, stderr });
     });
   });
+}
+
+function createCliFixtureResult(request: any) {
+  if (request.params.tool === "network.export") {
+    fs.writeFileSync(request.params.args.output, "[]");
+    return { path: request.params.args.output, format: "json", count: 0 };
+  }
+  if (request.params.tool === "screenshot") {
+    return {
+      base64: require("node:buffer").Buffer.from("local-screenshot").toString("base64"),
+      width: 1,
+      height: 1,
+    };
+  }
+  return "OK";
 }
 
 function runCli(args: string[]): Promise<{ request: any; stdout: string; stderr: string }> {
@@ -97,8 +161,9 @@ function runCli(args: string[]): Promise<{ request: any; stdout: string; stderr:
         }
 
         request = JSON.parse(buffer.slice(0, lineEnd));
+        const result = createCliFixtureResult(request);
         socket.write(
-          `${JSON.stringify({ result: { content: [{ type: "text", text: "OK" }] } })}\n`,
+          `${JSON.stringify({ id: request.id, result: { content: [{ type: "text", text: typeof result === "string" ? result : JSON.stringify(result) }] } })}\n`,
         );
         socket.end();
       });
@@ -205,54 +270,303 @@ describe("CLI argument parsing", () => {
     expect(stdout).toContain("--remote <host>:<port>");
   });
 
+  it("keeps remote credential management local when remote routing is configured", async () => {
+    const credential = createRemoteCredential();
+    const result = await runCliWithoutSocket(["remote", "list"], {
+      SURF_REMOTE: "127.0.0.1:1",
+      SURF_REMOTE_CREDENTIAL: undefined,
+      SURF_REMOTE_STATE_DIR: credential.stateDir,
+    });
+    fs.rmSync(credential.stateDir, { recursive: true, force: true });
+    expect(result.code).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("test-client");
+  });
+
   it("rejects remote record before attempting a connection", async () => {
-    const { code, stdout, stderr } = await runCliWithoutSocket([
+    const credential = createRemoteCredential();
+    const result = await runCliWithoutSocket([
       "record",
       "--remote",
       "browser.tailnet:4321",
+      "--remote-credential",
+      credential.credentialPath,
     ]);
+    fs.rmSync(credential.stateDir, { recursive: true, force: true });
 
-    expect(code).toBe(1);
-    expect(stdout).toBe("");
-    expect(stderr).toContain("record is not supported with remote endpoint browser.tailnet:4321");
-    expect(stderr).not.toContain("/tmp/surf.sock");
+    expect(result.code).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain(
+      "record is not supported with remote endpoint browser.tailnet:4321",
+    );
+    expect(result.stderr).not.toContain("/tmp/surf.sock");
   });
 
   it("routes normal, script, and workflow requests to TCP remote without forwarding --remote", async () => {
     const requests: any[] = [];
-    const server = net.createServer((socket: any) => {
-      let buffer = "";
-      socket.on("data", (chunk: { toString(): string }) => {
-        buffer += chunk.toString();
-        const line = buffer.split("\n")[0];
-        if (!line) return;
-        requests.push(JSON.parse(line));
-        socket.end(`${JSON.stringify({ result: { content: [{ type: "text", text: "OK" }] } })}\n`);
-      });
-    });
+    const connections = new Set<any>();
+    const credential = createRemoteCredential();
+    const server = net.createServer((socket: any) =>
+      attachAuthenticatedServer(socket, credential.stateDir, (request: any, client: any) => {
+        requests.push(request);
+        connections.add(client);
+        remoteTransport.writeFrame(client, {
+          id: request.id,
+          result: { content: [{ type: "text", text: "OK" }] },
+        });
+      }),
+    );
     await new Promise<void>((resolve, reject) => {
       server.on("error", reject);
       server.listen(0, "127.0.0.1", resolve);
     });
     const port = (server.address() as any).port;
     const remote = `127.0.0.1:${port}`;
-    const scriptPath = path.join(os.tmpdir(), `surf-remote-script-${process.pid}-${Date.now()}.json`);
-    fs.writeFileSync(scriptPath, JSON.stringify({ steps: [{ tool: "page.state" }] }));
-    const invoke = (args: string[]) => new Promise<number | null>((resolve, reject) => {
-      const child = spawn(process.execPath, ["native/cli.cjs", ...args, "--remote", remote, "--no-lock"], {
-        cwd: process.cwd(), env: createCliEnv(), stdio: ["ignore", "ignore", "pipe"],
+    const scriptPath = path.join(
+      os.tmpdir(),
+      `surf-remote-script-${process.pid}-${Date.now()}.json`,
+    );
+    fs.writeFileSync(
+      scriptPath,
+      JSON.stringify({ steps: [{ tool: "page.state" }, { tool: "page.text" }] }),
+    );
+    const invoke = (args: string[]) =>
+      new Promise<number | null>((resolve, reject) => {
+        const child = spawn(
+          process.execPath,
+          [
+            "native/cli.cjs",
+            ...args,
+            "--remote",
+            remote,
+            "--remote-credential",
+            credential.credentialPath,
+            "--no-lock",
+          ],
+          {
+            cwd: process.cwd(),
+            env: createCliEnv(),
+            stdio: ["ignore", "ignore", "pipe"],
+          },
+        );
+        child.on("error", reject);
+        child.on("close", resolve);
       });
+    try {
+      expect(await invoke(["page.read"])).toBe(0);
+      expect(await invoke(["--script", scriptPath])).toBe(0);
+      expect(await invoke(["do", "page.text\npage.state"])).toBe(0);
+      expect(requests.map((request) => request.params.tool)).toEqual([
+        "page.read",
+        "page.state",
+        "page.text",
+        "page.text",
+        "page.state",
+      ]);
+      expect(connections.size).toBe(3);
+      expect(requests.every((request) => request.params.args.remote === undefined)).toBe(true);
+    } finally {
+      fs.rmSync(scriptPath, { force: true });
+      fs.rmSync(credential.stateDir, { recursive: true, force: true });
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("generates a local network-export output when omitted", async () => {
+    const { request, stdout } = await runCli(["network.export"]);
+    expect(request.params.tool).toBe("network.export");
+    expect(request.params.args.output).toMatch(/\.json$/);
+    expect(path.isAbsolute(request.params.args.output)).toBe(true);
+    expect(fs.readFileSync(request.params.args.output, "utf8")).toBe("[]");
+    expect(stdout).toContain(request.params.args.output);
+    fs.rmSync(request.params.args.output, { force: true });
+  });
+
+  it("writes local-prefixed screenshot output to the normalized path", async () => {
+    const output = path.join(os.tmpdir(), `surf-local-screenshot-${process.pid}-${Date.now()}.png`);
+    try {
+      const { request } = await runCli(["screenshot", "--output", `local:${output}`]);
+      expect(request.params.args.savePath).toBe(output);
+      expect(fs.readFileSync(output, "utf8")).toBe("local-screenshot");
+    } finally {
+      fs.rmSync(output, { force: true });
+    }
+  });
+
+  it("preserves direct remote provider and network paths through CLI preprocessing", async () => {
+    const requests: any[] = [];
+    const credential = createRemoteCredential();
+    const server = net.createServer((socket: any) =>
+      attachAuthenticatedServer(socket, credential.stateDir, (request: any, client: any) => {
+        requests.push(request);
+        remoteTransport.writeFrame(client, {
+          id: request.id,
+          result: { content: [{ type: "text", text: "OK" }] },
+        });
+      }),
+    );
+    await new Promise<void>((resolve, reject) => {
+      server.on("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const remote = `127.0.0.1:${(server.address() as any).port}`;
+    const invoke = (args: string[]) =>
+      new Promise<number | null>((resolve, reject) => {
+        const child = spawn(
+          process.execPath,
+          [
+            "native/cli.cjs",
+            ...args,
+            "--remote",
+            remote,
+            "--remote-credential",
+            credential.credentialPath,
+          ],
+          { cwd: process.cwd(), env: createCliEnv(), stdio: ["ignore", "ignore", "pipe"] },
+        );
+        child.on("error", reject);
+        child.on("close", resolve);
+      });
+    try {
+      expect(await invoke(["chatgpt", "q", "--file", "remote:/tmp/input.txt"])).toBe(0);
+      expect(
+        await invoke([
+          "gemini",
+          "edit",
+          "--edit-image",
+          "remote:/tmp/in.png",
+          "--output",
+          "remote:/tmp/out.png",
+        ]),
+      ).toBe(0);
+      expect(await invoke(["network.export", "--output", "remote:/tmp/network.json"])).toBe(0);
+      expect(requests[0].params.args.file).toBe("remote:/tmp/input.txt");
+      expect(requests[1].params.args["edit-image"]).toBe("remote:/tmp/in.png");
+      expect(requests[1].params.args.output).toBe("remote:/tmp/out.png");
+      expect(requests[2].params.args.output).toBe("remote:/tmp/network.json");
+    } finally {
+      fs.rmSync(credential.stateDir, { recursive: true, force: true });
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("auto-captures a remote primary error through a normal screenshot transfer", async () => {
+    const credential = createRemoteCredential();
+    const captureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "surf-cli-auto-capture-"));
+    const server = net.createServer((socket: any) => {
+      const writeFrame = (message: any) => remoteTransport.writeFrame(socket, message);
+      const toolHandlers: Record<string, (message: any) => Promise<void>> = {
+        "page.text": async (message) => {
+          await writeFrame({
+            id: message.id,
+            error: { content: [{ type: "text", text: "primary failure" }] },
+          });
+        },
+        console: async (message) => {
+          await writeFrame({
+            id: message.id,
+            result: { content: [{ type: "text", text: JSON.stringify({ messages: [] }) }] },
+          });
+        },
+        screenshot: async (message) => {
+          const download = message._surfTransfers?.downloads?.[0];
+          const bytes = require("node:buffer").Buffer.from("remote-auto-capture");
+          const sha256 = require("node:crypto").createHash("sha256").update(bytes).digest("hex");
+          await writeFrame({
+            type: "transfer_begin",
+            version: 1,
+            direction: "download",
+            transferId: download.transferId,
+            size: bytes.length,
+            sha256,
+          });
+          await writeFrame({
+            type: "transfer_chunk",
+            version: 1,
+            transferId: download.transferId,
+            sequence: 0,
+            data: bytes.toString("base64"),
+          });
+          await writeFrame({
+            type: "transfer_end",
+            version: 1,
+            transferId: download.transferId,
+          });
+          await writeFrame({
+            id: message.id,
+            result: { content: [{ type: "text", text: "screenshot transferred" }] },
+          });
+        },
+      };
+      const auth = remoteTransport.createServerAuthSession({
+        socket,
+        stateDir: credential.stateDir,
+        onAuthenticated: () => undefined,
+        onError: () => socket.destroy(),
+      });
+      const parser = remoteTransport.createFrameParser({
+        onFrame: async (message: any) => {
+          if (!auth.authenticated) {
+            await auth.handle(message);
+            return;
+          }
+          const handler =
+            message.type === "tool_request" ? toolHandlers[message.params?.tool] : null;
+          await handler?.(message);
+        },
+        onError: () => socket.destroy(),
+      });
+      socket.on("data", (chunk: any) => parser.push(chunk));
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.on("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const remote = `127.0.0.1:${(server.address() as any).port}`;
+    const child = spawn(
+      process.execPath,
+      [
+        "native/cli.cjs",
+        "page.text",
+        "--auto-capture",
+        "--remote",
+        remote,
+        "--remote-credential",
+        credential.credentialPath,
+      ],
+      {
+        cwd: process.cwd(),
+        env: { ...createCliEnv(), SURF_TMP: captureRoot },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: { toString(): string }) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk: { toString(): string }) => {
+      stderr += chunk.toString();
+    });
+    const code = await new Promise<number | null>((resolve, reject) => {
       child.on("error", reject);
       child.on("close", resolve);
     });
     try {
-      expect(await invoke(["page.read"])).toBe(0);
-      expect(await invoke(["--script", scriptPath])).toBe(0);
-      expect(await invoke(["do", "page.text"])).toBe(0);
-      expect(requests.map((request) => request.params.tool)).toEqual(["page.read", "page.state", "page.text"]);
-      expect(requests.every((request) => request.params.args.remote === undefined)).toBe(true);
+      expect(code).toBe(1);
+      expect(stderr).toContain("Auto-captured:");
+      expect(stderr).not.toContain("surf-transfer-");
+      const captures = fs
+        .readdirSync(captureRoot)
+        .filter((entry: string) => entry.startsWith("surf-error-") && entry.endsWith(".png"));
+      expect(captures).toHaveLength(1);
+      expect(fs.readFileSync(path.join(captureRoot, captures[0]), "utf8")).toBe(
+        "remote-auto-capture",
+      );
+      expect(stdout).toBe("");
     } finally {
-      fs.rmSync(scriptPath, { force: true });
+      fs.rmSync(captureRoot, { recursive: true, force: true });
+      fs.rmSync(credential.stateDir, { recursive: true, force: true });
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }
   });
@@ -260,17 +574,40 @@ describe("CLI argument parsing", () => {
   it("sends stream requests over the selected TCP endpoint without forwarding remote", async () => {
     let request: any;
     let receivedRequest!: () => void;
-    const requestReceived = new Promise<void>((resolve) => { receivedRequest = resolve; });
-    const server = net.createServer((socket: any) => socket.once("data", (chunk: { toString(): string }) => {
-      request = JSON.parse(chunk.toString().trim());
-      receivedRequest();
-      socket.write('{"type":"stream_started"}\n');
-    }));
-    await new Promise<void>((resolve, reject) => { server.on("error", reject); server.listen(0, "127.0.0.1", resolve); });
-    const remote = `127.0.0.1:${(server.address() as any).port}`;
-    const child = spawn(process.execPath, ["native/cli.cjs", "console", "--stream", "--remote", remote, "--no-lock"], {
-      cwd: process.cwd(), env: createCliEnv(), stdio: ["ignore", "ignore", "pipe"],
+    const requestReceived = new Promise<void>((resolve) => {
+      receivedRequest = resolve;
     });
+    const credential = createRemoteCredential();
+    const server = net.createServer((socket: any) =>
+      attachAuthenticatedServer(socket, credential.stateDir, (message: any, client: any) => {
+        request = message;
+        receivedRequest();
+        remoteTransport.writeFrame(client, { type: "stream_started" }).catch(() => undefined);
+      }),
+    );
+    await new Promise<void>((resolve, reject) => {
+      server.on("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const remote = `127.0.0.1:${(server.address() as any).port}`;
+    const child = spawn(
+      process.execPath,
+      [
+        "native/cli.cjs",
+        "console",
+        "--stream",
+        "--remote",
+        remote,
+        "--remote-credential",
+        credential.credentialPath,
+        "--no-lock",
+      ],
+      {
+        cwd: process.cwd(),
+        env: createCliEnv(),
+        stdio: ["ignore", "ignore", "pipe"],
+      },
+    );
     try {
       await waitFor(requestReceived, 1000, "stream request");
       expect(request).toMatchObject({ type: "stream_request", streamType: "STREAM_CONSOLE" });
@@ -278,6 +615,7 @@ describe("CLI argument parsing", () => {
     } finally {
       child.kill("SIGINT");
       await new Promise<void>((resolve) => child.once("close", () => resolve()));
+      fs.rmSync(credential.stateDir, { recursive: true, force: true });
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }
   });
@@ -285,34 +623,80 @@ describe("CLI argument parsing", () => {
   it("routes MCP tool calls over the selected TCP endpoint", async () => {
     let request: any;
     let receivedRequest!: () => void;
-    const requestReceived = new Promise<void>((resolve) => { receivedRequest = resolve; });
-    const server = net.createServer((socket: any) => {
-      socket.on("error", () => {});
-      socket.once("data", (chunk: { toString(): string }) => {
-        request = JSON.parse(chunk.toString().trim());
+    const requestReceived = new Promise<void>((resolve) => {
+      receivedRequest = resolve;
+    });
+    const credential = createRemoteCredential();
+    const server = net.createServer((socket: any) =>
+      attachAuthenticatedServer(socket, credential.stateDir, (message: any, client: any) => {
+        request = message;
         receivedRequest();
-        socket.end('{"result":{"content":[{"type":"text","text":"OK"}]}}\n');
-      });
+        remoteTransport
+          .writeFrame(client, {
+            id: message.id,
+            result: { content: [{ type: "text", text: "OK" }] },
+          })
+          .finally(() => client.end())
+          .catch(() => client.end());
+      }),
+    );
+    await new Promise<void>((resolve, reject) => {
+      server.on("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
     });
-    await new Promise<void>((resolve, reject) => { server.on("error", reject); server.listen(0, "127.0.0.1", resolve); });
     const remote = `127.0.0.1:${(server.address() as any).port}`;
-    const child = spawn(process.execPath, ["native/cli.cjs", "server", "--remote", remote], {
-      cwd: process.cwd(), env: createCliEnv(), stdio: ["pipe", "pipe", "pipe"],
-    });
+    const child = spawn(
+      process.execPath,
+      [
+        "native/cli.cjs",
+        "server",
+        "--remote",
+        remote,
+        "--remote-credential",
+        credential.credentialPath,
+      ],
+      {
+        cwd: process.cwd(),
+        env: createCliEnv(),
+        stdio: ["pipe", "pipe", "pipe"],
+      },
+    );
     let initialized!: () => void;
-    const initializationComplete = new Promise<void>((resolve) => { initialized = resolve; });
+    const initializationComplete = new Promise<void>((resolve) => {
+      initialized = resolve;
+    });
     let completed!: () => void;
-    const toolCallComplete = new Promise<void>((resolve) => { completed = resolve; });
+    const toolCallComplete = new Promise<void>((resolve) => {
+      completed = resolve;
+    });
     child.stdout.on("data", (chunk: { toString(): string }) => {
       const output = chunk.toString();
-      if (output.includes('"id":1')) initialized();
-      if (output.includes('"id":2')) completed();
+      if (output.includes('"id":1')) {
+        initialized();
+      }
+      if (output.includes('"id":2')) {
+        completed();
+      }
     });
     const send = (message: object) => child.stdin.write(`${JSON.stringify(message)}\n`);
     try {
-      send({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "test", version: "1" } } });
+      send({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "test", version: "1" },
+        },
+      });
       await waitFor(initializationComplete, 1000, "MCP initialization");
-      send({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "page.text", arguments: {} } });
+      send({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "page.text", arguments: {} },
+      });
       await waitFor(requestReceived, 1000, "MCP TCP request");
       expect(request.params.tool).toBe("page.text");
       expect(JSON.stringify(request)).not.toContain("remote");
@@ -321,6 +705,7 @@ describe("CLI argument parsing", () => {
       child.stdin.end();
       child.kill("SIGTERM");
       await new Promise<void>((resolve) => child.once("close", () => resolve()));
+      fs.rmSync(credential.stateDir, { recursive: true, force: true });
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }
   });
@@ -439,13 +824,15 @@ describe("CLI argument parsing", () => {
           return;
         }
 
+        const request = JSON.parse(buffer.slice(0, lineEnd));
+        buffer = buffer.slice(lineEnd + 1);
         requestCount++;
         if (requestCount === 1) {
           firstRequestAt = Date.now();
           resolveFirstRequest();
           setTimeout(() => {
             socket.write(
-              `${JSON.stringify({ result: { content: [{ type: "text", text: "first" }] } })}\n`,
+              `${JSON.stringify({ id: request.id, result: { content: [{ type: "text", text: "first" }] } })}\n`,
             );
             socket.end();
           }, 250);
@@ -454,7 +841,7 @@ describe("CLI argument parsing", () => {
 
         secondRequestAt = Date.now();
         socket.write(
-          `${JSON.stringify({ result: { content: [{ type: "text", text: "second" }] } })}\n`,
+          `${JSON.stringify({ id: request.id, result: { content: [{ type: "text", text: "second" }] } })}\n`,
         );
         socket.end();
       });
@@ -516,13 +903,15 @@ describe("CLI argument parsing", () => {
             return;
           }
 
+          const request = JSON.parse(buffer.slice(0, lineEnd));
+          buffer = buffer.slice(lineEnd + 1);
           requestCount++;
           if (requestCount === 1) {
             firstRequestAt = Date.now();
             resolveFirstRequest();
             setTimeout(() => {
               socket.write(
-                `${JSON.stringify({ result: { content: [{ type: "text", text: "first" }] } })}\n`,
+                `${JSON.stringify({ id: request.id, result: { content: [{ type: "text", text: "first" }] } })}\n`,
               );
               socket.end();
             }, 250);
@@ -531,7 +920,7 @@ describe("CLI argument parsing", () => {
 
           secondRequestAt = Date.now();
           socket.write(
-            `${JSON.stringify({ result: { content: [{ type: "text", text: "second" }] } })}\n`,
+            `${JSON.stringify({ id: request.id, result: { content: [{ type: "text", text: "second" }] } })}\n`,
           );
           socket.end();
         });
@@ -582,7 +971,7 @@ describe("CLI argument parsing", () => {
         const request = JSON.parse(buffer.slice(0, lineEnd));
         requests.push(request);
         socket.write(
-          `${JSON.stringify({ result: { content: [{ type: "text", text: JSON.stringify({ ok: true }) }] } })}\n`,
+          `${JSON.stringify({ id: request.id, result: { content: [{ type: "text", text: JSON.stringify({ ok: true }) }] } })}\n`,
         );
         socket.end();
       });
@@ -655,6 +1044,7 @@ describe("CLI argument parsing", () => {
         request = JSON.parse(buffer.slice(0, lineEnd));
         socket.write(
           `${JSON.stringify({
+            id: request.id,
             result: {
               content: [
                 {
@@ -725,12 +1115,14 @@ describe("CLI argument parsing", () => {
           return;
         }
 
+        const request = JSON.parse(buffer.slice(0, lineEnd));
+        buffer = buffer.slice(lineEnd + 1);
         requestCount++;
         if (requestCount === 1) {
           resolveFirstRequest();
           setTimeout(() => {
             socket.write(
-              `${JSON.stringify({ result: { content: [{ type: "text", text: "first" }] } })}\n`,
+              `${JSON.stringify({ id: request.id, result: { content: [{ type: "text", text: "first" }] } })}\n`,
             );
             socket.end();
           }, 300);
@@ -739,7 +1131,7 @@ describe("CLI argument parsing", () => {
 
         resolveSecondRequest();
         socket.write(
-          `${JSON.stringify({ result: { content: [{ type: "text", text: "second" }] } })}\n`,
+          `${JSON.stringify({ id: request.id, result: { content: [{ type: "text", text: "second" }] } })}\n`,
         );
         socket.end();
       });

--- a/test/unit/client-transport.test.ts
+++ b/test/unit/client-transport.test.ts
@@ -1,0 +1,327 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+type SocketLike = {
+  on(event: string, listener: (...args: unknown[]) => void): void;
+  once(event: string, listener: (...args: unknown[]) => void): void;
+  write(value: string): void;
+  destroy(): void;
+};
+type ServerLike = {
+  listen(port: number, host: string, callback: () => void): void;
+  address(): { port: number } | string | null;
+  close(callback: () => void): void;
+};
+const net = require("node:net") as {
+  createServer(handler: (socket: SocketLike) => void): ServerLike;
+};
+const fs = require("node:fs") as {
+  existsSync(filePath: string): boolean;
+  mkdtempSync(prefix: string): string;
+  readFileSync(filePath: string, encoding: string): string;
+  rmSync(filePath: string, options: { recursive: boolean; force: boolean }): void;
+  writeFileSync(filePath: string, value: string): void;
+};
+const os = require("node:os") as { tmpdir(): string };
+const path = require("node:path") as { join(...parts: string[]): string };
+const Buffer: any = require("node:buffer").Buffer;
+const remoteAuth = require("../../native/remote-auth.cjs") as {
+  authorizeClient(label: string, outputPath: string, stateDir: string): unknown;
+};
+const { openClientTransport } = require("../../native/client-transport.cjs") as {
+  openClientTransport(
+    endpoint: Record<string, unknown>,
+    options?: { requestTimeoutMs?: number },
+  ): Promise<{
+    request(
+      message: Record<string, unknown>,
+      timeoutMs?: number,
+      transferPlan?: Record<string, unknown>,
+    ): Promise<Record<string, unknown>>;
+    close(): void;
+  }>;
+};
+const { writeFrame, createFrameParser, createServerAuthSession } =
+  require("../../native/remote-transport.cjs") as {
+    writeFrame(socket: SocketLike, value: Record<string, unknown>): Promise<void>;
+    createFrameParser(options: Record<string, unknown>): { push(chunk: unknown): void };
+    createServerAuthSession(options: Record<string, unknown>): {
+      authenticated: boolean;
+      handle(message: Record<string, unknown>): Promise<boolean>;
+      close(): void;
+    };
+  };
+
+const servers: ServerLike[] = [];
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  for (const server of servers.splice(0)) {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+  for (const tempDir of tempDirs.splice(0)) {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+async function startServer(handler: (socket: SocketLike) => void) {
+  const server = net.createServer(handler);
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("server did not bind");
+  }
+  return { kind: "local", connectionOptions: { host: "127.0.0.1", port: address.port } };
+}
+
+describe("client transport framing", () => {
+  it("requires response IDs instead of matching arbitrary id-less frames", async () => {
+    const endpoint = await startServer((socket) => {
+      socket.on("data", () => {
+        socket.write('{"type":"tool_response","result":{"ok":true}}\n');
+      });
+    });
+    const transport = await openClientTransport(endpoint, { requestTimeoutMs: 20 });
+    await expect(transport.request({ type: "tool_request", id: "request-1" })).rejects.toThrow(
+      "request timed out",
+    );
+    transport.close();
+  });
+
+  it("settles a tool response only after a preceding download end is renamed", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "surf-client-order-"));
+    tempDirs.push(stateDir);
+    const credentialPath = path.join(stateDir, "client.json");
+    remoteAuth.authorizeClient("client", credentialPath, stateDir);
+    const endpoint = await startServer((socket) => {
+      const auth = createServerAuthSession({
+        socket,
+        stateDir,
+        onAuthenticated: () => undefined,
+        onError: () => socket.destroy(),
+      });
+      const parser = createFrameParser({
+        onFrame: async (message: Record<string, unknown>) => {
+          if (!auth.authenticated) {
+            await auth.handle(message);
+            return;
+          }
+          if (message.type === "tool_request") {
+            const bytes = Buffer.from("ordered-download");
+            const sha256 = require("node:crypto").createHash("sha256").update(bytes).digest("hex");
+            await writeFrame(socket, {
+              type: "transfer_begin",
+              version: 1,
+              direction: "download",
+              transferId: "ordered-file",
+              size: bytes.length,
+              sha256,
+            });
+            await writeFrame(socket, {
+              type: "transfer_chunk",
+              version: 1,
+              transferId: "ordered-file",
+              sequence: 0,
+              data: bytes.toString("base64"),
+            });
+            socket.write(
+              `${JSON.stringify({ type: "transfer_end", version: 1, transferId: "ordered-file" })}\n${JSON.stringify({ type: "tool_response", id: message.id, result: { content: [{ type: "text", text: "done" }] } })}\n`,
+            );
+          }
+        },
+        onError: () => socket.destroy(),
+      });
+      socket.on("data", (chunk: unknown) => parser.push(chunk));
+    });
+    const destination = path.join(stateDir, "received.txt");
+    const transport = await openClientTransport({
+      kind: "remote",
+      connectionOptions: endpoint.connectionOptions,
+      credentialPath,
+    });
+    try {
+      const response = await transport.request(
+        { type: "tool_request", id: "ordered-request" },
+        30000,
+        {
+          downloads: [
+            { transferId: "ordered-file", field: "savePath", original: destination, destination },
+          ],
+          uploads: [],
+          pathRefs: [],
+        },
+      );
+      expect((response as any).result.content[0].text).toBe("done");
+      expect(fs.readFileSync(destination, "utf8")).toBe("ordered-download");
+    } finally {
+      await transport.close();
+    }
+  });
+
+  it("destroys a remote connection after request timeout and cancels downloads", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "surf-client-timeout-"));
+    tempDirs.push(stateDir);
+    const credentialPath = path.join(stateDir, "client.json");
+    remoteAuth.authorizeClient("client", credentialPath, stateDir);
+    let resolveClosed!: () => void;
+    const closed = new Promise<void>((resolve) => {
+      resolveClosed = resolve;
+    });
+    const endpoint = await startServer((socket) => {
+      socket.once("close", resolveClosed);
+      const auth = createServerAuthSession({
+        socket,
+        stateDir,
+        onAuthenticated: () => undefined,
+        onError: () => socket.destroy(),
+      });
+      const parser = createFrameParser({
+        onFrame: async (message: Record<string, unknown>) => {
+          if (!auth.authenticated) {
+            await auth.handle(message);
+          }
+        },
+        onError: () => socket.destroy(),
+      });
+      socket.on("data", (chunk: unknown) => parser.push(chunk));
+    });
+    const destination = path.join(stateDir, "timeout.png");
+    const transport = await openClientTransport(
+      {
+        kind: "remote",
+        connectionOptions: endpoint.connectionOptions,
+        credentialPath,
+      },
+      { requestTimeoutMs: 20 },
+    );
+    await expect(
+      transport.request({ type: "tool_request", id: "timeout-request" }, 20, {
+        uploads: [],
+        pathRefs: [],
+        downloads: [
+          { transferId: "timeout-download", field: "output", original: destination, destination },
+        ],
+      }),
+    ).rejects.toThrow("request timed out");
+    await closed;
+    expect(fs.existsSync(destination)).toBe(false);
+    await expect(transport.request({ type: "tool_request", id: "after-timeout" })).rejects.toThrow(
+      /closed/,
+    );
+    await transport.close();
+  });
+
+  it("times out stalled remote upload setup and destroys the connection", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "surf-client-upload-timeout-"));
+    tempDirs.push(stateDir);
+    const credentialPath = path.join(stateDir, "client.json");
+    const source = path.join(stateDir, "upload.txt");
+    fs.writeFileSync(source, "stalled upload");
+    remoteAuth.authorizeClient("client", credentialPath, stateDir);
+    let resolveClosed!: () => void;
+    const closed = new Promise<void>((resolve) => {
+      resolveClosed = resolve;
+    });
+    const endpoint = await startServer((socket) => {
+      socket.once("close", resolveClosed);
+      const auth = createServerAuthSession({
+        socket,
+        stateDir,
+        onAuthenticated: () => undefined,
+        onError: () => socket.destroy(),
+      });
+      const parser = createFrameParser({
+        onFrame: async (message: Record<string, unknown>) => {
+          if (!auth.authenticated) {
+            await auth.handle(message);
+          }
+        },
+        onError: () => socket.destroy(),
+      });
+      socket.on("data", (chunk: unknown) => parser.push(chunk));
+    });
+    const transport = await openClientTransport(
+      {
+        kind: "remote",
+        connectionOptions: endpoint.connectionOptions,
+        credentialPath,
+      },
+      { requestTimeoutMs: 20 },
+    );
+    await expect(
+      transport.request({ type: "tool_request", id: "upload-timeout" }, 20, {
+        downloads: [],
+        pathRefs: [],
+        uploads: [{ transferId: "stalled-upload", field: "file", original: source, path: source }],
+      }),
+    ).rejects.toThrow("request timed out");
+    await closed;
+    await expect(
+      transport.request({ type: "tool_request", id: "after-upload-timeout" }),
+    ).rejects.toThrow(/closed/);
+    await transport.close();
+  });
+
+  it("rejects a clean pre-auth peer close promptly", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "surf-client-close-"));
+    tempDirs.push(stateDir);
+    const credentialPath = path.join(stateDir, "client.json");
+    remoteAuth.authorizeClient("client", credentialPath, stateDir);
+    const endpoint = await startServer((socket) => {
+      socket.on("data", () => socket.destroy());
+    });
+    const started = Date.now();
+    await expect(
+      openClientTransport({
+        kind: "remote",
+        connectionOptions: endpoint.connectionOptions,
+        credentialPath,
+      }),
+    ).rejects.toThrow("closed");
+    expect(Date.now() - started).toBeLessThan(1000);
+  });
+
+  it("forwards remote auth failure and closes the endpoint exactly once", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "surf-client-transport-"));
+    tempDirs.push(stateDir);
+    const credentialPath = path.join(stateDir, "client.json");
+    remoteAuth.authorizeClient("client", credentialPath, stateDir);
+    let closeCount = 0;
+    let resolveClosed!: () => void;
+    const closed = new Promise<void>((resolve) => {
+      resolveClosed = resolve;
+    });
+    const endpoint = await startServer((socket) => {
+      socket.once("close", () => {
+        closeCount += 1;
+        resolveClosed();
+      });
+      socket.on("data", () => {
+        writeFrame(socket, { type: "auth_error", message: "rejected" });
+      });
+    });
+    const remoteEndpoint = {
+      kind: "remote",
+      connectionOptions: endpoint.connectionOptions,
+      credentialPath,
+    };
+    await expect(openClientTransport(remoteEndpoint, { requestTimeoutMs: 20 })).rejects.toThrow(
+      "rejected",
+    );
+    await closed;
+    expect(closeCount).toBe(1);
+  });
+
+  it("rejects pending requests on the extension terminal frame", async () => {
+    const endpoint = await startServer((socket) => {
+      socket.on("data", () => {
+        writeFrame(socket, { type: "extension_disconnected", message: "extension stopped" });
+      });
+    });
+    const transport = await openClientTransport(endpoint);
+    await expect(transport.request({ type: "tool_request", id: "request-1" })).rejects.toThrow(
+      "extension stopped",
+    );
+    transport.close();
+  });
+});

--- a/test/unit/doctor.test.ts
+++ b/test/unit/doctor.test.ts
@@ -11,8 +11,10 @@ declare const require: (moduleName: string) => any;
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
+const net = require("node:net");
 const { spawnSync } = require("node:child_process");
 const { parseDoctorArgs, runDoctor, windowsPathToWslPath } = require("../../native/doctor.cjs");
+const remoteAuth = require("../../native/remote-auth.cjs");
 
 function makeTempDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), "surf-doctor-test-"));
@@ -319,16 +321,67 @@ describe("surf doctor", () => {
     expect(result.stderr).toBe("");
   });
 
+  it("does not treat a TCP acceptor that never authenticates as a doctor success", async () => {
+    const stateDir = makeTempDir();
+    const credentialPath = path.join(stateDir, "client.json");
+    remoteAuth.authorizeClient("doctor-client", credentialPath, stateDir);
+    let acceptedSocket: { destroy(): void } | undefined;
+    const server = net.createServer((socket: any) => {
+      acceptedSocket = socket;
+      socket.on("error", () => undefined);
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const port = server.address().port;
+    const report = await runDoctor(
+      {
+        connectTimeoutMs: 25,
+        endpoint: {
+          kind: "remote",
+          host: "127.0.0.1",
+          port,
+          display: `127.0.0.1:${port}`,
+          credentialPath,
+          connectionOptions: { host: "127.0.0.1", port },
+        },
+      },
+      { platform: "linux", env: {} },
+    );
+    acceptedSocket?.destroy();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    fs.rmSync(stateDir, { recursive: true, force: true });
+
+    expect(report.ok).toBe(false);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "remote-connect", status: "fail", code: "EAUTH" }),
+        expect.objectContaining({ id: "remote-auth", status: "fail" }),
+      ]),
+    );
+  });
+
   it("runs remote-only diagnostics with Tailnet-specific connection guidance", async () => {
     const report = await runDoctor(
-      { endpoint: { kind: "remote", host: "browser.tailnet", port: 4321, display: "browser.tailnet:4321" } },
-      { platform: "linux", env: {}, connectEndpoint: async () => ({ ok: false, code: "ETIMEDOUT", message: "timed out" }) },
+      {
+        endpoint: {
+          kind: "remote",
+          host: "browser.tailnet",
+          port: 4321,
+          display: "browser.tailnet:4321",
+        },
+      },
+      {
+        platform: "linux",
+        env: {},
+        connectEndpoint: async () => ({ ok: false, code: "ETIMEDOUT", message: "timed out" }),
+      },
     );
 
     expect(report.manifests).toEqual([]);
-    expect(report.checks).toEqual(expect.arrayContaining([
-      expect.objectContaining({ id: "remote-connect", code: "ETIMEDOUT" }),
-    ]));
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "remote-connect", code: "ETIMEDOUT" }),
+      ]),
+    );
     expect(report.recommendations.join("\n")).toContain("tailscale ping browser.tailnet");
     expect(report.recommendations.join("\n")).toContain("ACLs/grants");
   });

--- a/test/unit/doctor.test.ts
+++ b/test/unit/doctor.test.ts
@@ -318,4 +318,18 @@ describe("surf doctor", () => {
     expect(result.stdout).toContain("Usage: surf doctor");
     expect(result.stderr).toBe("");
   });
+
+  it("runs remote-only diagnostics with Tailnet-specific connection guidance", async () => {
+    const report = await runDoctor(
+      { endpoint: { kind: "remote", host: "browser.tailnet", port: 4321, display: "browser.tailnet:4321" } },
+      { platform: "linux", env: {}, connectEndpoint: async () => ({ ok: false, code: "ETIMEDOUT", message: "timed out" }) },
+    );
+
+    expect(report.manifests).toEqual([]);
+    expect(report.checks).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "remote-connect", code: "ETIMEDOUT" }),
+    ]));
+    expect(report.recommendations.join("\n")).toContain("tailscale ping browser.tailnet");
+    expect(report.recommendations.join("\n")).toContain("ACLs/grants");
+  });
 });

--- a/test/unit/endpoint.test.ts
+++ b/test/unit/endpoint.test.ts
@@ -7,28 +7,75 @@ const { getBrowserLockDir } = require("../../native/browser-lock.cjs");
 
 describe("endpoint selection", () => {
   it("parses DNS, IPv4, and bracketed IPv6 endpoints canonically", () => {
-    expect(parseRemoteEndpoint("Host.Tailnet:1234")).toMatchObject({ host: "host.tailnet", port: 1234, display: "host.tailnet:1234", key: "tcp:host.tailnet:1234" });
+    expect(parseRemoteEndpoint("Host.Tailnet:1234")).toMatchObject({
+      host: "host.tailnet",
+      port: 1234,
+      display: "host.tailnet:1234",
+      key: "tcp:host.tailnet:1234",
+    });
     expect(parseRemoteEndpoint("127.0.0.1:1")).toMatchObject({ host: "127.0.0.1", port: 1 });
-    expect(parseRemoteEndpoint("[fd7a:115c:a1e0::1]:65535")).toMatchObject({ display: "[fd7a:115c:a1e0::1]:65535" });
-    expect(parseRemoteEndpoint("[0:0:0:0:0:0:0:1]:123").key).toBe(parseRemoteEndpoint("[::1]:123").key);
+    expect(parseRemoteEndpoint("[fd7a:115c:a1e0::1]:65535")).toMatchObject({
+      display: "[fd7a:115c:a1e0::1]:65535",
+    });
+    expect(parseRemoteEndpoint("[0:0:0:0:0:0:0:1]:123").key).toBe(
+      parseRemoteEndpoint("[::1]:123").key,
+    );
   });
 
   it("rejects ambiguous or unsafe remote endpoint syntax", () => {
-    for (const value of ["", "host", ":1", "https://host:1", "user@host:1", "host/path:1", "*:1", "0.0.0.0:1", "[::]:1", "[::1:1", "::1:1", "host:0", "host:65536"]) {
+    for (const value of [
+      "",
+      "host",
+      ":1",
+      "https://host:1",
+      "user@host:1",
+      "host/path:1",
+      "*:1",
+      "0.0.0.0:1",
+      "[::]:1",
+      "[::1:1",
+      "::1:1",
+      "host:0",
+      "host:65536",
+    ]) {
       expect(() => parseRemoteEndpoint(value)).toThrow();
     }
   });
 
   it("uses CLI remote before env and preserves local SURF_SOCKET", () => {
-    expect(selectEndpoint(["page.read", "--remote", "cli.tailnet:1234"], { SURF_REMOTE: "env.tailnet:2", SURF_SOCKET: "/tmp/local.sock" })).toMatchObject({ args: ["page.read"], endpoint: { display: "cli.tailnet:1234" } });
-    expect(selectEndpoint(["page.read"], { SURF_REMOTE: "env.tailnet:2", SURF_SOCKET: "/tmp/local.sock" }).endpoint).toMatchObject({ display: "env.tailnet:2" });
-    expect(selectEndpoint(["page.read"], { SURF_SOCKET: "/tmp/local.sock" }).endpoint).toMatchObject({ kind: "local", path: "/tmp/local.sock" });
+    expect(
+      selectEndpoint(
+        ["page.read", "--remote", "cli.tailnet:1234", "--remote-credential", "/tmp/client.json"],
+        { SURF_REMOTE: "env.tailnet:2", SURF_SOCKET: "/tmp/local.sock" },
+      ),
+    ).toMatchObject({
+      args: ["page.read"],
+      endpoint: { display: "cli.tailnet:1234", credentialPath: "/tmp/client.json" },
+    });
+    expect(
+      selectEndpoint(["page.read"], {
+        SURF_REMOTE: "env.tailnet:2",
+        SURF_REMOTE_CREDENTIAL: "/tmp/env-client.json",
+        SURF_SOCKET: "/tmp/local.sock",
+      }).endpoint,
+    ).toMatchObject({ display: "env.tailnet:2", credentialPath: "/tmp/env-client.json" });
+    expect(
+      selectEndpoint(["page.read"], { SURF_SOCKET: "/tmp/local.sock" }).endpoint,
+    ).toMatchObject({ kind: "local", path: "/tmp/local.sock" });
     expect(selectEndpoint(["page.read"], {}).endpoint.path).not.toBe(process.env.SURF_SOCKET);
     expect(() => selectEndpoint(["--remote", "a:1", "--remote", "b:2"], {})).toThrow("only");
+    expect(() => selectEndpoint(["--remote", "a:1"], {})).toThrow("credential");
+    expect(() => selectEndpoint(["--remote-credential", "/tmp/client.json"], {})).toThrow(
+      "requires a remote",
+    );
   });
 
   it("uses canonical endpoint keys for independent browser locks", () => {
-    expect(getBrowserLockDir(parseRemoteEndpoint("HOST.tailnet:9").key, "/tmp")).toBe(getBrowserLockDir(parseRemoteEndpoint("host.tailnet:9").key, "/tmp"));
-    expect(getBrowserLockDir(parseRemoteEndpoint("host.tailnet:9").key, "/tmp")).not.toBe(getBrowserLockDir(parseRemoteEndpoint("host.tailnet:10").key, "/tmp"));
+    expect(getBrowserLockDir(parseRemoteEndpoint("HOST.tailnet:9").key, "/tmp")).toBe(
+      getBrowserLockDir(parseRemoteEndpoint("host.tailnet:9").key, "/tmp"),
+    );
+    expect(getBrowserLockDir(parseRemoteEndpoint("host.tailnet:9").key, "/tmp")).not.toBe(
+      getBrowserLockDir(parseRemoteEndpoint("host.tailnet:10").key, "/tmp"),
+    );
   });
 });

--- a/test/unit/endpoint.test.ts
+++ b/test/unit/endpoint.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+declare const require: (moduleName: string) => any;
+
+const { parseRemoteEndpoint, selectEndpoint } = require("../../native/endpoint.cjs");
+const { getBrowserLockDir } = require("../../native/browser-lock.cjs");
+
+describe("endpoint selection", () => {
+  it("parses DNS, IPv4, and bracketed IPv6 endpoints canonically", () => {
+    expect(parseRemoteEndpoint("Host.Tailnet:1234")).toMatchObject({ host: "host.tailnet", port: 1234, display: "host.tailnet:1234", key: "tcp:host.tailnet:1234" });
+    expect(parseRemoteEndpoint("127.0.0.1:1")).toMatchObject({ host: "127.0.0.1", port: 1 });
+    expect(parseRemoteEndpoint("[fd7a:115c:a1e0::1]:65535")).toMatchObject({ display: "[fd7a:115c:a1e0::1]:65535" });
+    expect(parseRemoteEndpoint("[0:0:0:0:0:0:0:1]:123").key).toBe(parseRemoteEndpoint("[::1]:123").key);
+  });
+
+  it("rejects ambiguous or unsafe remote endpoint syntax", () => {
+    for (const value of ["", "host", ":1", "https://host:1", "user@host:1", "host/path:1", "*:1", "0.0.0.0:1", "[::]:1", "[::1:1", "::1:1", "host:0", "host:65536"]) {
+      expect(() => parseRemoteEndpoint(value)).toThrow();
+    }
+  });
+
+  it("uses CLI remote before env and preserves local SURF_SOCKET", () => {
+    expect(selectEndpoint(["page.read", "--remote", "cli.tailnet:1234"], { SURF_REMOTE: "env.tailnet:2", SURF_SOCKET: "/tmp/local.sock" })).toMatchObject({ args: ["page.read"], endpoint: { display: "cli.tailnet:1234" } });
+    expect(selectEndpoint(["page.read"], { SURF_REMOTE: "env.tailnet:2", SURF_SOCKET: "/tmp/local.sock" }).endpoint).toMatchObject({ display: "env.tailnet:2" });
+    expect(selectEndpoint(["page.read"], { SURF_SOCKET: "/tmp/local.sock" }).endpoint).toMatchObject({ kind: "local", path: "/tmp/local.sock" });
+    expect(selectEndpoint(["page.read"], {}).endpoint.path).not.toBe(process.env.SURF_SOCKET);
+    expect(() => selectEndpoint(["--remote", "a:1", "--remote", "b:2"], {})).toThrow("only");
+  });
+
+  it("uses canonical endpoint keys for independent browser locks", () => {
+    expect(getBrowserLockDir(parseRemoteEndpoint("HOST.tailnet:9").key, "/tmp")).toBe(getBrowserLockDir(parseRemoteEndpoint("host.tailnet:9").key, "/tmp"));
+    expect(getBrowserLockDir(parseRemoteEndpoint("host.tailnet:9").key, "/tmp")).not.toBe(getBrowserLockDir(parseRemoteEndpoint("host.tailnet:10").key, "/tmp"));
+  });
+});

--- a/test/unit/file-transfer.test.ts
+++ b/test/unit/file-transfer.test.ts
@@ -1,0 +1,680 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+const fs = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const crypto = require("node:crypto");
+const B = require("buffer").Buffer;
+
+const transfer = require("../../native/file-transfer.cjs");
+
+const tempDirs: string[] = [];
+async function tempDir() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "surf-transfer-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+function digest(data: any) {
+  return crypto.createHash("sha256").update(data).digest("hex");
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("file transfer path policy", () => {
+  it("creates private staging directories", async () => {
+    const root = await tempDir();
+    const staging = await transfer.createStagingDirectory(root, "connection");
+    expect((await fs.stat(staging)).mode & 0o777).toBe(0o700);
+    await fs.rm(staging, { recursive: true, force: true });
+  });
+
+  it("distinguishes local and absolute remote paths", () => {
+    expect(transfer.parsePathDescriptor("local:input.txt", { mode: "remote" }).kind).toBe("local");
+    expect(transfer.parsePathDescriptor("remote:/tmp/input.txt", { mode: "remote" })).toMatchObject(
+      { kind: "remote", path: "/tmp/input.txt" },
+    );
+    expect(() => transfer.parsePathDescriptor("remote:relative.txt", { mode: "remote" })).toThrow(
+      /absolute/,
+    );
+    expect(() => transfer.parsePathDescriptor("remote:/tmp/input.txt", { mode: "local" })).toThrow(
+      /local mode/,
+    );
+  });
+
+  it("rewrites bounded nested response values without mutating input", () => {
+    const original = {
+      path: "/tmp/stage",
+      nested: [{ message: "Saved /tmp/stage" }],
+      untouched: Object.create(null),
+    };
+    const rewritten = transfer.rewriteTransferPaths(original, [
+      { path: "/tmp/stage", original: "local:shot.png" },
+    ]);
+    expect(rewritten.path).toBe("local:shot.png");
+    expect(rewritten.nested[0].message).toBe("Saved local:shot.png");
+    expect(original.path).toBe("/tmp/stage");
+  });
+
+  it("preserves __proto__ as data without changing the rewritten prototype", () => {
+    const original = JSON.parse('{"__proto__":{"error":"spoofed"},"path":"/tmp/stage"}');
+    const rewritten = transfer.rewriteTransferPaths(original, [
+      { path: "/tmp/stage", original: "local:shot.png" },
+    ]);
+    expect(Object.getPrototypeOf(rewritten)).toBe(Object.prototype);
+    expect(Object.hasOwn(rewritten, "__proto__")).toBe(true);
+    expect(rewritten.error).toBeUndefined();
+    expect(rewritten.path).toBe("local:shot.png");
+  });
+
+  it("fails closed when a response exceeds rewrite limits", () => {
+    let nested: unknown = "/tmp/stage";
+    for (let depth = 0; depth < 10; depth += 1) {
+      nested = { nested };
+    }
+    expect(() =>
+      transfer.rewriteTransferPaths(nested, [{ path: "/tmp/stage", original: "local:shot.png" }]),
+    ).toThrow(/rewrite limits/);
+  });
+
+  it("normalizes local prefixes while preserving upload shape", () => {
+    const normalized = transfer.validateLocalToolPaths("upload", {
+      files: ["local:one.txt", "two.txt"],
+    });
+    expect(normalized.files).toEqual([path.resolve("one.txt"), path.resolve("two.txt")]);
+    expect(
+      transfer.validateLocalToolPaths("screenshot", { savePath: "local:shot.png" }).savePath,
+    ).toBe(path.resolve("shot.png"));
+    expect(() =>
+      transfer.validateLocalToolPaths("screenshot", { savePath: "a", output: "b" }),
+    ).toThrow(/one output/);
+    expect(() => transfer.validateLocalToolPaths("upload", { files: "remote:/tmp/x" })).toThrow(
+      /local mode/,
+    );
+    const localExport = transfer.validateLocalToolPaths("network.export", { jsonl: true });
+    expect(localExport.output).toMatch(/\.jsonl$/);
+    expect(path.isAbsolute(localExport.output)).toBe(true);
+    expect(() =>
+      transfer.validateLocalToolPaths("network.export", { har: true, jsonl: true }),
+    ).toThrow(/combine/);
+    expect(() =>
+      transfer.validateLocalToolPaths("network.export", { output: "remote:/tmp/export.json" }),
+    ).toThrow(/local mode/);
+  });
+
+  it("keeps client-local resolved paths out of host descriptors", () => {
+    const prepared = transfer.prepareRemoteTool("screenshot", { savePath: "local:shot.png" });
+    expect(prepared.pathRefs[0]).toMatchObject({
+      original: "local:shot.png",
+      path: "local:shot.png",
+      pathKind: "local",
+    });
+    expect(prepared.downloads[0].destination).toBe(path.resolve("shot.png"));
+  });
+
+  it("plans scalar provider attachments and image modes", () => {
+    const chatgpt = transfer.prepareRemoteTool("chatgpt", { query: "q", file: "local:note.txt" });
+    expect(chatgpt.pathRefs).toMatchObject([{ field: "file", kind: "input", pathKind: "local" }]);
+    expect(chatgpt.uploads).toHaveLength(1);
+    expect(() => transfer.prepareRemoteTool("chatgpt", { query: "q", file: ["a", "b"] })).toThrow(
+      /one path/,
+    );
+
+    const edit = transfer.prepareRemoteTool("gemini", {
+      query: "edit",
+      "edit-image": "local:in.png",
+    });
+    expect(edit.args.output).toBe("edited.png");
+    expect(edit.pathRefs.map((entry: any) => entry.field)).toEqual(["edit-image", "output"]);
+    expect(edit.downloads).toHaveLength(1);
+    expect(() =>
+      transfer.prepareRemoteTool("gemini", { query: "q", file: "a", output: "b" }),
+    ).toThrow(/cannot combine/);
+    expect(() => transfer.prepareRemoteTool("gemini", { query: "q", output: "b" })).toThrow(
+      /requires edit-image/,
+    );
+    expect(() =>
+      transfer.prepareRemoteTool("gemini", { query: "q", "generate-image": "a", output: "b" }),
+    ).toThrow(/own output/);
+  });
+
+  it("generates network and auto-capture client destinations", async () => {
+    const network = transfer.prepareRemoteTool("network.export", { jsonl: true });
+    expect(network.args.output).toMatch(/\.jsonl$/);
+    expect(network.downloads[0].field).toBe("output");
+    expect(() => transfer.prepareRemoteTool("network.export", { har: true, jsonl: true })).toThrow(
+      /combine/,
+    );
+    expect(() => transfer.prepareRemoteTool("network.export", { har: "yes" })).toThrow(/boolean/);
+    expect(() =>
+      transfer.prepareRemoteTool("click", { selector: "#go", autoScreenshot: "yes" }),
+    ).toThrow(/boolean/);
+    expect(() => transfer.prepareRemoteTool("tab.list", { autoScreenshot: true })).toThrow(
+      /not supported/,
+    );
+    const auto = transfer.prepareRemoteTool("click", { selector: "#go", autoScreenshot: true });
+    expect(auto.args.autoScreenshotOutput).toMatch(/\.png$/);
+    expect(auto.downloads[0].field).toBe("autoScreenshotOutput");
+    await expect(
+      transfer.materializeRemoteTool({
+        tool: "click",
+        args: {
+          selector: "#go",
+          autoScreenshot: true,
+          autoScreenshotOutput: "remote:/tmp/host.png",
+        },
+        metadata: { uploads: [], downloads: [] },
+        pathRefs: [
+          {
+            field: "autoScreenshotOutput",
+            kind: "output",
+            original: "remote:/tmp/host.png",
+            path: "/tmp/host.png",
+            pathKind: "remote",
+          },
+        ],
+      }),
+    ).rejects.toThrow(/auto screenshot metadata/);
+  });
+
+  it("materializes staged and direct provider paths with rewrites", async () => {
+    const directory = await tempDir();
+    const stagedInput = path.join(directory, "staged-input");
+    await fs.writeFile(stagedInput, "input");
+    const state = {
+      directory,
+      takeCompleted: (transferId: string) => ({ filePath: stagedInput, id: transferId }),
+    };
+    const chat = transfer.prepareRemoteTool("chatgpt", { query: "q", file: "local:note.txt" });
+    const chatMaterialized = await transfer.materializeRemoteTool({
+      tool: "chatgpt",
+      args: chat.args,
+      metadata: {
+        uploads: [
+          { transferId: "chat-upload", field: "file", original: "local:note.txt", kind: "upload" },
+        ],
+        downloads: [],
+      },
+      pathRefs: chat.pathRefs,
+      transferState: state,
+      getTransferState: async () => state,
+    });
+    expect(chatMaterialized.args.file).toBe(stagedInput);
+    expect(chatMaterialized.pathRewrites).toContainEqual({
+      path: stagedInput,
+      original: "local:note.txt",
+    });
+
+    const remoteInput = path.join(directory, "remote-input");
+    await fs.writeFile(remoteInput, "remote");
+    const direct = transfer.prepareRemoteTool("chatgpt", {
+      query: "q",
+      file: `remote:${remoteInput}`,
+    });
+    const directMaterialized = await transfer.materializeRemoteTool({
+      tool: "chatgpt",
+      args: direct.args,
+      metadata: { uploads: [], downloads: [] },
+      pathRefs: direct.pathRefs,
+      getTransferState: async () => state,
+    });
+    expect(directMaterialized.args.file).toBe(remoteInput);
+    expect(directMaterialized.outputTransfers).toEqual([]);
+
+    const edit = transfer.prepareRemoteTool("gemini", {
+      query: "edit",
+      "edit-image": "local:input.png",
+      output: `remote:${path.join(directory, "edited.png")}`,
+    });
+    const editMaterialized = await transfer.materializeRemoteTool({
+      tool: "gemini",
+      args: edit.args,
+      metadata: {
+        uploads: [
+          {
+            transferId: "edit-upload",
+            field: "edit-image",
+            original: "local:input.png",
+            kind: "upload",
+          },
+        ],
+        downloads: [],
+      },
+      pathRefs: edit.pathRefs,
+      transferState: state,
+      getTransferState: async () => state,
+    });
+    expect(editMaterialized.args["edit-image"]).toBe(stagedInput);
+    expect(editMaterialized.args.output).toBe(path.join(directory, "edited.png"));
+  });
+
+  it("rolls back a claimed Gemini input when output metadata fails", async () => {
+    const directory = await tempDir();
+    const staged = path.join(directory, "claimed-edit-input");
+    await fs.writeFile(staged, "input");
+    const plan = transfer.prepareRemoteTool("gemini", {
+      query: "edit",
+      "edit-image": "local:input.png",
+      output: "local:output.png",
+    });
+    await expect(
+      transfer.materializeRemoteTool({
+        tool: "gemini",
+        args: plan.args,
+        metadata: {
+          uploads: [
+            {
+              transferId: "edit-upload",
+              field: "edit-image",
+              original: "local:input.png",
+              kind: "upload",
+            },
+          ],
+          downloads: [],
+        },
+        pathRefs: plan.pathRefs,
+        transferState: { directory, takeCompleted: () => ({ filePath: staged }) },
+      }),
+    ).rejects.toThrow(/download descriptor/);
+    await expect(fs.access(staged)).rejects.toThrow();
+  });
+
+  it("rejects unsupported remote commands and multi-file uploads", () => {
+    expect(() => transfer.prepareRemoteTool("record", {})).toThrow(/not supported/);
+    expect(() => transfer.prepareRemoteTool("upload", { files: ["a", "b"] })).toThrow(
+      /exactly one/,
+    );
+    expect(() => transfer.prepareRemoteTool("smoke", { screenshot: "/tmp" })).toThrow(
+      /screenshots/,
+    );
+  });
+});
+
+describe("bounded upload state", () => {
+  it("streams chunks and verifies zero-byte and non-empty files", async () => {
+    const dir = await tempDir();
+    const frames: unknown[] = [];
+    const state = transfer.createTransferState({
+      directory: dir,
+      writer: { send: async (frame: unknown) => frames.push(frame) },
+      limits: { maxChunkBytes: 4, maxFileBytes: 32, maxSessionBytes: 64, maxFiles: 2 },
+    });
+    const emptyHash = digest(B.alloc(0));
+    await state.handle({
+      type: "transfer_begin",
+      version: 1,
+      direction: "upload",
+      transferId: "zero",
+      size: 0,
+      sha256: emptyHash,
+    });
+    await state.handle({ type: "transfer_end", version: 1, transferId: "zero" });
+    const complete = frames.find((frame: any) => frame.type === "transfer_complete") as any;
+    const stored = state.takeCompleted("zero");
+    expect(complete.path).toBeUndefined();
+    expect(stored.filePath).toBeTruthy();
+    expect((await fs.stat(stored.filePath)).mode & 0o777).toBe(0o600);
+    expect((await fs.stat(stored.filePath)).size).toBe(0);
+    await state.cleanup();
+  });
+
+  it("keeps cumulative file, byte, and ID quotas after completed files are claimed", async () => {
+    const countDir = await tempDir();
+    const countState = transfer.createTransferState({
+      directory: countDir,
+      writer: { send: async () => undefined },
+      limits: { maxChunkBytes: 4, maxFileBytes: 8, maxSessionBytes: 8, maxFiles: 2 },
+    });
+    const complete = async (state: any, id: string, data: any) => {
+      await state.handle({
+        type: "transfer_begin",
+        version: 1,
+        direction: "upload",
+        transferId: id,
+        size: data.length,
+        sha256: digest(data),
+      });
+      if (data.length) {
+        await state.handle({
+          type: "transfer_chunk",
+          version: 1,
+          transferId: id,
+          sequence: 0,
+          data: data.toString("base64"),
+        });
+      }
+      await state.handle({ type: "transfer_end", version: 1, transferId: id });
+      const claimed = state.takeCompleted(id);
+      await fs.rm(claimed.filePath, { force: true });
+    };
+    await complete(countState, "first", B.from("a"));
+    await complete(countState, "second", B.from("b"));
+    expect(countState.fileCount).toBe(2);
+    expect(countState.usedBytes).toBe(2);
+    await expect(
+      countState.handle({
+        type: "transfer_begin",
+        version: 1,
+        direction: "upload",
+        transferId: "first",
+        size: 0,
+        sha256: digest(B.alloc(0)),
+      }),
+    ).rejects.toThrow(/duplicate/);
+    await expect(
+      countState.handle({
+        type: "transfer_begin",
+        version: 1,
+        direction: "upload",
+        transferId: "third",
+        size: 0,
+        sha256: digest(B.alloc(0)),
+      }),
+    ).rejects.toThrow(/count limit/);
+    await countState.cleanup();
+
+    const byteDir = await tempDir();
+    const byteState = transfer.createTransferState({
+      directory: byteDir,
+      writer: { send: async () => undefined },
+      limits: { maxChunkBytes: 4, maxFileBytes: 8, maxSessionBytes: 2, maxFiles: 8 },
+    });
+    await complete(byteState, "full", B.from("ab"));
+    await expect(
+      byteState.handle({
+        type: "transfer_begin",
+        version: 1,
+        direction: "upload",
+        transferId: "over",
+        size: 1,
+        sha256: digest(B.from("c")),
+      }),
+    ).rejects.toThrow(/session byte limit/);
+    await byteState.cleanup();
+  });
+
+  it("cleans request-owned paths idempotently before completion", async () => {
+    const dir = await tempDir();
+    const first = path.join(dir, "first");
+    const second = path.join(dir, "second");
+    await fs.writeFile(first, "1");
+    await fs.writeFile(second, "2");
+    const paths = [first, second];
+    await transfer.cleanupFilePaths(paths);
+    await transfer.cleanupFilePaths(paths);
+    expect(paths).toEqual([]);
+    await expect(fs.access(first)).rejects.toThrow();
+    await expect(fs.access(second)).rejects.toThrow();
+  });
+
+  it("expires unclaimed completed uploads and supports explicit discard", async () => {
+    const dir = await tempDir();
+    const frames: any[] = [];
+    const state = transfer.createTransferState({
+      directory: dir,
+      writer: { send: async (frame: any) => frames.push(frame) },
+      completedTtlMs: 5,
+    });
+    const bytes = B.from("x");
+    await state.handle({
+      type: "transfer_begin",
+      version: 1,
+      direction: "upload",
+      transferId: "ttl",
+      size: 1,
+      sha256: digest(bytes),
+    });
+    await state.handle({
+      type: "transfer_chunk",
+      version: 1,
+      transferId: "ttl",
+      sequence: 0,
+      data: bytes.toString("base64"),
+    });
+    await state.handle({ type: "transfer_end", version: 1, transferId: "ttl" });
+    await new Promise((resolve) => setTimeout(resolve, 15));
+    expect(state.completed.size).toBe(0);
+    expect(await state.discardCompleted("ttl")).toBe(false);
+    await state.cleanup();
+  });
+
+  it("rejects invalid base64, order, size, and hash", async () => {
+    const dir = await tempDir();
+    const state = transfer.createTransferState({
+      directory: dir,
+      writer: { send: async () => undefined },
+      limits: { maxChunkBytes: 4, maxFileBytes: 32, maxSessionBytes: 64, maxFiles: 8 },
+    });
+    const hash = digest(B.from("abc"));
+    await state.handle({
+      type: "transfer_begin",
+      version: 1,
+      direction: "upload",
+      transferId: "bad-base64",
+      size: 3,
+      sha256: hash,
+    });
+    await expect(
+      state.handle({
+        version: 1,
+        type: "transfer_chunk",
+        transferId: "bad-base64",
+        sequence: 0,
+        data: "%%%=",
+      }),
+    ).rejects.toThrow(/base64/);
+    await state.handle({
+      type: "transfer_begin",
+      version: 1,
+      direction: "upload",
+      transferId: "noncanonical",
+      size: 1,
+      sha256: digest(B.from("a")),
+    });
+    await expect(
+      state.handle({
+        version: 1,
+        type: "transfer_chunk",
+        transferId: "noncanonical",
+        sequence: 0,
+        data: "YR==",
+      }),
+    ).rejects.toThrow(/canonical/);
+    await state.handle({
+      type: "transfer_begin",
+      version: 1,
+      direction: "upload",
+      transferId: "bad-order",
+      size: 3,
+      sha256: hash,
+    });
+    await expect(
+      state.handle({
+        version: 1,
+        type: "transfer_chunk",
+        transferId: "bad-order",
+        sequence: 1,
+        data: "YQ==",
+      }),
+    ).rejects.toThrow(/order/);
+    await state.handle({
+      type: "transfer_begin",
+      version: 1,
+      direction: "upload",
+      transferId: "bad-size",
+      size: 2,
+      sha256: digest(B.from("ab")),
+    });
+    await expect(
+      state.handle({
+        version: 1,
+        type: "transfer_chunk",
+        transferId: "bad-size",
+        sequence: 0,
+        data: "YWJj",
+      }),
+    ).rejects.toThrow(/declared size|exceeds/);
+    await state.handle({
+      type: "transfer_begin",
+      version: 1,
+      direction: "upload",
+      transferId: "bad-hash",
+      size: 3,
+      sha256: digest(B.from("abd")),
+    });
+    await state.handle({
+      version: 1,
+      type: "transfer_chunk",
+      transferId: "bad-hash",
+      sequence: 0,
+      data: "YWJj",
+    });
+    await expect(
+      state.handle({ version: 1, type: "transfer_end", transferId: "bad-hash" }),
+    ).rejects.toThrow(/SHA-256/);
+    await state.cleanup();
+  });
+});
+
+describe("client transfer controller", () => {
+  it("cancels reserved downloads and removes their temp files", async () => {
+    const dir = await tempDir();
+    const destination = path.join(dir, "cancelled.bin");
+    const controller = transfer.createClientTransferController({
+      writer: { send: async () => undefined },
+    });
+    await controller.expectDownload({ transferId: "cancel", destination });
+    expect(await controller.cancelDownload("cancel")).toBe(true);
+    await expect(fs.readdir(dir)).resolves.toEqual([]);
+    await controller.cleanup();
+  });
+
+  it("correlates upload control frames and atomically completes downloads", async () => {
+    const dir = await tempDir();
+    const input = path.join(dir, "input.txt");
+    const destination = path.join(dir, "received.txt");
+    const bytes = B.from("hello transfer");
+    await fs.writeFile(input, bytes, { mode: 0o600 });
+    const sent: any[] = [];
+    let controller: any;
+    const writer = {
+      send: async (frame: any) => {
+        sent.push(frame);
+        if (frame.type === "transfer_begin" && frame.direction === "upload") {
+          await controller.handle({
+            version: 1,
+            type: "transfer_ready",
+            transferId: frame.transferId,
+          });
+        }
+        if (frame.type === "transfer_end") {
+          await controller.handle({
+            version: 1,
+            type: "transfer_complete",
+            transferId: frame.transferId,
+            path: "staged",
+          });
+        }
+      },
+    };
+    controller = transfer.createClientTransferController({ writer, limits: { maxChunkBytes: 4 } });
+    const uploaded = await controller.upload(input, { transferId: "up-1", original: "input.txt" });
+    expect(uploaded.transferId).toBe("up-1");
+    expect(sent.filter((frame) => frame.type === "transfer_chunk").length).toBeGreaterThan(1);
+
+    await controller.expectDownload({ transferId: "down-1", destination });
+    const downloadBytes = B.from("downloaded");
+    await controller.handle({
+      type: "transfer_begin",
+      version: 1,
+      direction: "download",
+      transferId: "down-1",
+      size: downloadBytes.length,
+      sha256: digest(downloadBytes),
+    });
+    await controller.handle({
+      version: 1,
+      type: "transfer_chunk",
+      transferId: "down-1",
+      sequence: 0,
+      data: downloadBytes.subarray(0, 4).toString("base64"),
+    });
+    await controller.handle({
+      version: 1,
+      type: "transfer_chunk",
+      transferId: "down-1",
+      sequence: 1,
+      data: downloadBytes.subarray(4, 8).toString("base64"),
+    });
+    await controller.handle({
+      version: 1,
+      type: "transfer_chunk",
+      transferId: "down-1",
+      sequence: 2,
+      data: downloadBytes.subarray(8).toString("base64"),
+    });
+    await controller.handle({ version: 1, type: "transfer_end", transferId: "down-1" });
+    expect(await fs.readFile(destination)).toEqual(downloadBytes);
+    expect(
+      sent.some((frame) => frame.type === "transfer_complete" && frame.transferId === "down-1"),
+    ).toBe(true);
+    controller.cleanup();
+  });
+});
+
+describe("outbound transfer limits", () => {
+  it("rejects an oversized sparse file before hashing or sending", async () => {
+    const dir = await tempDir();
+    const filePath = path.join(dir, "oversized.bin");
+    await fs.writeFile(filePath, "");
+    await fs.truncate(filePath, 256 * 1024 * 1024 + 1);
+    const frames: unknown[] = [];
+    const state = transfer.createTransferState({
+      directory: dir,
+      writer: { send: async (frame: unknown) => frames.push(frame) },
+    });
+    await expect(
+      transfer.streamFileDownload({
+        writer: { send: async (frame: unknown) => frames.push(frame) },
+        state,
+        filePath,
+        transferId: "oversized",
+      }),
+    ).rejects.toThrow(/file size limit/);
+    expect(frames).toEqual([]);
+    expect(state.fileCount).toBe(0);
+    expect(state.usedBytes).toBe(0);
+    await state.cleanup();
+  });
+});
+
+describe("atomic downloads", () => {
+  it("writes mode 0600 and removes partial destinations on failure", async () => {
+    const dir = await tempDir();
+    const destination = path.join(dir, "nested", "output.bin");
+    const bytes = B.from("download");
+    await fs.mkdir(path.dirname(destination), { recursive: true });
+    await fs.writeFile(destination, "old destination");
+    await transfer.writeAtomicDownload(
+      destination,
+      (async function* () {
+        yield bytes.subarray(0, 3);
+        yield bytes.subarray(3);
+      })(),
+      { size: bytes.length, sha256: digest(bytes) },
+    );
+    expect(await fs.readFile(destination)).toEqual(bytes);
+    expect((await fs.stat(destination)).mode & 0o777).toBe(0o600);
+    await expect(
+      transfer.writeAtomicDownload(
+        path.join(dir, "bad.bin"),
+        (async function* () {
+          yield B.from("bad");
+        })(),
+        { size: 4, sha256: digest(B.from("bad!")) },
+      ),
+    ).rejects.toThrow(/mismatch/);
+    await expect(fs.access(path.join(dir, "bad.bin"))).rejects.toThrow();
+  });
+});

--- a/test/unit/host-sessions.test.ts
+++ b/test/unit/host-sessions.test.ts
@@ -1,0 +1,297 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const {
+  AUTHENTICATED_IDLE_MS,
+  HostSessionManager,
+  LEASE_IDLE_MS,
+  MAX_CONNECTIONS,
+  MAX_PRINCIPAL_CONNECTIONS,
+  MAX_REMOTE_CONNECTIONS,
+  MAX_WAITERS,
+  QUEUE_TIMEOUT_MS,
+  resolveRequestDeadlineMs,
+} = require("../../native/host-sessions.cjs") as {
+  HostSessionManager: new (
+    options?: Record<string, unknown>,
+  ) => {
+    admit(socket: object, isRemote: boolean): Record<string, unknown>;
+    authenticate(
+      context: Record<string, unknown>,
+      principal: { clientId: string; label: string },
+    ): void;
+    beginRequest(
+      context: Record<string, unknown>,
+      options: { id: string; tool: string; deadlineMs?: number },
+    ): Promise<Record<string, unknown>>;
+    canRespond(context: Record<string, unknown>, id: string): boolean;
+    complete(context: Record<string, unknown>, id: string, outcome?: string): void;
+    close(context: Record<string, unknown>): void;
+    canStartStream(context: Record<string, unknown>): boolean;
+    stopStream(context: Record<string, unknown>): void;
+  };
+  AUTHENTICATED_IDLE_MS: number;
+  LEASE_IDLE_MS: number;
+  MAX_CONNECTIONS: number;
+  MAX_PRINCIPAL_CONNECTIONS: number;
+  MAX_REMOTE_CONNECTIONS: number;
+  MAX_WAITERS: number;
+  QUEUE_TIMEOUT_MS: number;
+  resolveRequestDeadlineMs(tool: string, args?: Record<string, unknown>): number;
+};
+
+const contexts: Array<Record<string, unknown>> = [];
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
+
+function manager() {
+  return new HostSessionManager();
+}
+
+function connection(sessions: ReturnType<typeof manager>, remote = false) {
+  const context = sessions.admit({}, remote);
+  contexts.push(context);
+  if (remote) {
+    sessions.authenticate(context, { clientId: `client-${contexts.length}`, label: "client" });
+  }
+  return context;
+}
+
+describe("host session manager", () => {
+  it("serializes FIFO leases and rejects duplicate/in-flight IDs", async () => {
+    const sessions = manager();
+    const first = connection(sessions);
+    const second = connection(sessions);
+    const firstRequest = await sessions.beginRequest(first, { id: "one", tool: "one" });
+    await expect(sessions.beginRequest(first, { id: "two", tool: "two" })).rejects.toThrow(
+      "in-flight",
+    );
+    sessions.complete(first, "one");
+    const secondRequest = await sessions.beginRequest(second, { id: "two", tool: "two" });
+    expect(firstRequest.id).toBe("one");
+    expect(secondRequest.id).toBe("two");
+    sessions.complete(second, "two");
+    await expect(sessions.beginRequest(second, { id: "two", tool: "two" })).rejects.toThrow(
+      "duplicate",
+    );
+    sessions.close(first);
+    sessions.close(second);
+  });
+
+  it("retains an abandoned lease until the active request settles", async () => {
+    const sessions = manager();
+    const first = connection(sessions);
+    const second = connection(sessions);
+    await sessions.beginRequest(first, { id: "active", tool: "navigate" });
+    sessions.close(first);
+    let granted = false;
+    const waiting = sessions.beginRequest(second, { id: "queued", tool: "click" }).then(() => {
+      granted = true;
+    });
+    await Promise.resolve();
+    expect(granted).toBe(false);
+    sessions.complete(first, "active", "abandoned-completed");
+    await waiting;
+    expect(granted).toBe(true);
+    sessions.complete(second, "queued");
+    sessions.close(second);
+  });
+
+  it("closes authenticated idle connections after fifteen seconds", () => {
+    vi.useFakeTimers();
+    const sessions = manager();
+    const socket = { destroy: vi.fn() };
+    const context = sessions.admit(socket, true);
+    sessions.authenticate(context, { clientId: "idle", label: "idle" });
+    vi.advanceTimersByTime(AUTHENTICATED_IDLE_MS);
+    expect(socket.destroy).toHaveBeenCalledOnce();
+    sessions.close(context);
+  });
+
+  it("keeps an authenticated stream alive past the no-work deadline", () => {
+    vi.useFakeTimers();
+    const sessions = manager();
+    const socket = { destroy: vi.fn() };
+    const context = sessions.admit(socket, true);
+    sessions.authenticate(context, { clientId: "stream-client", label: "stream-client" });
+    expect(sessions.canStartStream(context)).toBe(true);
+    vi.advanceTimersByTime(AUTHENTICATED_IDLE_MS);
+    expect(socket.destroy).not.toHaveBeenCalled();
+    sessions.close(context);
+  });
+
+  it("releases an idle lease after five seconds", async () => {
+    vi.useFakeTimers();
+    const sessions = manager();
+    const first = connection(sessions);
+    const second = connection(sessions);
+    await sessions.beginRequest(first, { id: "one", tool: "one" });
+    sessions.complete(first, "one");
+    const waiting = sessions.beginRequest(second, { id: "two", tool: "two" });
+    await vi.advanceTimersByTimeAsync(LEASE_IDLE_MS);
+    await waiting;
+    sessions.complete(second, "two");
+    sessions.close(first);
+    sessions.close(second);
+  });
+
+  it("rejects oversized audit-controlled request fields before queueing", async () => {
+    const sessions = manager();
+    const context = connection(sessions);
+    await expect(
+      sessions.beginRequest(context, { id: "x".repeat(129), tool: "click" }),
+    ).rejects.toThrow("too long");
+    await expect(
+      sessions.beginRequest(context, { id: "ok", tool: "x".repeat(129) }),
+    ).rejects.toThrow("too long");
+    sessions.close(context);
+  });
+
+  it("enforces total and remote connection caps", () => {
+    const sessions = manager();
+    const localContexts = Array.from({ length: MAX_CONNECTIONS }, () => sessions.admit({}, false));
+    expect(() => sessions.admit({}, false)).toThrow("maximum client connections");
+    for (const context of localContexts) {
+      sessions.close(context);
+    }
+
+    const remoteSessions = manager();
+    const remoteContexts = Array.from({ length: MAX_REMOTE_CONNECTIONS }, () =>
+      remoteSessions.admit({}, true),
+    );
+    expect(() => remoteSessions.admit({}, true)).toThrow("maximum remote connections");
+    for (const context of remoteContexts) {
+      remoteSessions.close(context);
+    }
+  });
+
+  it("aborts and tombstones at the hard deadline until cleanup settles", async () => {
+    vi.useFakeTimers();
+    let timedOut: Record<string, unknown> | undefined;
+    const sessions = new HostSessionManager({
+      onTimeout: (_context: Record<string, unknown>, request: Record<string, unknown>) => {
+        timedOut = request;
+      },
+    });
+    const context = connection(sessions);
+    await sessions.beginRequest(context, { id: "deadline", tool: "click", deadlineMs: 10 });
+    await vi.advanceTimersByTimeAsync(10);
+    expect(timedOut?.signal).toMatchObject({ aborted: true });
+    expect(timedOut?.tombstoned).toBe(true);
+    expect(sessions.canRespond(context, "deadline")).toBe(true);
+    sessions.complete(context, "deadline", "cleanup-settled");
+    sessions.close(context);
+  });
+
+  it("times out queued lease requests", async () => {
+    vi.useFakeTimers();
+    const sessions = manager();
+    const first = connection(sessions);
+    const second = connection(sessions);
+    await sessions.beginRequest(first, { id: "held", tool: "click" });
+    const waiting = sessions.beginRequest(second, { id: "queued", tool: "click" });
+    const assertion = expect(waiting).rejects.toThrow("timed out waiting");
+    await vi.advanceTimersByTimeAsync(QUEUE_TIMEOUT_MS);
+    await assertion;
+    sessions.complete(first, "held");
+    sessions.close(first);
+    sessions.close(second);
+  });
+
+  it("does not audit queued disconnects as abandoned active work", async () => {
+    const events: Array<Record<string, unknown>> = [];
+    const sessions = new HostSessionManager({
+      audit: (event: Record<string, unknown>) => events.push(event),
+    });
+    const first = connection(sessions);
+    const second = connection(sessions);
+    await sessions.beginRequest(first, { id: "held", tool: "click" });
+    const queued = sessions
+      .beginRequest(second, { id: "queued", tool: "click" })
+      .catch(() => undefined);
+    await Promise.resolve();
+    sessions.close(second);
+    await queued;
+    expect(
+      events.some(
+        (event) =>
+          event.outcome === "abandoned" &&
+          (event.request as Record<string, unknown>)?.id === "queued",
+      ),
+    ).toBe(false);
+    sessions.complete(first, "held");
+    sessions.close(first);
+  });
+
+  it("resolves browser and provider deadlines in milliseconds with grace and a cap", () => {
+    expect(resolveRequestDeadlineMs("click")).toBe(60000);
+    expect(resolveRequestDeadlineMs("chatgpt")).toBe(2700000 + 60000);
+    expect(resolveRequestDeadlineMs("gemini", { timeout: 10 })).toBe(10000 + 60000);
+    expect(resolveRequestDeadlineMs("aistudio.build")).toBe(600000 + 60000);
+    expect(resolveRequestDeadlineMs("chatgpt", { timeout: 999999 })).toBe(50 * 60 * 1000);
+  });
+
+  it("enforces stream-only and per-principal stream caps", async () => {
+    const sessions = manager();
+    const local = sessions.admit({}, false);
+    expect(sessions.canStartStream(local)).toBe(true);
+    expect(sessions.canStartStream(local)).toBe(false);
+    sessions.stopStream(local);
+    expect(sessions.canStartStream(local)).toBe(true);
+    sessions.close(local);
+    const first = sessions.admit({}, true);
+    const second = sessions.admit({}, true);
+    const third = sessions.admit({}, true);
+    sessions.authenticate(first, { clientId: "stream-principal", label: "stream" });
+    sessions.authenticate(second, { clientId: "stream-principal", label: "stream" });
+    sessions.authenticate(third, { clientId: "stream-principal", label: "stream" });
+    expect(sessions.canStartStream(first)).toBe(true);
+    expect(sessions.canStartStream(second)).toBe(true);
+    expect(sessions.canStartStream(third)).toBe(false);
+    await expect(sessions.beginRequest(first, { id: "blocked", tool: "click" })).rejects.toThrow(
+      "stream connection",
+    );
+    sessions.close(first);
+    sessions.close(second);
+    sessions.close(third);
+  });
+
+  it("enforces principal and waiter caps", async () => {
+    const sessions = manager();
+    const principal = connection(sessions, true);
+    sessions.close(principal);
+    const principals = Array.from({ length: MAX_PRINCIPAL_CONNECTIONS }, (_, index) => {
+      const ctx = sessions.admit({}, true);
+      sessions.authenticate(ctx, { clientId: "same", label: `same-${index}` });
+      return ctx;
+    });
+    expect(() =>
+      sessions.authenticate(sessions.admit({}, true), { clientId: "same", label: "overflow" }),
+    ).toThrow("maximum connections");
+    for (const ctx of principals) {
+      sessions.close(ctx);
+    }
+
+    const first = connection(sessions);
+    await sessions.beginRequest(first, { id: "held", tool: "held" });
+    const waiters = [];
+    const waiterContexts = [];
+    for (let index = 0; index < MAX_WAITERS; index += 1) {
+      const ctx = connection(sessions);
+      waiterContexts.push(ctx);
+      waiters.push(sessions.beginRequest(ctx, { id: `queued-${index}`, tool: "queued" }));
+    }
+    await expect(
+      sessions.beginRequest(connection(sessions), { id: "overflow", tool: "queued" }),
+    ).rejects.toThrow("queue is full");
+    sessions.complete(first, "held", "test-release");
+    sessions.close(first);
+    for (const ctx of waiterContexts) {
+      sessions.close(ctx);
+    }
+    for (const promise of waiters) {
+      promise.catch(() => undefined);
+    }
+  });
+});

--- a/test/unit/mcp-server.test.ts
+++ b/test/unit/mcp-server.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+const { TOOL_SCHEMAS } = require("../../native/mcp-server.cjs") as {
+  TOOL_SCHEMAS: Record<string, { schema: Record<string, unknown> }>;
+};
+
+describe("MCP file-backed tool schemas", () => {
+  it("exposes fixed ChatGPT, Gemini, and network export fields", () => {
+    expect(Object.keys(TOOL_SCHEMAS.chatgpt.schema)).toEqual(
+      expect.arrayContaining(["query", "model", "with-page", "file", "timeout"]),
+    );
+    expect(Object.keys(TOOL_SCHEMAS.gemini.schema)).toEqual(
+      expect.arrayContaining([
+        "query",
+        "model",
+        "with-page",
+        "file",
+        "edit-image",
+        "generate-image",
+        "output",
+        "youtube",
+        "aspect-ratio",
+        "timeout",
+      ]),
+    );
+    expect(Object.keys(TOOL_SCHEMAS["network.export"].schema)).toEqual(
+      expect.arrayContaining(["output", "jsonl", "har"]),
+    );
+  });
+});

--- a/test/unit/native-host-installer.test.ts
+++ b/test/unit/native-host-installer.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 declare const process: {
   execPath: string;
   platform: string;
+  env: Record<string, string | undefined>;
 };
 declare const require: (moduleName: string) => any;
 
@@ -10,7 +11,11 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 const { spawnSync } = require("node:child_process");
-const { createWrapper, writeManifest, assertListenTargetSupported } = require("../../scripts/install-native-host.cjs");
+const {
+  createWrapper,
+  writeManifest,
+  assertListenTargetSupported,
+} = require("../../scripts/install-native-host.cjs");
 const { parseListenEndpoint } = require("../../native/listener.cjs");
 
 const extensionA = "abcdefghijklmnopabcdefghijklmnop";
@@ -22,7 +27,7 @@ function makeTempDir() {
 
 function envWithoutListen() {
   const env = { ...process.env };
-  delete env.SURF_LISTEN;
+  env.SURF_LISTEN = undefined;
   return env;
 }
 
@@ -74,7 +79,10 @@ describe("native host installer", () => {
     const tempDir = makeTempDir();
     const nodePath = process.execPath;
     const hostPath = path.join(tempDir, "host.cjs");
-    fs.writeFileSync(hostPath, "process.stdout.write(JSON.stringify({ listen: process.env.SURF_LISTEN, args: process.argv.slice(2) }));");
+    fs.writeFileSync(
+      hostPath,
+      "process.stdout.write(JSON.stringify({ listen: process.env.SURF_LISTEN, args: process.argv.slice(2) }));",
+    );
 
     const nativeWrapperPath = createWrapper(tempDir, nodePath, hostPath, "linux");
     const nativeWrapperContent = fs.readFileSync(nativeWrapperPath, "utf8");
@@ -82,18 +90,36 @@ describe("native host installer", () => {
       expect(nativeWrapperContent).toContain(`"${hostPath}" %*`);
     } else {
       expect(nativeWrapperContent).toContain(`"${hostPath}" "$@"`);
-      const persisted = spawnSync(nativeWrapperPath, ["one"], { encoding: "utf8", env: envWithoutListen() });
+      const persisted = spawnSync(nativeWrapperPath, ["one"], {
+        encoding: "utf8",
+        env: envWithoutListen(),
+      });
       expect(JSON.parse(persisted.stdout)).toEqual({ listen: undefined, args: ["one"] });
 
-      const configuredWrapper = createWrapper(tempDir, nodePath, hostPath, "linux", "100.64.1.2:4321");
-      const defaulted = spawnSync(configuredWrapper, ["two"], { encoding: "utf8", env: envWithoutListen() });
+      const configuredWrapper = createWrapper(
+        tempDir,
+        nodePath,
+        hostPath,
+        "linux",
+        "100.64.1.2:4321",
+      );
+      const defaulted = spawnSync(configuredWrapper, ["two"], {
+        encoding: "utf8",
+        env: envWithoutListen(),
+      });
       expect(JSON.parse(defaulted.stdout)).toEqual({ listen: "100.64.1.2:4321", args: ["two"] });
-      const overridden = spawnSync(configuredWrapper, ["three"], { encoding: "utf8", env: { ...envWithoutListen(), SURF_LISTEN: "100.64.1.3:4321" } });
+      const overridden = spawnSync(configuredWrapper, ["three"], {
+        encoding: "utf8",
+        env: { ...envWithoutListen(), SURF_LISTEN: "100.64.1.3:4321" },
+      });
       expect(JSON.parse(overridden.stdout)).toEqual({ listen: "100.64.1.3:4321", args: ["three"] });
 
       const reinstalled = createWrapper(tempDir, nodePath, hostPath, "linux");
       expect(fs.readFileSync(reinstalled, "utf8")).not.toContain("SURF_LISTEN");
-      const inherited = spawnSync(reinstalled, ["four"], { encoding: "utf8", env: { ...envWithoutListen(), SURF_LISTEN: "100.64.1.4:4321" } });
+      const inherited = spawnSync(reinstalled, ["four"], {
+        encoding: "utf8",
+        env: { ...envWithoutListen(), SURF_LISTEN: "100.64.1.4:4321" },
+      });
       expect(JSON.parse(inherited.stdout)).toEqual({ listen: "100.64.1.4:4321", args: ["four"] });
     }
 
@@ -105,29 +131,65 @@ describe("native host installer", () => {
   });
 
   it("validates Tailnet-only listener endpoints and persists the wrapper setting", () => {
-    expect(parseListenEndpoint("100.64.1.2:4321")).toMatchObject({ host: "100.64.1.2", port: 4321 });
-    expect(parseListenEndpoint("[fd7a:115c:a1e0::1]:4321").display).toBe("[fd7a:115c:a1e0::1]:4321");
-    for (const value of ["localhost:1", "127.0.0.1:1", "0.0.0.0:1", "host:1", "100.1.1.1:1", "100.64.1.2:0"]) expect(() => parseListenEndpoint(value)).toThrow();
+    expect(parseListenEndpoint("100.64.1.2:4321")).toMatchObject({
+      host: "100.64.1.2",
+      port: 4321,
+    });
+    expect(parseListenEndpoint("[fd7a:115c:a1e0::1]:4321").display).toBe(
+      "[fd7a:115c:a1e0::1]:4321",
+    );
+    for (const value of [
+      "localhost:1",
+      "127.0.0.1:1",
+      "0.0.0.0:1",
+      "host:1",
+      "100.1.1.1:1",
+      "100.64.1.2:0",
+    ]) {
+      expect(() => parseListenEndpoint(value)).toThrow();
+    }
     const tempDir = makeTempDir();
-    const wrapper = createWrapper(tempDir, process.execPath, "/tmp/host.cjs", "linux", "100.64.1.2:4321");
+    const wrapper = createWrapper(
+      tempDir,
+      process.execPath,
+      "/tmp/host.cjs",
+      "linux",
+      "100.64.1.2:4321",
+    );
     expect(fs.readFileSync(wrapper, "utf8")).toContain("SURF_LISTEN:=100.64.1.2:4321");
     const clearedWrapper = createWrapper(tempDir, process.execPath, "/tmp/host.cjs", "linux");
     expect(fs.readFileSync(clearedWrapper, "utf8")).not.toContain("unset SURF_LISTEN");
   });
 
   it("accepts only inclusive Tailscale IPv4 and IPv6 CIDR boundaries", () => {
-    for (const host of ["100.64.0.0", "100.127.255.255"]) expect(parseListenEndpoint(`${host}:1`).host).toBe(host);
-    for (const host of ["100.63.255.255", "100.128.0.0"]) expect(() => parseListenEndpoint(`${host}:1`)).toThrow();
-    for (const host of ["fd7a:115c:a1e0::", "fd7a:115c:a1e0:ffff:ffff:ffff:ffff:ffff"]) expect(parseListenEndpoint(`[${host}]:1`).host).toBe(host);
-    for (const host of ["fd7a:115c:a1df:ffff::1", "fd7a:115c:a1e1::1"]) expect(() => parseListenEndpoint(`[${host}]:1`)).toThrow();
+    for (const host of ["100.64.0.0", "100.127.255.255"]) {
+      expect(parseListenEndpoint(`${host}:1`).host).toBe(host);
+    }
+    for (const host of ["100.63.255.255", "100.128.0.0"]) {
+      expect(() => parseListenEndpoint(`${host}:1`)).toThrow();
+    }
+    for (const host of ["fd7a:115c:a1e0::", "fd7a:115c:a1e0:ffff:ffff:ffff:ffff:ffff"]) {
+      expect(parseListenEndpoint(`[${host}]:1`).host).toBe(host);
+    }
+    for (const host of ["fd7a:115c:a1df:ffff::1", "fd7a:115c:a1e1::1"]) {
+      expect(() => parseListenEndpoint(`[${host}]:1`)).toThrow();
+    }
   });
 
   it("rejects missing and Windows/WSL listener configuration explicitly", () => {
-    const missing = spawnSync(process.execPath, ["scripts/install-native-host.cjs", extensionA, "--listen"], { encoding: "utf8" });
+    const missing = spawnSync(
+      process.execPath,
+      ["scripts/install-native-host.cjs", extensionA, "--listen"],
+      { encoding: "utf8" },
+    );
     expect(missing.status).toBe(1);
     expect(missing.stderr).toContain("--listen requires a Tailnet IP and port");
-    expect(() => assertListenTargetSupported("100.64.1.2:4321", "win32")).toThrow("Windows native-host wrappers");
-    expect(() => assertListenTargetSupported("100.64.1.2:4321", "wsl-windows")).toThrow("Windows native-host wrappers");
+    expect(() => assertListenTargetSupported("100.64.1.2:4321", "win32")).toThrow(
+      "Windows native-host wrappers",
+    );
+    expect(() => assertListenTargetSupported("100.64.1.2:4321", "wsl-windows")).toThrow(
+      "Windows native-host wrappers",
+    );
   });
 
   it.runIf(process.platform !== "linux")(

--- a/test/unit/native-host-installer.test.ts
+++ b/test/unit/native-host-installer.test.ts
@@ -10,7 +10,8 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 const { spawnSync } = require("node:child_process");
-const { createWrapper, writeManifest } = require("../../scripts/install-native-host.cjs");
+const { createWrapper, writeManifest, assertListenTargetSupported } = require("../../scripts/install-native-host.cjs");
+const { parseListenEndpoint } = require("../../native/listener.cjs");
 
 const extensionA = "abcdefghijklmnopabcdefghijklmnop";
 const extensionB = "bcdefghijklmnopabcdefghijklmnopa";
@@ -19,7 +20,23 @@ function makeTempDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), "surf-native-host-test-"));
 }
 
+function envWithoutListen() {
+  const env = { ...process.env };
+  delete env.SURF_LISTEN;
+  return env;
+}
+
 describe("native host installer", () => {
+  it("documents the Tailnet-only listener option", () => {
+    const result = spawnSync(process.execPath, ["scripts/install-native-host.cjs", "--help"], {
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("--listen <tailscale-ip>:<port>");
+    expect(result.stdout).toContain("Tailnet-only listener endpoint");
+  });
+
   it("merges manifest allowed_origins without dropping existing fields", () => {
     const tempDir = makeTempDir();
     const manifestPath = path.join(tempDir, "surf.browser.host.json");
@@ -53,11 +70,11 @@ describe("native host installer", () => {
     ]);
   });
 
-  it("forwards wrapper arguments for POSIX and WSL Windows wrappers", () => {
+  it("executes POSIX wrappers with persisted listen defaults and inherited overrides", () => {
     const tempDir = makeTempDir();
     const nodePath = process.execPath;
     const hostPath = path.join(tempDir, "host.cjs");
-    fs.writeFileSync(hostPath, "");
+    fs.writeFileSync(hostPath, "process.stdout.write(JSON.stringify({ listen: process.env.SURF_LISTEN, args: process.argv.slice(2) }));");
 
     const nativeWrapperPath = createWrapper(tempDir, nodePath, hostPath, "linux");
     const nativeWrapperContent = fs.readFileSync(nativeWrapperPath, "utf8");
@@ -65,6 +82,19 @@ describe("native host installer", () => {
       expect(nativeWrapperContent).toContain(`"${hostPath}" %*`);
     } else {
       expect(nativeWrapperContent).toContain(`"${hostPath}" "$@"`);
+      const persisted = spawnSync(nativeWrapperPath, ["one"], { encoding: "utf8", env: envWithoutListen() });
+      expect(JSON.parse(persisted.stdout)).toEqual({ listen: undefined, args: ["one"] });
+
+      const configuredWrapper = createWrapper(tempDir, nodePath, hostPath, "linux", "100.64.1.2:4321");
+      const defaulted = spawnSync(configuredWrapper, ["two"], { encoding: "utf8", env: envWithoutListen() });
+      expect(JSON.parse(defaulted.stdout)).toEqual({ listen: "100.64.1.2:4321", args: ["two"] });
+      const overridden = spawnSync(configuredWrapper, ["three"], { encoding: "utf8", env: { ...envWithoutListen(), SURF_LISTEN: "100.64.1.3:4321" } });
+      expect(JSON.parse(overridden.stdout)).toEqual({ listen: "100.64.1.3:4321", args: ["three"] });
+
+      const reinstalled = createWrapper(tempDir, nodePath, hostPath, "linux");
+      expect(fs.readFileSync(reinstalled, "utf8")).not.toContain("SURF_LISTEN");
+      const inherited = spawnSync(reinstalled, ["four"], { encoding: "utf8", env: { ...envWithoutListen(), SURF_LISTEN: "100.64.1.4:4321" } });
+      expect(JSON.parse(inherited.stdout)).toEqual({ listen: "100.64.1.4:4321", args: ["four"] });
     }
 
     const cmdPath = createWrapper(tempDir, nodePath, hostPath, "wsl-windows");
@@ -72,6 +102,32 @@ describe("native host installer", () => {
       `"${hostPath}" %*`,
     );
     expect(cmdPath).toBeTruthy();
+  });
+
+  it("validates Tailnet-only listener endpoints and persists the wrapper setting", () => {
+    expect(parseListenEndpoint("100.64.1.2:4321")).toMatchObject({ host: "100.64.1.2", port: 4321 });
+    expect(parseListenEndpoint("[fd7a:115c:a1e0::1]:4321").display).toBe("[fd7a:115c:a1e0::1]:4321");
+    for (const value of ["localhost:1", "127.0.0.1:1", "0.0.0.0:1", "host:1", "100.1.1.1:1", "100.64.1.2:0"]) expect(() => parseListenEndpoint(value)).toThrow();
+    const tempDir = makeTempDir();
+    const wrapper = createWrapper(tempDir, process.execPath, "/tmp/host.cjs", "linux", "100.64.1.2:4321");
+    expect(fs.readFileSync(wrapper, "utf8")).toContain("SURF_LISTEN:=100.64.1.2:4321");
+    const clearedWrapper = createWrapper(tempDir, process.execPath, "/tmp/host.cjs", "linux");
+    expect(fs.readFileSync(clearedWrapper, "utf8")).not.toContain("unset SURF_LISTEN");
+  });
+
+  it("accepts only inclusive Tailscale IPv4 and IPv6 CIDR boundaries", () => {
+    for (const host of ["100.64.0.0", "100.127.255.255"]) expect(parseListenEndpoint(`${host}:1`).host).toBe(host);
+    for (const host of ["100.63.255.255", "100.128.0.0"]) expect(() => parseListenEndpoint(`${host}:1`)).toThrow();
+    for (const host of ["fd7a:115c:a1e0::", "fd7a:115c:a1e0:ffff:ffff:ffff:ffff:ffff"]) expect(parseListenEndpoint(`[${host}]:1`).host).toBe(host);
+    for (const host of ["fd7a:115c:a1df:ffff::1", "fd7a:115c:a1e1::1"]) expect(() => parseListenEndpoint(`[${host}]:1`)).toThrow();
+  });
+
+  it("rejects missing and Windows/WSL listener configuration explicitly", () => {
+    const missing = spawnSync(process.execPath, ["scripts/install-native-host.cjs", extensionA, "--listen"], { encoding: "utf8" });
+    expect(missing.status).toBe(1);
+    expect(missing.stderr).toContain("--listen requires a Tailnet IP and port");
+    expect(() => assertListenTargetSupported("100.64.1.2:4321", "win32")).toThrow("Windows native-host wrappers");
+    expect(() => assertListenTargetSupported("100.64.1.2:4321", "wsl-windows")).toThrow("Windows native-host wrappers");
   });
 
   it.runIf(process.platform !== "linux")(

--- a/test/unit/network-export.test.ts
+++ b/test/unit/network-export.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+const fs = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const exporter = require("../../native/network-export.cjs");
+
+const tempDirs: string[] = [];
+
+async function tempDir() {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "surf-network-export-test-"));
+  tempDirs.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe("network export serialization", () => {
+  const entries = [
+    {
+      id: "r-1",
+      ts: 1700000000000,
+      method: "POST",
+      url: "https://example.test/api",
+      origin: "https://example.test",
+      requestHeaders: { accept: "application/json" },
+      requestBody: "body",
+      requestBodySize: 4,
+      status: 201,
+      statusText: "Created",
+      responseHeaders: { "content-type": "application/json" },
+      responseBody: '{"ok":true}',
+      responseBodySize: 11,
+      mimeType: "application/json",
+      duration: 25,
+      ttfb: 10,
+      _requestId: "secret-request-id",
+      _responseReceived: true,
+      _loadingFinished: true,
+    },
+  ];
+
+  it("strips internal fields from JSON and JSONL", () => {
+    const json = JSON.parse(exporter.serializeNetworkExport(entries, "json"));
+    expect(json[0]).not.toHaveProperty("_requestId");
+    expect(json[0]).not.toHaveProperty("_responseReceived");
+    expect(json[0]).not.toHaveProperty("_loadingFinished");
+    const jsonl = exporter.serializeNetworkExport(entries, "jsonl");
+    expect(jsonl.endsWith("\n")).toBe(true);
+    expect(JSON.parse(jsonl.trim()).url).toBe(entries[0].url);
+  });
+
+  it("writes a valid compact HAR projection atomically with private permissions", async () => {
+    const directory = await tempDir();
+    const output = path.join(directory, "capture.har");
+    await fs.writeFile(output, "old content");
+    const result = exporter.writeNetworkExport(output, entries, "har");
+    expect(result).toMatchObject({ path: output, format: "har", count: 1 });
+    const har = JSON.parse(await fs.readFile(output, "utf8"));
+    expect(har.log.version).toBe("1.2");
+    expect(har.log.creator.name).toBe("surf-cli");
+    expect(har.log.entries[0].request.method).toBe("POST");
+    expect(har.log.entries[0].response.status).toBe(201);
+    expect((await fs.stat(output)).mode & 0o777).toBe(0o600);
+  });
+
+  it("does not let __proto__ entries influence HAR fields", () => {
+    const entry = JSON.parse('{"__proto__":{"url":"https://attacker.test"},"_requestId":"hidden"}');
+    const har = JSON.parse(exporter.serializeNetworkExport([entry], "har"));
+    expect(har.log.entries[0].request.url).toBe("");
+    expect(JSON.stringify(har)).not.toContain("hidden");
+  });
+
+  it("rejects unsupported formats", () => {
+    expect(() => exporter.serializeNetworkExport(entries, "xml")).toThrow(/unsupported/);
+  });
+});

--- a/test/unit/provider-abort.test.ts
+++ b/test/unit/provider-abort.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+
+const never = () =>
+  new Promise<never>(() => {
+    // Deliberately unresolved until the request signal aborts.
+  });
+const chatgpt = require("../../native/chatgpt-client.cjs");
+const gemini = require("../../native/gemini-client.cjs");
+const perplexity = require("../../native/perplexity-client.cjs");
+const grok = require("../../native/grok-client.cjs");
+const aistudio = require("../../native/aistudio-client.cjs");
+const aistudioBuild = require("../../native/aistudio-build.cjs");
+const https = require("node:https");
+const geminiHttp = require("../../native/gemini-client.cjs");
+
+function abortAfterCreate() {
+  const controller = new AbortController();
+  let created = false;
+  let closed = 0;
+  const createTab = async () => {
+    created = true;
+    setTimeout(() => controller.abort(), 5);
+    return { tabId: 42 };
+  };
+  const closeTab = async () => {
+    closed += 1;
+  };
+  return { controller, createTab, closeTab, wasCreated: () => created, closed: () => closed };
+}
+
+function attachFake(promise: Promise<unknown>, fake: ReturnType<typeof abortAfterCreate>) {
+  Object.assign(promise, { fake });
+  return promise as Promise<unknown> & { fake: ReturnType<typeof abortAfterCreate> };
+}
+
+const googleCookies = {
+  cookies: [
+    { name: "__Secure-1PSID", value: "sid" },
+    { name: "__Secure-1PSIDTS", value: "ts" },
+  ],
+};
+
+describe("provider request cancellation", () => {
+  it.each([
+    [
+      "ChatGPT",
+      () => {
+        const fake = abortAfterCreate();
+        return attachFake(
+          chatgpt.query({
+            prompt: "query",
+            getCookies: async () => ({
+              cookies: [{ name: "__Secure-next-auth.session-token", value: "token" }],
+            }),
+            createTab: fake.createTab,
+            closeTab: fake.closeTab,
+            cdpEvaluate: never,
+            cdpCommand: never,
+            signal: fake.controller.signal,
+          }),
+          fake,
+        );
+      },
+    ],
+    [
+      "Perplexity",
+      () => {
+        const fake = abortAfterCreate();
+        return attachFake(
+          perplexity.query({
+            prompt: "query",
+            createTab: fake.createTab,
+            closeTab: fake.closeTab,
+            cdpEvaluate: never,
+            cdpCommand: never,
+            signal: fake.controller.signal,
+          }),
+          fake,
+        );
+      },
+    ],
+    [
+      "Grok",
+      () => {
+        const fake = abortAfterCreate();
+        return attachFake(
+          grok.query({
+            prompt: "query",
+            getCookies: async () => ({ cookies: [{ name: "auth_token", value: "token" }] }),
+            createTab: fake.createTab,
+            closeTab: fake.closeTab,
+            cdpEvaluate: never,
+            cdpCommand: never,
+            signal: fake.controller.signal,
+          }),
+          fake,
+        );
+      },
+    ],
+    [
+      "AI Studio",
+      () => {
+        const fake = abortAfterCreate();
+        return attachFake(
+          aistudio.query({
+            prompt: "query",
+            getCookies: async () => googleCookies,
+            createTab: fake.createTab,
+            closeTab: fake.closeTab,
+            cdpEvaluate: never,
+            cdpCommand: never,
+            signal: fake.controller.signal,
+          }),
+          fake,
+        );
+      },
+    ],
+    [
+      "AI Studio Build",
+      () => {
+        const fake = abortAfterCreate();
+        return attachFake(
+          aistudioBuild.build({
+            prompt: "query",
+            getCookies: async () => googleCookies,
+            createTab: fake.createTab,
+            closeTab: fake.closeTab,
+            cdpEvaluate: never,
+            cdpCommand: never,
+            searchDownloads: never,
+            signal: fake.controller.signal,
+          }),
+          fake,
+        );
+      },
+    ],
+  ])("aborts %s and closes its owned tab", async (_name, run) => {
+    const runPromise = run();
+    await expect(runPromise).rejects.toMatchObject({ code: "SURF_REQUEST_ABORTED" });
+    expect(runPromise.fake.wasCreated()).toBe(true);
+    expect(runPromise.fake.closed()).toBeGreaterThan(0);
+  });
+
+  it("aborts Grok validation and closes its tab", async () => {
+    const fake = abortAfterCreate();
+    await expect(
+      grok.validate({
+        getCookies: async () => ({ cookies: [{ name: "auth_token", value: "token" }] }),
+        createTab: fake.createTab,
+        closeTab: fake.closeTab,
+        cdpEvaluate: never,
+        signal: fake.controller.signal,
+        log: () => undefined,
+      }),
+    ).rejects.toMatchObject({ code: "SURF_REQUEST_ABORTED" });
+    expect(fake.closed()).toBeGreaterThan(0);
+  });
+
+  it("destroys an active Gemini HTTPS request on abort", async () => {
+    const controller = new AbortController();
+    let destroyed = false;
+    const listeners = new Map<string, (error?: Error) => void>();
+    const originalRequest = https.request;
+    https.request = (_options: unknown, _callback: unknown) => ({
+      on(event: string, listener: (error?: Error) => void) {
+        listeners.set(event, listener);
+        return this;
+      },
+      end() {
+        return undefined;
+      },
+      destroy(error: Error) {
+        destroyed = true;
+        listeners.get("error")?.(error);
+      },
+    });
+    try {
+      const pending = geminiHttp.httpsGet(
+        "https://example.test/",
+        {},
+        { signal: controller.signal },
+      );
+      controller.abort();
+      await expect(pending).rejects.toMatchObject({ code: "SURF_REQUEST_ABORTED" });
+      expect(destroyed).toBe(true);
+    } finally {
+      https.request = originalRequest;
+    }
+  });
+
+  it("aborts Gemini in-page work from its first JavaScript callback", async () => {
+    const controller = new AbortController();
+    let closed = 0;
+    const createTab = async () => ({ tabId: 42 });
+    const closeTab = async () => {
+      closed += 1;
+    };
+    const jsEval = async () => {
+      controller.abort();
+      return JSON.stringify({ ok: true });
+    };
+    await expect(
+      gemini.query({
+        prompt: "query",
+        editImage: "input.png",
+        getCookies: async () => googleCookies,
+        createTab,
+        closeTab,
+        jsEval,
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ code: "SURF_REQUEST_ABORTED" });
+    expect(closed).toBeGreaterThan(0);
+  }, 20000);
+});

--- a/test/unit/provider-materialization.test.ts
+++ b/test/unit/provider-materialization.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+const fs = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const transfer = require("../../native/file-transfer.cjs");
+const helpers = require("../../native/host-helpers.cjs");
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe("provider path materialization", () => {
+  it("passes ordinary host paths to ChatGPT and Gemini dispatch", async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "surf-provider-materialization-"));
+    tempDirs.push(directory);
+    const staged = path.join(directory, "chat-stage.txt");
+    const direct = path.join(directory, "gemini-input.png");
+    const output = path.join(directory, "gemini-output.png");
+    await fs.writeFile(staged, "chat");
+    await fs.writeFile(direct, "image");
+
+    const chatPlan = transfer.prepareRemoteTool("chatgpt", { query: "q", file: "local:chat.txt" });
+    const chat = await transfer.materializeRemoteTool({
+      tool: "chatgpt",
+      args: chatPlan.args,
+      metadata: {
+        uploads: [
+          { transferId: "chat", field: "file", original: "local:chat.txt", kind: "upload" },
+        ],
+        downloads: [],
+      },
+      pathRefs: chatPlan.pathRefs,
+      transferState: { takeCompleted: () => ({ filePath: staged }) },
+    });
+    const chatMessage = helpers.mapToolToMessage("chatgpt", chat.args, 1);
+    expect(chatMessage.file).toBe(staged);
+    expect(JSON.stringify(chatMessage)).not.toMatch(/local:|remote:/);
+
+    const geminiPlan = transfer.prepareRemoteTool("gemini", {
+      query: "edit",
+      "edit-image": `remote:${direct}`,
+      output: `remote:${output}`,
+    });
+    const gemini = await transfer.materializeRemoteTool({
+      tool: "gemini",
+      args: geminiPlan.args,
+      metadata: { uploads: [], downloads: [] },
+      pathRefs: geminiPlan.pathRefs,
+    });
+    const geminiMessage = helpers.mapToolToMessage("gemini", gemini.args, 1);
+    expect(geminiMessage.editImage).toBe(direct);
+    expect(geminiMessage.output).toBe(output);
+    expect(JSON.stringify(geminiMessage)).not.toMatch(/local:|remote:/);
+  });
+});

--- a/test/unit/remote-auth.test.ts
+++ b/test/unit/remote-auth.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+declare const require: (moduleName: string) => unknown;
+declare const process: { pid: number };
+type ByteBuffer = { toString(encoding?: string): string };
+declare const Buffer: { alloc(size: number, fill?: number): ByteBuffer };
+const fs = require("node:fs") as {
+  mkdtempSync(prefix: string): string;
+  readFileSync(filePath: string, encoding: string): string;
+  rmSync(filePath: string, options: { recursive?: boolean; force?: boolean }): void;
+  statSync(filePath: string): { mode: number };
+  symlinkSync(target: string, linkPath: string): void;
+};
+const os = require("node:os") as { tmpdir(): string };
+const path = require("node:path") as { join(...parts: string[]): string };
+
+const auth = require("../../native/remote-auth.cjs") as {
+  authorizeClient(
+    label: string,
+    outputPath: string,
+    stateDir: string,
+  ): { id: string; output: string };
+  canonicalTranscript(
+    role: string,
+    clientId: string,
+    clientNonce: string,
+    serverNonce: string,
+    clientPublicKey: string,
+    hostPublicKey: string,
+  ): ByteBuffer;
+  ensureHostIdentity(stateDir: string): { publicKey: string; privateKey: object };
+  listClients(stateDir: string): Array<{ id: string; label: string }>;
+  loadCredential(filePath: string): {
+    clientId: string;
+    label: string;
+    hostPublicKey: string;
+    publicKey: string;
+    privateKey: object;
+  };
+  loadRegistry(stateDir: string): { clients: Array<Record<string, unknown>> };
+  revokeClient(label: string, stateDir: string): void;
+  signChallenge(
+    host: { publicKey: string; privateKey: object },
+    clientId: string,
+    clientNonce: string,
+    serverNonce: string,
+    clientPublicKey: string,
+  ): string;
+  signProof(
+    credential: { clientId: string; publicKey: string; hostPublicKey: string; privateKey: object },
+    clientNonce: string,
+    serverNonce: string,
+  ): string;
+  verifyChallenge(
+    credential: { clientId: string; publicKey: string; hostPublicKey: string },
+    challenge: Record<string, unknown>,
+  ): boolean;
+  verifyProof(
+    client: { id: string; publicKey: string },
+    hostPublicKey: string,
+    clientNonce: string,
+    serverNonce: string,
+    proof: string,
+  ): boolean;
+};
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function createState() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "surf-remote-auth-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("remote authentication state", () => {
+  it("creates a private state directory, public-only registry, and non-overwriting credential", () => {
+    const stateDir = createState();
+    const output = path.join(stateDir, "client.json");
+    const client = auth.authorizeClient("alice", output, stateDir);
+
+    expect(client.id).toMatch(/^[a-f0-9]{32}$/);
+    expect(fs.statSync(stateDir).mode & 0o777).toBe(0o700);
+    expect(fs.statSync(output).mode & 0o777).toBe(0o600);
+    expect(auth.loadRegistry(stateDir).clients[0]).not.toHaveProperty("privateKey");
+    expect(JSON.parse(fs.readFileSync(output, "utf8"))).toHaveProperty("privateKey");
+    expect(() =>
+      auth.authorizeClient("alice", path.join(stateDir, "second.json"), stateDir),
+    ).toThrow("already exists");
+    expect(() => auth.authorizeClient("bob", output, stateDir)).toThrow("already exists");
+  });
+
+  it("rejects unsafe labels, symlinked state, and symlinked credential output", () => {
+    const stateDir = createState();
+    expect(() =>
+      auth.authorizeClient("bad label", path.join(stateDir, "client.json"), stateDir),
+    ).toThrow("label");
+    const linkedOutput = path.join(stateDir, "linked.json");
+    fs.symlinkSync(path.join(stateDir, "missing.json"), linkedOutput);
+    expect(() => auth.authorizeClient("alice", linkedOutput, stateDir)).toThrow("symbolic link");
+
+    const linkedState = path.join(os.tmpdir(), `surf-remote-state-link-${process.pid}`);
+    fs.rmSync(linkedState, { force: true });
+    fs.symlinkSync(stateDir, linkedState);
+    tempDirs.push(linkedState);
+    expect(() =>
+      auth.authorizeClient("alice", path.join(linkedState, "client.json"), linkedState),
+    ).toThrow("symbolic link");
+  });
+
+  it("lists and revokes clients without retaining private keys in the registry", () => {
+    const stateDir = createState();
+    auth.authorizeClient("alice", path.join(stateDir, "alice.json"), stateDir);
+    auth.authorizeClient("bob", path.join(stateDir, "bob.json"), stateDir);
+    expect(auth.listClients(stateDir).map((client) => client.label)).toEqual(["alice", "bob"]);
+    auth.revokeClient("alice", stateDir);
+    expect(auth.listClients(stateDir).map((client) => client.label)).toEqual(["bob"]);
+    expect(() => auth.revokeClient("alice", stateDir)).toThrow("not found");
+    expect(fs.readFileSync(path.join(stateDir, "remote-clients.json"), "utf8")).not.toContain(
+      "privateKey",
+    );
+  });
+
+  it("binds signatures to both nonces and the pinned host identity", () => {
+    const stateDir = createState();
+    auth.authorizeClient("alice", path.join(stateDir, "alice.json"), stateDir);
+    const credential = auth.loadCredential(path.join(stateDir, "alice.json"));
+    const host = auth.ensureHostIdentity(stateDir);
+    const client = auth.loadRegistry(stateDir).clients[0] as { id: string; publicKey: string };
+    const clientNonce = Buffer.alloc(32, 1).toString("base64");
+    const serverNonce = Buffer.alloc(32, 2).toString("base64");
+    const challenge = {
+      type: "auth_challenge",
+      version: 1,
+      clientId: credential.clientId,
+      clientNonce,
+      serverNonce,
+      hostPublicKey: credential.hostPublicKey,
+      signature: auth.signChallenge(
+        host,
+        credential.clientId,
+        clientNonce,
+        serverNonce,
+        credential.publicKey,
+      ),
+    };
+
+    expect(auth.verifyChallenge(credential, challenge)).toBe(true);
+    expect(
+      auth.verifyChallenge(credential, {
+        ...challenge,
+        serverNonce: Buffer.alloc(32, 3).toString("base64"),
+      }),
+    ).toBe(false);
+    const proof = auth.signProof(credential, clientNonce, serverNonce);
+    expect(auth.verifyProof(client, host.publicKey, clientNonce, serverNonce, proof)).toBe(true);
+    expect(
+      auth.verifyProof(
+        client,
+        host.publicKey,
+        clientNonce,
+        Buffer.alloc(32, 3).toString("base64"),
+        proof,
+      ),
+    ).toBe(false);
+    expect(
+      auth.canonicalTranscript(
+        "client",
+        credential.clientId,
+        clientNonce,
+        serverNonce,
+        credential.publicKey,
+        credential.hostPublicKey,
+      ),
+    ).toBeInstanceOf(Buffer);
+  });
+});

--- a/test/unit/remote-transport.test.ts
+++ b/test/unit/remote-transport.test.ts
@@ -1,0 +1,488 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+declare const require: (moduleName: string) => unknown;
+declare const Buffer: {
+  from(value: string): BufferLike;
+  alloc(size: number, fill?: number): BufferLike;
+};
+type BufferLike = { toString(encoding?: string): string };
+type SocketLike = {
+  once(event: string, listener: (...args: unknown[]) => void): void;
+  on(event: string, listener: (...args: unknown[]) => void): void;
+  write(data: unknown): boolean;
+  removeListener(event: string, listener: (...args: unknown[]) => void): void;
+  destroy(error?: Error): void;
+};
+type ServerLike = {
+  listen(port: number, host: string, callback: () => void): void;
+  close(callback: () => void): void;
+  address(): { port: number } | string | null;
+};
+const fs = require("node:fs") as {
+  mkdtempSync(prefix: string): string;
+  rmSync(filePath: string, options: { recursive?: boolean; force?: boolean }): void;
+};
+const net = require("node:net") as {
+  createServer(handler: (socket: SocketLike) => void): ServerLike;
+  createConnection(options: { host: string; port: number }): SocketLike;
+};
+const os = require("node:os") as { tmpdir(): string };
+const path = require("node:path") as { join(...parts: string[]): string };
+
+const sessions = require("../../native/host-sessions.cjs") as {
+  HostSessionManager: new () => {
+    admit(socket: object, isRemote: boolean): Record<string, unknown>;
+    authenticate(
+      context: Record<string, unknown>,
+      principal: { clientId: string; label: string },
+    ): void;
+    close(context: Record<string, unknown>): void;
+  };
+};
+const auth = require("../../native/remote-auth.cjs") as {
+  authorizeClient(label: string, outputPath: string, stateDir: string): unknown;
+  loadCredential(filePath: string): Record<string, unknown>;
+  revokeClient(label: string, stateDir: string): void;
+  signProof(credential: Record<string, unknown>, clientNonce: string, serverNonce: string): string;
+};
+const transport = require("../../native/remote-transport.cjs") as {
+  authenticateClient(
+    socket: SocketLike,
+    credential: string | Record<string, unknown>,
+    options?: { timeoutMs?: number },
+  ): Promise<{ clientId: string; label: string }>;
+  createFrameParser(options: {
+    onFrame: (value: Record<string, unknown>) => void;
+    onError: (error: Error) => void;
+    frameTimeoutMs?: number;
+  }): { push(chunk: BufferLike): void; close(): void };
+  createServerAuthSession(options: {
+    socket: SocketLike;
+    stateDir: string;
+    timeoutMs?: number;
+    onAuthenticated: (principal: { clientId: string; label: string }) => void;
+    onError: (error: Error) => void;
+  }): {
+    authenticated: boolean;
+    failed: boolean;
+    principal: { clientId: string; label: string } | null;
+    handle(message: Record<string, unknown>): Promise<boolean>;
+    close(): void;
+  };
+  isClientAuthorized(stateDir: string, clientId: string): boolean;
+  createSocketWriter(
+    socket: SocketLike,
+    options?: {
+      maxPendingBytes?: number;
+      onOverflow?: (value: { stream: boolean; error: Error }) => void;
+    },
+  ): {
+    send(value: Record<string, unknown>, sendOptions?: { stream?: boolean }): Promise<void>;
+    close(): void;
+  };
+  writeFrame(socket: SocketLike, value: Record<string, unknown>): Promise<void>;
+};
+
+const tempDirs: string[] = [];
+const servers: ServerLike[] = [];
+
+afterEach(async () => {
+  for (const server of servers.splice(0)) {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function createState() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "surf-remote-transport-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function startAuthServer(
+  stateDir: string,
+  authTimeoutMs = 5000,
+  sessionManager?: InstanceType<typeof sessions.HostSessionManager>,
+) {
+  const server = net.createServer((socket: SocketLike) => {
+    socket.on("error", () => undefined);
+    const context = sessionManager?.admit(socket, true);
+    const session = transport.createServerAuthSession({
+      socket,
+      stateDir,
+      timeoutMs: authTimeoutMs,
+      onAuthenticated: (principal) => {
+        if (sessionManager && context) {
+          sessionManager.authenticate(context, principal);
+        }
+      },
+      onError: (error) => {
+        transport
+          .writeFrame(socket, { type: "auth_error", message: error.message })
+          .finally(() => socket.destroy())
+          .catch(() => socket.destroy());
+      },
+    });
+    const parser = transport.createFrameParser({
+      onFrame: (message) => {
+        (async () => {
+          if (!session.authenticated) {
+            await session.handle(message);
+            return;
+          }
+          if (
+            !session.principal ||
+            !transport.isClientAuthorized(stateDir, session.principal.clientId)
+          ) {
+            await transport.writeFrame(socket, {
+              error: "remote client authorization was revoked",
+            });
+            socket.destroy();
+            return;
+          }
+          await transport.writeFrame(socket, { type: "tool_response", id: message.id || null });
+        })().catch(() => socket.destroy());
+      },
+      onError: () => socket.destroy(),
+      frameTimeoutMs: 100,
+    });
+    socket.on("data", (...args: unknown[]) => parser.push(args[0] as BufferLike));
+    socket.on("close", () => {
+      parser.close();
+      session.close();
+      if (sessionManager && context) {
+        sessionManager.close(context);
+      }
+    });
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("server did not bind");
+  }
+  return address.port;
+}
+
+function connect(port: number) {
+  return new Promise<SocketLike>((resolve, reject) => {
+    const socket = net.createConnection({ host: "127.0.0.1", port });
+    socket.once("connect", () => resolve(socket));
+    socket.once("error", reject);
+  });
+}
+
+function readFrame(socket: SocketLike) {
+  return new Promise<Record<string, unknown>>((resolve, reject) => {
+    const onData = (...args: unknown[]) => {
+      const text = (args[0] as BufferLike).toString("utf8");
+      const line = text.split("\\n")[0];
+      try {
+        socket.removeListener("error", onError);
+        resolve(JSON.parse(line) as Record<string, unknown>);
+      } catch (error) {
+        reject(error);
+      }
+    };
+    const onError = (...args: unknown[]) => reject(args[0]);
+    socket.once("data", onData);
+    socket.once("error", onError);
+  });
+}
+
+describe("remote transport authentication", () => {
+  it("authenticates a real client over loopback and rejects commands before auth", async () => {
+    const stateDir = createState();
+    const credentialPath = path.join(stateDir, "client.json");
+    auth.authorizeClient("alice", credentialPath, stateDir);
+    const port = await startAuthServer(stateDir);
+    const unauthenticated = await connect(port);
+    unauthenticated.on("error", () => undefined);
+    const preAuth = new Promise<string>((resolve) =>
+      unauthenticated.once("data", (...args: unknown[]) =>
+        resolve((args[0] as BufferLike).toString("utf8")),
+      ),
+    );
+    await transport.writeFrame(unauthenticated, { type: "tool_request", id: "before-auth" });
+    expect(await preAuth).toContain("authentication required");
+    unauthenticated.destroy();
+
+    const socket = await connect(port);
+    socket.on("error", () => undefined);
+    await expect(transport.authenticateClient(socket, credentialPath)).resolves.toMatchObject({
+      label: "alice",
+    });
+    await transport.writeFrame(socket, { type: "tool_request", id: "request-1" });
+    socket.destroy();
+  });
+
+  it("rejects the fifth authenticated connection before sending auth_ok", async () => {
+    const stateDir = createState();
+    const credentialPath = path.join(stateDir, "client.json");
+    auth.authorizeClient("alice", credentialPath, stateDir);
+    const sessionManager = new sessions.HostSessionManager();
+    const port = await startAuthServer(stateDir, 5000, sessionManager);
+    const sockets = await Promise.all(Array.from({ length: 5 }, () => connect(port)));
+    for (const socket of sockets) {
+      socket.on("error", () => undefined);
+    }
+    for (const socket of sockets.slice(0, 4)) {
+      await expect(transport.authenticateClient(socket, credentialPath)).resolves.toMatchObject({
+        label: "alice",
+      });
+    }
+    await expect(transport.authenticateClient(sockets[4], credentialPath)).rejects.toThrow(
+      "maximum connections",
+    );
+    for (const socket of sockets) {
+      socket.destroy();
+    }
+  });
+
+  it("fails closed for revoked clients and pinned server mismatches", async () => {
+    const stateDir = createState();
+    const credentialPath = path.join(stateDir, "client.json");
+    auth.authorizeClient("alice", credentialPath, stateDir);
+    const port = await startAuthServer(stateDir);
+    auth.revokeClient("alice", stateDir);
+    const revoked = await connect(port);
+    revoked.on("error", () => undefined);
+    await expect(transport.authenticateClient(revoked, credentialPath)).rejects.toThrow(
+      "not authorized",
+    );
+    revoked.destroy();
+
+    const replacementPath = path.join(stateDir, "replacement.json");
+    auth.authorizeClient("alice", replacementPath, stateDir);
+    const credential = auth.loadCredential(replacementPath);
+    credential.hostPublicKey = Buffer.alloc(32, 8).toString("base64");
+    const wrongPin = await connect(port);
+    wrongPin.on("error", () => undefined);
+    await expect(transport.authenticateClient(wrongPin, credential)).rejects.toThrow(
+      "identity verification failed",
+    );
+    wrongPin.destroy();
+  });
+
+  it("rejects malformed client proofs", async () => {
+    const stateDir = createState();
+    const credentialPath = path.join(stateDir, "client.json");
+    auth.authorizeClient("alice", credentialPath, stateDir);
+    const credential = auth.loadCredential(credentialPath);
+    const port = await startAuthServer(stateDir);
+    const socket = await connect(port);
+    socket.on("error", () => undefined);
+    const clientNonce = Buffer.alloc(32, 4).toString("base64");
+    await transport.writeFrame(socket, {
+      type: "auth_hello",
+      version: 1,
+      clientId: credential.clientId,
+      clientNonce,
+    });
+    await readFrame(socket);
+    await transport.writeFrame(socket, {
+      type: "auth_proof",
+      version: 1,
+      clientId: credential.clientId,
+      proof: Buffer.alloc(64, 7).toString("base64"),
+    });
+    await expect(readFrame(socket)).resolves.toMatchObject({
+      type: "auth_error",
+      message: "remote client proof verification failed",
+    });
+    socket.destroy();
+  });
+
+  it("times out clients that never complete authentication", async () => {
+    const stateDir = createState();
+    const port = await startAuthServer(stateDir, 20);
+    const socket = await connect(port);
+    socket.on("error", () => undefined);
+    await expect(readFrame(socket)).resolves.toMatchObject({
+      type: "auth_error",
+      message: "authentication timed out",
+    });
+    socket.destroy();
+  });
+
+  it("rejects a captured proof replayed against a fresh server nonce", async () => {
+    const stateDir = createState();
+    const credentialPath = path.join(stateDir, "client.json");
+    auth.authorizeClient("alice", credentialPath, stateDir);
+    const credential = auth.loadCredential(credentialPath);
+    const clientNonce = Buffer.alloc(32, 9).toString("base64");
+    const port = await startAuthServer(stateDir);
+    const first = await connect(port);
+    first.on("error", () => undefined);
+    await transport.writeFrame(first, {
+      type: "auth_hello",
+      version: 1,
+      clientId: credential.clientId,
+      clientNonce,
+    });
+    const firstChallenge = await readFrame(first);
+    const capturedProof = auth.signProof(
+      credential,
+      clientNonce,
+      firstChallenge.serverNonce as string,
+    );
+    await transport.writeFrame(first, {
+      type: "auth_proof",
+      version: 1,
+      clientId: credential.clientId,
+      proof: capturedProof,
+    });
+    await expect(readFrame(first)).resolves.toMatchObject({ type: "auth_ok" });
+    first.destroy();
+
+    const second = await connect(port);
+    second.on("error", () => undefined);
+    await transport.writeFrame(second, {
+      type: "auth_hello",
+      version: 1,
+      clientId: credential.clientId,
+      clientNonce,
+    });
+    await readFrame(second);
+    await transport.writeFrame(second, {
+      type: "auth_proof",
+      version: 1,
+      clientId: credential.clientId,
+      proof: capturedProof,
+    });
+    await expect(readFrame(second)).resolves.toMatchObject({
+      type: "auth_error",
+      message: "remote client proof verification failed",
+    });
+    second.destroy();
+  });
+
+  it("rejects the next request after an authenticated client is revoked", async () => {
+    const stateDir = createState();
+    const credentialPath = path.join(stateDir, "client.json");
+    auth.authorizeClient("alice", credentialPath, stateDir);
+    const port = await startAuthServer(stateDir);
+    const socket = await connect(port);
+    socket.on("error", () => undefined);
+    await expect(transport.authenticateClient(socket, credentialPath)).resolves.toMatchObject({
+      label: "alice",
+    });
+    auth.revokeClient("alice", stateDir);
+    await transport.writeFrame(socket, { type: "tool_request", id: "revoked-request" });
+    await expect(readFrame(socket)).resolves.toMatchObject({
+      error: "remote client authorization was revoked",
+    });
+    socket.destroy();
+  });
+
+  it("rejects an oversized remainder after a valid frame", () => {
+    const errors: string[] = [];
+    const parser = transport.createFrameParser({
+      onFrame: () => undefined,
+      onError: (error) => errors.push(error.message),
+    });
+    parser.push(Buffer.from(`{"ok":true}\n${"x".repeat(1024 * 1024 + 1)}`));
+    expect(errors).toEqual(["frame exceeds byte limit"]);
+  });
+
+  it("rejects a backpressured frame when the socket closes cleanly", async () => {
+    const listeners = new Map<string, (...args: unknown[]) => void>();
+    const socket: SocketLike = {
+      once(event, listener) {
+        listeners.set(event, listener);
+      },
+      on(event, listener) {
+        listeners.set(event, listener);
+      },
+      removeListener(event, listener) {
+        if (listeners.get(event) === listener) {
+          listeners.delete(event);
+        }
+      },
+      write: () => false,
+      destroy: () => undefined,
+    };
+    const pending = transport.writeFrame(socket, { frame: true });
+    listeners.get("close")?.();
+    await expect(pending).rejects.toThrow("closed");
+    expect(listeners.has("drain")).toBe(false);
+  });
+
+  it("serializes writes and rejects bounded queue overflow", async () => {
+    const listeners = new Map<string, (...args: unknown[]) => void>();
+    const socket: SocketLike = {
+      once(event, listener) {
+        listeners.set(event, listener);
+      },
+      on(event, listener) {
+        listeners.set(event, listener);
+      },
+      removeListener(event, listener) {
+        if (listeners.get(event) === listener) {
+          listeners.delete(event);
+        }
+      },
+      write: () => false,
+      destroy: () => undefined,
+    };
+    let overflow: { stream: boolean } | undefined;
+    const writer = transport.createSocketWriter(socket, {
+      maxPendingBytes: 100,
+      onOverflow: (value) => {
+        overflow = value;
+      },
+    });
+    const first = writer.send({ first: true });
+    await expect(writer.send({ second: "x".repeat(90) }, { stream: true })).rejects.toThrow(
+      "queue is full",
+    );
+    expect(overflow?.stream).toBe(true);
+    writer.close();
+    await expect(first).rejects.toThrow("socket writer closed");
+  });
+
+  it("counts the backpressured frame against the writer bound", async () => {
+    const listeners = new Map<string, (...args: unknown[]) => void>();
+    const socket: SocketLike = {
+      once(event, listener) {
+        listeners.set(event, listener);
+      },
+      on(event, listener) {
+        listeners.set(event, listener);
+      },
+      removeListener(event, listener) {
+        if (listeners.get(event) === listener) {
+          listeners.delete(event);
+        }
+      },
+      write: () => false,
+      destroy: () => undefined,
+    };
+    const writer = transport.createSocketWriter(socket, { maxPendingBytes: 40 });
+    const first = writer.send({ first: true });
+    await expect(writer.send({ second: "123456789012" })).rejects.toThrow("queue is full");
+    writer.close();
+    await expect(first).rejects.toThrow("socket writer closed");
+  });
+
+  it("rejects malformed JSON and incomplete frames", async () => {
+    const errors: string[] = [];
+    const parser = transport.createFrameParser({
+      onFrame: () => undefined,
+      onError: (error) => errors.push(error.message),
+      frameTimeoutMs: 10,
+    });
+    parser.push(Buffer.from("{not-json}\n"));
+    expect(errors).toEqual(["frame contains invalid JSON"]);
+    const timeoutParser = transport.createFrameParser({
+      onFrame: () => undefined,
+      onError: (error) => errors.push(error.message),
+      frameTimeoutMs: 10,
+    });
+    timeoutParser.push(Buffer.from('{"partial":'));
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(errors).toContain("incomplete frame timed out");
+  });
+});

--- a/test/unit/request-pending.test.ts
+++ b/test/unit/request-pending.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { RequestPendingMap } = require("../../native/request-pending.cjs") as {
+  RequestPendingMap: new () => {
+    set(id: number, data: Record<string, unknown>): unknown;
+    get(id: number): Record<string, unknown> | undefined;
+    resolve(id: number, value: unknown): boolean;
+    hardDeadline(request: Record<string, unknown>): void;
+    expire(id: number, error: Error): boolean;
+    onDrain(request: Record<string, unknown>, callback: () => void): void;
+    clear(): void;
+  };
+};
+
+function request() {
+  const controller = new AbortController();
+  return {
+    controller,
+    signal: controller.signal,
+    startedAt: Date.now(),
+    deadlineMs: 1000,
+    pendingEntries: new Set(),
+  };
+}
+
+describe("request-owned pending operations", () => {
+  it("rejects once on abort, retains the tombstone, and drains on late response", async () => {
+    const pending = new RequestPendingMap();
+    const owner = request();
+    const reject = vi.fn();
+    const resolveDrain = vi.fn();
+    pending.set(1, { request: owner, reject });
+    pending.onDrain(owner, resolveDrain);
+    owner.controller.abort();
+    expect(reject).toHaveBeenCalledOnce();
+    expect(pending.get(1)).toBeDefined();
+    expect(resolveDrain).not.toHaveBeenCalled();
+    pending.resolve(1, { late: true });
+    expect(resolveDrain).toHaveBeenCalledOnce();
+    owner.controller.abort();
+    expect(reject).toHaveBeenCalledOnce();
+  });
+
+  it("rejects nested timeouts while retaining their tombstone", () => {
+    const pending = new RequestPendingMap();
+    const owner = request();
+    const reject = vi.fn();
+    pending.set(1, { request: owner, reject });
+    pending.expire(1, new Error("nested timeout"));
+    expect(reject).toHaveBeenCalledOnce();
+    expect(pending.get(1)).toBeDefined();
+  });
+
+  it("keeps cleanup entries owned after abort and settles them normally", () => {
+    const pending = new RequestPendingMap();
+    const owner = request();
+    const resolve = vi.fn();
+    pending.set(1, { request: owner, cleanup: true, resolve });
+    owner.controller.abort();
+    expect(pending.get(1)).toBeDefined();
+    pending.resolve(1, { closed: true });
+    expect(resolve).toHaveBeenCalledWith({ closed: true });
+    expect(owner.pendingEntries.size).toBe(0);
+  });
+
+  it("drains only after every tombstone and cleanup entry settles", () => {
+    const pending = new RequestPendingMap();
+    const owner = request();
+    const reject = vi.fn();
+    const resolveCleanup = vi.fn();
+    const resolveDrain = vi.fn();
+    pending.set(1, { request: owner, reject });
+    pending.set(2, { request: owner, cleanup: true, resolve: resolveCleanup });
+    pending.onDrain(owner, resolveDrain);
+    owner.controller.abort();
+    pending.resolve(1, { late: true });
+    expect(resolveDrain).not.toHaveBeenCalled();
+    pending.resolve(2, { closed: true });
+    expect(resolveCleanup).toHaveBeenCalledWith({ closed: true });
+    expect(resolveDrain).toHaveBeenCalledOnce();
+  });
+
+  it("rejects and removes all owned entries at the hard boundary", () => {
+    const pending = new RequestPendingMap();
+    const owner = request();
+    const reject = vi.fn();
+    pending.set(1, { request: owner, reject });
+    pending.set(2, { request: owner, cleanup: true, reject });
+    pending.hardDeadline(owner);
+    expect(owner.pendingEntries.size).toBe(0);
+    expect(pending.get(1)).toBeUndefined();
+    expect(pending.get(2)).toBeUndefined();
+    expect(reject).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears listeners and tombstone timers", () => {
+    vi.useFakeTimers();
+    const pending = new RequestPendingMap();
+    const owner = request();
+    const reject = vi.fn();
+    pending.set(1, { request: owner, reject });
+    owner.controller.abort();
+    pending.clear();
+    vi.advanceTimersByTime(2000);
+    expect(reject).toHaveBeenCalledOnce();
+    vi.useRealTimers();
+  });
+});

--- a/test/unit/service-worker/network-export-handlers.test.ts
+++ b/test/unit/service-worker/network-export-handlers.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createChromeMock, resetChromeMock } from "../../mocks/chrome";
+
+const cdpState = vi.hoisted(() => ({
+  entries: [] as Array<Record<string, unknown>>,
+  enableNetworkTracking: vi.fn(),
+  getNetworkEntries: vi.fn(() => cdpState.entries),
+}));
+
+vi.mock("../../../src/cdp/controller", () => ({
+  CDPController: class {
+    enableNetworkTracking = cdpState.enableNetworkTracking;
+    getNetworkEntries = cdpState.getNetworkEntries;
+  },
+}));
+
+vi.mock("../../../src/native/port-manager", () => ({
+  initNativeMessaging: vi.fn(),
+  postToNativeHost: vi.fn(),
+}));
+
+async function loadHandleMessage() {
+  vi.resetModules();
+  (globalThis as any).chrome = createChromeMock();
+  const mod = await import("../../../src/service-worker/index");
+  return mod.handleMessage;
+}
+
+describe("network export handlers", () => {
+  beforeEach(() => {
+    resetChromeMock();
+    cdpState.entries = [];
+    cdpState.enableNetworkTracking.mockReset();
+    cdpState.getNetworkEntries.mockClear();
+  });
+
+  it("returns captured entries and format flags", async () => {
+    const handleMessage = await loadHandleMessage();
+    cdpState.entries = [{ id: "r1", url: "https://example.test" }];
+    const result = await handleMessage(
+      { type: "EXPORT_NETWORK_REQUESTS", tabId: 42, har: true },
+      {},
+    );
+    expect(result).toEqual({ entries: cdpState.entries, har: true, jsonl: false });
+    expect(cdpState.enableNetworkTracking).toHaveBeenCalledWith(42);
+    expect(cdpState.getNetworkEntries).toHaveBeenCalledWith(42, {});
+  });
+
+  it("rejects entries exceeding the native-message source cap", async () => {
+    const handleMessage = await loadHandleMessage();
+    cdpState.entries = [{ body: "x".repeat(17 * 1024 * 1024) }];
+    await expect(handleMessage({ type: "EXPORT_NETWORK_REQUESTS", tabId: 42 }, {})).rejects.toThrow(
+      /16 MiB native-message limit/,
+    );
+  });
+});


### PR DESCRIPTION
This replaces the original Tailnet endpoint implementation with authenticated remote control that is safe to enable by default. Each client receives its own mode-0600 Ed25519 credential through `surf remote authorize`, pins the host identity, completes mutual fresh-nonce challenge-response, and can be listed or revoked independently. Tailscale ACLs remain defense in depth rather than Surf's authorization boundary.

Local Unix/named-pipe clients and authenticated remote clients share one bounded FIFO host lease. Disconnects and timeouts abort queued or in-flight work, while the lease stays held until request-owned browser work and cleanup drain or reach the hard boundary. Provider requests propagate cancellation and cleanup-owned tabs before the next client runs.

Remote paths are client-local unless explicitly written as `remote:/absolute/path`. The release supports one upload or ChatGPT/Gemini input and one screenshot, network export, or Gemini image output, with private staging, atomic verified downloads, cumulative 256 MiB/file, 512 MiB/connection, 32-file, and 256 KiB chunk limits. Remote `record`, `aistudio.build`, smoke screenshot directories, directory transfer, and multi-file inputs remain intentionally unsupported.

Local validation passes 38 test files and 546 tests, lint with the existing `FakeNode` warning only, typecheck, production build, critical audit, CJS syntax checks, and diff hygiene. Fresh security and correctness reviews found no remaining issues. Thanks to Alvin (@alvinunreal) for the original remote-browser contribution; the changelog preserves credit for #155.
