### PR TITLE
fix: route content messages through one listener

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -57,6 +60,30 @@ jobs:
 
       - name: TypeScript check
         run: npm run check
+
+  real-chrome:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install pinned Chrome for Testing
+        run: npx puppeteer browsers install chrome@150.0.7871.24
+
+      - name: Build extension
+        run: npm run build
+
+      - name: Run real Chrome E2E
+        run: npm run test:e2e:chrome
 
   audit:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,14 @@
 ## [Unreleased]
 
 ### Added
+- **Real Chrome E2E coverage** - Added a pinned Chrome for Testing CI lane that exercises the production MV3 extension, native messaging, core CLI navigation and page commands, interaction, visual indicators, screenshot bytes, and process cleanup against local fixtures. Thanks to Carlos Villela (@cv) for #7.
 - **Authenticated Tailnet remote control** - Added mutually authenticated per-client remote access with Ed25519 host pinning, authorize/list/revoke lifecycle, shared local/remote FIFO serialization, disconnect cancellation, bounded single-file transfer, explicit `local:`/`remote:` path semantics, remote AI attachments and image outputs, network export, and transferred action/error screenshots. Thanks to @alvinunreal for the original remote-browser contribution in #155.
 - **Deep X Research skill** - Added `skills/deep-x-research/`, an agent skill that layers an exhaustive X (Twitter) research procedure on top of `surf grok`: a quota-budgeted multi-angle Grok sweep (keyword + semantic, with DeepSearch), Grok-native video analysis, quota-free URL verification via direct post opens, categorized findings, and a References section where every cited post carries its full post URL. Falls back to the x.com search UI when the Grok quota is exhausted.
 - **Tab movement** - Added `surf tab.move <id> --to-window <id>` with multi-tab and insertion-index support. (@zm2231, #148)
 - **Page text byte limit** - Added `page.read --max-bytes <n>` for UTF-8-safe visible-text truncation without changing the existing default limit. (@zm2231, #148)
 
 ### Fixed
+- **Content-script message routing** - Routed accessibility and visual-indicator commands through one authoritative Chrome message listener so unrelated listeners cannot win the response race and return empty results.
 - **Provider response extraction** - Fixed truncated Perplexity answers, trailing Grok suggestion chips, and incomplete Gemini stream/image extraction; refreshed Gemini's selectable web models and unknown-model fallback guidance. (@zm2231, #148)
 - **Browser command edge cases** - Fixed `tab.name` on restricted active pages, `zoom --level` argument loss, and selector-targeted `type --into`; selector typing now follows the active iframe context. (@zm2231, #148)
 

--- a/manifest.json
+++ b/manifest.json
@@ -24,15 +24,9 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["content/accessibility-tree.js"],
+      "js": ["content/index.js"],
       "run_at": "document_start",
       "all_frames": true
-    },
-    {
-      "matches": ["<all_urls>"],
-      "js": ["content/visual-indicator.js"],
-      "run_at": "document_idle",
-      "all_frames": false
     }
   ],
   "permissions": [
@@ -60,10 +54,7 @@
   "web_accessible_resources": [
     {
       "matches": ["<all_urls>"],
-      "resources": [
-        "content/accessibility-tree.js",
-        "content/visual-indicator.js"
-      ],
+      "resources": ["content/index.js"],
       "use_dynamic_url": false
     }
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@types/chrome": "^0.2.2",
         "@vitest/coverage-v8": "^4.1.9",
         "@vitest/ui": "^4.1.9",
+        "puppeteer": "25.3.0",
         "typescript": "^7.0.2",
         "vite": "^8.1.4",
         "vitest": "^4.1.9"
@@ -418,6 +419,35 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.0.6.tgz",
+      "integrity": "sha512-B/gKoqlFkzhvzsI6jo9K1cZz9o5ypviVv/xu8CwA4grZzyVwN+XfkT+tu8T1zrauuEXv6VhS2oGX+6NL95WcKA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "modern-tar": "^0.7.6",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "browsers": "lib/main-cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "proxy-agent": ">=8.0.1",
+        "yauzl": "^2.10.0 || ^3.4.0"
+      },
+      "peerDependenciesMeta": {
+        "proxy-agent": {
+          "optional": true
+        },
+        "yauzl": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.5",
@@ -1367,6 +1397,32 @@
         }
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/asn1.js": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
@@ -1691,6 +1747,33 @@
         "node": ">=18"
       }
     },
+    "node_modules/chromium-bidi": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-16.0.1.tgz",
+      "integrity": "sha512-J63PGu/9PpeCwLIcKYyzWP6yaVL5pxuBc0shlYCYM8BaAkmlwiQboXO1iNbOgSDbVklEyYFfNEcHD8oOAWacUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=20.19.0 <22.0.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/chromium-bidi/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/cipher-base": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
@@ -1703,6 +1786,21 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/console-browserify": {
@@ -1950,6 +2048,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1638949",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1638949.tgz",
+      "integrity": "sha512-mXwg4Fqnv0WR4iuAT/gYUmctNkjILwXFHyZ+m7Ty1dfr0ezZt2U3gnrrJTfRobJTHoXf+IbuFvFITzLrLFjwJA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/diffie-hellman": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
@@ -2020,6 +2125,13 @@
       "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
       "license": "MIT"
     },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -2064,6 +2176,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -2351,6 +2473,29 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -3065,6 +3210,19 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -3213,6 +3371,23 @@
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
       "license": "MIT"
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/modern-tar": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.6.tgz",
+      "integrity": "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/mrmime": {
       "version": "2.0.1",
@@ -3694,6 +3869,46 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "license": "MIT"
+    },
+    "node_modules/puppeteer": {
+      "version": "25.3.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-25.3.0.tgz",
+      "integrity": "sha512-O1tx8S315aw8eI99HZ5ZNcVEzJ9+jKF//eO5UvfZ3cXJ6okZ5sX3Y50u7DJaM+ewEK4LqXP068tBhfRaWikj+g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "3.0.6",
+        "chromium-bidi": "16.0.1",
+        "devtools-protocol": "0.0.1638949",
+        "lilconfig": "^3.1.3",
+        "puppeteer-core": "25.3.0",
+        "typed-query-selector": "^2.12.2"
+      },
+      "bin": {
+        "puppeteer": "lib/puppeteer/node/cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "25.3.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.3.0.tgz",
+      "integrity": "sha512-fm+wpUr2oigH1PXZvwgATrM2tYWHMDG8ASzTEe9uukCye4X5Ldx1K5BTHPFKITrIWvQQAQ256d1NpbEveBcKjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "3.0.6",
+        "chromium-bidi": "16.0.1",
+        "devtools-protocol": "0.0.1638949",
+        "typed-query-selector": "^2.12.2",
+        "webdriver-bidi-protocol": "0.4.2",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
     },
     "node_modules/qs": {
       "version": "6.14.1",
@@ -4250,6 +4465,40 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -4409,6 +4658,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "7.0.2",
@@ -4684,6 +4940,13 @@
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "license": "MIT"
     },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.2.tgz",
+      "integrity": "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4737,11 +5000,51 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -4750,6 +5053,44 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "lint:test": "biome check test/",
     "format": "biome format --write .",
     "test": "vitest run",
+    "test:e2e:chrome": "node test/e2e/real-chrome.mjs",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:ui": "vitest --ui",
@@ -64,6 +65,7 @@
     "@types/chrome": "^0.2.2",
     "@vitest/coverage-v8": "^4.1.9",
     "@vitest/ui": "^4.1.9",
+    "puppeteer": "25.3.0",
     "typescript": "^7.0.2",
     "vite": "^8.1.4",
     "vitest": "^4.1.9"

--- a/src/content/accessibility-tree.ts
+++ b/src/content/accessibility-tree.ts
@@ -1,3 +1,5 @@
+import type { VisualIndicatorMessageType } from "./visual-indicator.ts";
+
 export {};
 
 declare global {
@@ -1432,6 +1434,20 @@ function uploadImage(
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   switch (message.type) {
+    case "SHOW_AGENT_INDICATORS":
+    case "HIDE_AGENT_INDICATORS":
+    case "HIDE_FOR_TOOL_USE":
+    case "SHOW_AFTER_TOOL_USE":
+    case "SHOW_STATIC_INDICATOR":
+    case "HIDE_STATIC_INDICATOR": {
+      if (!window.__piVisualIndicatorMessageHandler) {
+        sendResponse({ error: "Visual indicator content script not loaded." });
+        break;
+      }
+      window.__piVisualIndicatorMessageHandler(message.type as VisualIndicatorMessageType);
+      sendResponse({ success: true });
+      break;
+    }
     case "GENERATE_ACCESSIBILITY_TREE": {
       const options = message.options || {};
       

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,0 +1,2 @@
+import "./visual-indicator.ts";
+import "./accessibility-tree.ts";

--- a/src/content/visual-indicator.ts
+++ b/src/content/visual-indicator.ts
@@ -1,3 +1,17 @@
+export type VisualIndicatorMessageType =
+  | "SHOW_AGENT_INDICATORS"
+  | "HIDE_AGENT_INDICATORS"
+  | "HIDE_FOR_TOOL_USE"
+  | "SHOW_AFTER_TOOL_USE"
+  | "SHOW_STATIC_INDICATOR"
+  | "HIDE_STATIC_INDICATOR";
+
+declare global {
+  interface Window {
+    __piVisualIndicatorMessageHandler?: (type: VisualIndicatorMessageType) => void;
+  }
+}
+
 const PI_COLOR = "59, 178, 191";
 const DEFAULT_HEARTBEAT_INTERVAL = 10000;
 
@@ -10,25 +24,30 @@ let wasActiveBeforeToolUse = false;
 let wasStaticActiveBeforeToolUse = false;
 let heartbeatIntervalId: number | null = null;
 let heartbeatIntervalMs = DEFAULT_HEARTBEAT_INTERVAL;
+let showIndicatorsWhenReady = false;
+let showStaticIndicatorWhenReady = false;
+const isTopFrame = window === window.top;
 
-chrome.storage.local.get("heartbeatInterval").then(({ heartbeatInterval }) => {
-  if (heartbeatInterval && typeof heartbeatInterval === "number") {
-    heartbeatIntervalMs = heartbeatInterval * 1000;
-  }
-});
+if (isTopFrame) {
+  chrome.storage.local.get("heartbeatInterval").then(({ heartbeatInterval }) => {
+    if (heartbeatInterval && typeof heartbeatInterval === "number") {
+      heartbeatIntervalMs = heartbeatInterval * 1000;
+    }
+  });
 
-chrome.storage.onChanged.addListener((changes, areaName) => {
-  if (areaName === "local" && changes.heartbeatInterval) {
-    const newValue = changes.heartbeatInterval.newValue;
-    if (newValue && typeof newValue === "number") {
-      heartbeatIntervalMs = newValue * 1000;
-      if (isStaticActive && heartbeatIntervalId) {
-        clearInterval(heartbeatIntervalId);
-        startHeartbeat();
+  chrome.storage.onChanged.addListener((changes, areaName) => {
+    if (areaName === "local" && changes.heartbeatInterval) {
+      const newValue = changes.heartbeatInterval.newValue;
+      if (newValue && typeof newValue === "number") {
+        heartbeatIntervalMs = newValue * 1000;
+        if (isStaticActive && heartbeatIntervalId) {
+          clearInterval(heartbeatIntervalId);
+          startHeartbeat();
+        }
       }
     }
-  }
-});
+  });
+}
 
 function startHeartbeat() {
   heartbeatIntervalId = window.setInterval(async () => {
@@ -224,6 +243,22 @@ function createStaticIndicator(): HTMLDivElement {
 }
 
 function showIndicators() {
+  if (!document.body) {
+    if (!showIndicatorsWhenReady) {
+      showIndicatorsWhenReady = true;
+      window.addEventListener(
+        "DOMContentLoaded",
+        () => {
+          if (!showIndicatorsWhenReady) return;
+          showIndicatorsWhenReady = false;
+          showIndicators();
+        },
+        { once: true },
+      );
+    }
+    return;
+  }
+  showIndicatorsWhenReady = false;
   if (isActive) return;
   isActive = true;
 
@@ -256,6 +291,7 @@ function showIndicators() {
 }
 
 function hideIndicators() {
+  showIndicatorsWhenReady = false;
   if (!isActive) return;
   isActive = false;
 
@@ -283,6 +319,22 @@ function hideIndicators() {
 }
 
 function showStaticIndicator() {
+  if (!document.body) {
+    if (!showStaticIndicatorWhenReady) {
+      showStaticIndicatorWhenReady = true;
+      window.addEventListener(
+        "DOMContentLoaded",
+        () => {
+          if (!showStaticIndicatorWhenReady) return;
+          showStaticIndicatorWhenReady = false;
+          showStaticIndicator();
+        },
+        { once: true },
+      );
+    }
+    return;
+  }
+  showStaticIndicatorWhenReady = false;
   if (isStaticActive) return;
   isStaticActive = true;
 
@@ -298,6 +350,7 @@ function showStaticIndicator() {
 }
 
 function hideStaticIndicator() {
+  showStaticIndicatorWhenReady = false;
   if (!isStaticActive) return;
   isStaticActive = false;
 
@@ -312,50 +365,54 @@ function hideStaticIndicator() {
   }
 }
 
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  switch (message.type) {
-    case "SHOW_AGENT_INDICATORS":
-      showIndicators();
-      sendResponse({ success: true });
-      return false;
-    case "HIDE_AGENT_INDICATORS":
-      hideIndicators();
-      sendResponse({ success: true });
-      return false;
-    case "HIDE_FOR_TOOL_USE":
-      wasActiveBeforeToolUse = isActive;
-      wasStaticActiveBeforeToolUse = isStaticActive;
-      if (glowBorder) glowBorder.style.display = "none";
-      if (stopButton) stopButton.style.display = "none";
-      if (staticIndicator && isStaticActive) staticIndicator.style.display = "none";
-      sendResponse({ success: true });
-      return false;
-    case "SHOW_AFTER_TOOL_USE":
-      if (wasActiveBeforeToolUse) {
-        if (glowBorder) glowBorder.style.display = "";
-        if (stopButton) stopButton.style.display = "";
-      }
-      if (wasStaticActiveBeforeToolUse && staticIndicator) {
-        staticIndicator.style.display = "";
-      }
-      wasActiveBeforeToolUse = false;
-      wasStaticActiveBeforeToolUse = false;
-      sendResponse({ success: true });
-      return false;
-    case "SHOW_STATIC_INDICATOR":
-      showStaticIndicator();
-      sendResponse({ success: true });
-      return false;
-    case "HIDE_STATIC_INDICATOR":
-      hideStaticIndicator();
-      sendResponse({ success: true });
-      return false;
-    default:
-      return false;
-  }
-});
+if (isTopFrame) {
+  window.__piVisualIndicatorMessageHandler = (type) => {
+    switch (type) {
+      case "SHOW_AGENT_INDICATORS":
+        showIndicators();
+        break;
+      case "HIDE_AGENT_INDICATORS":
+        hideIndicators();
+        break;
+      case "HIDE_FOR_TOOL_USE":
+        wasActiveBeforeToolUse = isActive || showIndicatorsWhenReady;
+        wasStaticActiveBeforeToolUse = isStaticActive || showStaticIndicatorWhenReady;
+        showIndicatorsWhenReady = false;
+        showStaticIndicatorWhenReady = false;
+        if (glowBorder) glowBorder.style.display = "none";
+        if (stopButton) stopButton.style.display = "none";
+        if (staticIndicator && isStaticActive) staticIndicator.style.display = "none";
+        break;
+      case "SHOW_AFTER_TOOL_USE":
+        if (wasActiveBeforeToolUse) {
+          if (isActive) {
+            if (glowBorder) glowBorder.style.display = "";
+            if (stopButton) stopButton.style.display = "";
+          } else {
+            showIndicators();
+          }
+        }
+        if (wasStaticActiveBeforeToolUse) {
+          if (isStaticActive && staticIndicator) {
+            staticIndicator.style.display = "";
+          } else {
+            showStaticIndicator();
+          }
+        }
+        wasActiveBeforeToolUse = false;
+        wasStaticActiveBeforeToolUse = false;
+        break;
+      case "SHOW_STATIC_INDICATOR":
+        showStaticIndicator();
+        break;
+      case "HIDE_STATIC_INDICATOR":
+        hideStaticIndicator();
+        break;
+    }
+  };
 
-window.addEventListener("beforeunload", () => {
-  hideIndicators();
-  hideStaticIndicator();
-});
+  window.addEventListener("beforeunload", () => {
+    hideIndicators();
+    hideStaticIndicator();
+  });
+}

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -482,7 +482,7 @@ export async function handleMessage(
       if (!tabId) throw new Error("No tabId provided");
       
       try {
-        await chrome.tabs.sendMessage(tabId, { type: "HIDE_FOR_TOOL_USE" });
+        await chrome.tabs.sendMessage(tabId, { type: "HIDE_FOR_TOOL_USE" }, { frameId: 0 });
       } catch (e) {}
       await new Promise(resolve => setTimeout(resolve, 50));
       
@@ -544,7 +544,7 @@ export async function handleMessage(
         return { ...result, screenshotId };
       } finally {
         try {
-          await chrome.tabs.sendMessage(tabId, { type: "SHOW_AFTER_TOOL_USE" });
+          await chrome.tabs.sendMessage(tabId, { type: "SHOW_AFTER_TOOL_USE" }, { frameId: 0 });
         } catch (e) {}
       }
     }
@@ -945,7 +945,7 @@ export async function handleMessage(
         };
       } finally {
         try {
-          await chrome.tabs.sendMessage(tabId, { type: "SHOW_AFTER_TOOL_USE" });
+          await chrome.tabs.sendMessage(tabId, { type: "SHOW_AFTER_TOOL_USE" }, { frameId: 0 });
         } catch (e) {}
       }
       
@@ -1251,7 +1251,7 @@ export async function handleMessage(
     case "HIDE_STATIC_INDICATOR": {
       if (!tabId) throw new Error("No tabId provided");
       try {
-        return await chrome.tabs.sendMessage(tabId, { type: message.type });
+        return await chrome.tabs.sendMessage(tabId, { type: message.type }, { frameId: 0 });
       } catch (err) {
         return { error: "Content script not loaded. Try refreshing the page." };
       }
@@ -1479,7 +1479,7 @@ export async function handleMessage(
         };
       } finally {
         try {
-          await chrome.tabs.sendMessage(tabId, { type: "SHOW_AFTER_TOOL_USE" });
+          await chrome.tabs.sendMessage(tabId, { type: "SHOW_AFTER_TOOL_USE" }, { frameId: 0 });
         } catch (e) {}
       }
     }
@@ -1508,7 +1508,7 @@ export async function handleMessage(
         };
       } finally {
         try {
-          await chrome.tabs.sendMessage(tabId, { type: "SHOW_AFTER_TOOL_USE" });
+          await chrome.tabs.sendMessage(tabId, { type: "SHOW_AFTER_TOOL_USE" }, { frameId: 0 });
         } catch (e) {}
       }
     }
@@ -1535,7 +1535,7 @@ export async function handleMessage(
         };
       } finally {
         try {
-          await chrome.tabs.sendMessage(tabId, { type: "SHOW_AFTER_TOOL_USE" });
+          await chrome.tabs.sendMessage(tabId, { type: "SHOW_AFTER_TOOL_USE" }, { frameId: 0 });
         } catch (e) {}
       }
     }

--- a/test/e2e/real-chrome.mjs
+++ b/test/e2e/real-chrome.mjs
@@ -1,0 +1,372 @@
+import { createHash } from "node:crypto";
+import { execFile } from "node:child_process";
+import {
+  chmodSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import puppeteer from "puppeteer";
+
+const execFileAsync = promisify(execFile);
+const repo = process.cwd();
+const extensionKey =
+  "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArWZVsRzpoyzuyQFqRzGOnkxv9FNaX/SR/VMw2f9ld+DKmUMxJhi/14olehkLWRJQumFPYTzWr1oqb1LwwI2KhBtn9mbaqzPSrrRGQ1VobTx7ZmxU+ooppXNdb2KGh/WXVqahS0D1nsQplAE6hCqQWPjsPCnXnWjUIH/B0EsInIUDwA8PKfuMG8p2HDlLj8hEpmLwOA48W4aHbl2S6bZHu9O50Lbd0L94aSwJLBNLKuXpBt/kFwlnpHd3zoJme9DIbqnDU/nMNh9SlA+EXRT6FhyiKdo6ZBMdtJeUPLQI2uHeoF8wikkNhIXX/E2EXlBqtZJJaFEi895x2s40+j/iZQIDAQAB"; // gitleaks:allow -- public test manifest key
+const extensionId = "nionemkjcnknfdhdolfloigkhpjnifmf";
+const scratch = mkdtempSync(join(tmpdir(), "surf-real-chrome-"));
+const home = join(scratch, "home");
+const extensionDir = join(scratch, "extension");
+const profileDir = join(scratch, "profile");
+const socketPath = join(scratch, "surf.sock");
+const surfTmp = join(scratch, "tmp");
+const screenshotPath = join(scratch, "shot.png");
+const hostPidPath = join(scratch, "native-host.pid");
+let browser;
+let browserPid;
+let server;
+let failure;
+
+function extensionIdForKey(key) {
+  const digest = createHash("sha256").update(Buffer.from(key, "base64")).digest().subarray(0, 16);
+  return Array.from(digest, (byte) =>
+    `${String.fromCharCode(97 + (byte >> 4))}${String.fromCharCode(97 + (byte & 15))}`,
+  ).join("");
+}
+
+function processIsAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error?.code === "ESRCH") return false;
+    throw error;
+  }
+}
+
+async function waitFor(predicate, label, timeoutMs = 20_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Timed out waiting for ${label}`);
+}
+
+async function terminateProcess(pid, label) {
+  if (!processIsAlive(pid)) return;
+  process.kill(pid, "SIGTERM");
+  await waitFor(() => !processIsAlive(pid), `${label} SIGTERM`, 3_000).catch(() => {});
+  if (!processIsAlive(pid)) return;
+  process.kill(pid, "SIGKILL");
+  await waitFor(() => !processIsAlive(pid), `${label} SIGKILL`, 3_000);
+}
+
+async function terminateProcessesUsingProfile() {
+  const { stdout } = await execFileAsync("ps", ["-axo", "pid=,command="], {
+    timeout: 5_000,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  const profilePids = stdout
+    .split("\n")
+    .map((line) => line.trim().match(/^(\d+)\s+(.*)$/))
+    .filter((match) => match?.[2].includes(profileDir))
+    .map((match) => Number.parseInt(match[1], 10))
+    .filter((pid) => pid !== process.pid);
+
+  for (const pid of profilePids) await terminateProcess(pid, "Chrome profile process");
+}
+
+const env = {
+  ...process.env,
+  HOME: home,
+  SURF_HOST_PATH: join(repo, "native/host.cjs"),
+  SURF_NODE_PATH: process.execPath,
+  SURF_SOCKET: socketPath,
+  SURF_TMP: surfTmp,
+};
+
+async function runSurf(...args) {
+  const result = await execFileAsync(process.execPath, [join(repo, "native/cli.cjs"), ...args], {
+    cwd: repo,
+    env,
+    timeout: 20_000,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  return result.stdout;
+}
+
+try {
+  if (!new Set(["darwin", "linux"]).has(process.platform)) {
+    throw new Error(`Real Chrome E2E does not support ${process.platform}`);
+  }
+  if (extensionIdForKey(extensionKey) !== extensionId) {
+    throw new Error("Stable extension key does not match the expected test extension ID");
+  }
+
+  mkdirSync(home, { recursive: true });
+  mkdirSync(surfTmp, { recursive: true });
+  cpSync(join(repo, "dist"), extensionDir, { recursive: true });
+  const extensionManifestPath = join(extensionDir, "manifest.json");
+  const extensionManifest = JSON.parse(readFileSync(extensionManifestPath, "utf8"));
+  extensionManifest.key = extensionKey;
+  writeFileSync(extensionManifestPath, `${JSON.stringify(extensionManifest, null, 2)}\n`);
+
+  await execFileAsync(
+    process.execPath,
+    [join(repo, "scripts/install-native-host.cjs"), extensionId],
+    { cwd: repo, env, timeout: 20_000 },
+  );
+
+  const standardManifest = join(
+    home,
+    process.platform === "darwin"
+      ? "Library/Application Support/Google/Chrome/NativeMessagingHosts/surf.browser.host.json"
+      : ".config/google-chrome/NativeMessagingHosts/surf.browser.host.json",
+  );
+  const nativeManifest = JSON.parse(readFileSync(standardManifest, "utf8"));
+  writeFileSync(
+    nativeManifest.path,
+    `#!/usr/bin/env bash\necho $$ > ${JSON.stringify(hostPidPath)}\nexport SURF_SOCKET=${JSON.stringify(socketPath)}\nexport SURF_TMP=${JSON.stringify(surfTmp)}\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(join(repo, "native/host.cjs"))} "$@"\n`,
+  );
+  chmodSync(nativeManifest.path, 0o755);
+
+  const testingManifest = join(profileDir, "NativeMessagingHosts/surf.browser.host.json");
+  mkdirSync(join(profileDir, "NativeMessagingHosts"), { recursive: true });
+  cpSync(standardManifest, testingManifest);
+
+  server = createServer((_request, response) => {
+    response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+    response.end(`<!doctype html>
+<html>
+  <head><title>Surf real Chrome fixture</title></head>
+  <body>
+    <main>
+      <h1>Surf real Chrome fixture</h1>
+      <button id="fixture-button">Mark complete</button>
+      <p id="fixture-result">Waiting for Surf</p>
+    </main>
+    <script>
+      document.querySelector("#fixture-button").addEventListener("click", () => {
+        document.querySelector("#fixture-result").textContent = "Clicked by Surf";
+      });
+    </script>
+  </body>
+</html>`);
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  const fixtureUrl = `http://127.0.0.1:${address.port}/fixture`;
+  const navigationUrl = `${fixtureUrl}?navigated`;
+
+  browser = await puppeteer.launch({
+    headless: true,
+    enableExtensions: [extensionDir],
+    userDataDir: profileDir,
+    env,
+    args: process.platform === "linux" ? ["--no-sandbox"] : [],
+  });
+  browserPid = browser.process()?.pid;
+
+  const workerTarget = await browser.waitForTarget(
+    (target) =>
+      target.type() === "service_worker" &&
+      target.url().startsWith(`chrome-extension://${extensionId}/`),
+    { timeout: 20_000 },
+  );
+  await waitFor(() => existsSync(socketPath), "Surf native-host socket");
+  await waitFor(() => existsSync(hostPidPath), "Surf native-host PID");
+
+  await runSurf("tab.new", fixtureUrl, "--json");
+  await runSurf("go", navigationUrl, "--no-screenshot", "--json");
+  const tabs = JSON.parse(await runSurf("tab.list", "--json"));
+  const fixtureTab = tabs.find((tab) => tab.url === navigationUrl);
+  if (!fixtureTab?.id) {
+    throw new Error(`tab.list did not report the navigated fixture tab: ${JSON.stringify(tabs)}`);
+  }
+
+  const fixturePage = (await browser.pages()).find((page) => page.url() === navigationUrl);
+  if (!fixturePage) throw new Error("Puppeteer could not find the navigated fixture page");
+  let contentRealm;
+  let contentRealmState;
+  for (const realm of fixturePage.extensionRealms()) {
+    const extension = await realm.extension();
+    if (extension?.id === extensionId) {
+      contentRealm = realm;
+      contentRealmState = await realm.evaluate(() => ({
+        text: document.body.textContent,
+        visualHandler: typeof window.__piVisualIndicatorMessageHandler,
+      }));
+      break;
+    }
+  }
+  if (!contentRealmState?.text?.includes("Surf real Chrome fixture")) {
+    throw new Error("Surf content-script realm was not injected");
+  }
+
+  const worker = await workerTarget.worker();
+  if (!worker) throw new Error("Could not access the Surf service worker");
+  const directText = await worker.evaluate(
+    async (tabId) => await chrome.tabs.sendMessage(tabId, { type: "GET_PAGE_TEXT" }, { frameId: 0 }),
+    fixtureTab.id,
+  );
+  if (!directText?.text?.includes("Surf real Chrome fixture")) {
+    throw new Error(
+      `Direct page-text message failed: ${JSON.stringify({ contentRealmState, directText })}`,
+    );
+  }
+
+  const initialText = await runSurf("page.text");
+  if (!initialText.includes("Surf real Chrome fixture") || !initialText.includes("Waiting for Surf")) {
+    throw new Error(`page.text did not contain fixture text: ${initialText}`);
+  }
+
+  const pageRead = await runSurf("read", "--depth", "2", "--compact");
+  if (!pageRead.includes('button "Mark complete"')) {
+    throw new Error(`read did not contain the fixture button: ${pageRead}`);
+  }
+
+  await runSurf("click", "--selector", "#fixture-button", "--json");
+  await waitFor(
+    () => fixturePage.evaluate(() => document.querySelector("#fixture-result")?.textContent === "Clicked by Surf"),
+    "Surf click result",
+  );
+  const clickedText = await runSurf("page.text");
+  if (!clickedText.includes("Clicked by Surf")) {
+    throw new Error(`page.text did not reflect the click: ${clickedText}`);
+  }
+
+  await contentRealm.evaluate(() => {
+    const handleVisualIndicatorMessage = window.__piVisualIndicatorMessageHandler;
+    window.__surfE2EVisualStates = [];
+    window.__piVisualIndicatorMessageHandler = (type) => {
+      handleVisualIndicatorMessage(type);
+      window.__surfE2EVisualStates.push({
+        display: document.querySelector("#pi-agent-glow")?.style.display ?? null,
+        type,
+      });
+    };
+  });
+
+  const showResult = await worker.evaluate(
+    async (tabId) =>
+      await chrome.tabs.sendMessage(tabId, { type: "SHOW_AGENT_INDICATORS" }, { frameId: 0 }),
+    fixtureTab.id,
+  );
+  if (!showResult?.success) {
+    throw new Error(`Visual indicator show command failed: ${JSON.stringify(showResult)}`);
+  }
+  await waitFor(
+    () => fixturePage.evaluate(() => document.querySelector("#pi-agent-glow") !== null),
+    "visual indicator",
+  );
+
+  await runSurf("screenshot", "--output", screenshotPath);
+  const png = readFileSync(screenshotPath);
+  if (png.length < 100 || png.subarray(0, 8).toString("hex") !== "89504e470d0a1a0a") {
+    throw new Error("screenshot was not a valid PNG");
+  }
+  await waitFor(
+    () => fixturePage.evaluate(() => document.querySelector("#pi-agent-glow") !== null),
+    "visual indicator restoration after screenshot",
+  );
+  const screenshotVisualStates = await contentRealm.evaluate(() => window.__surfE2EVisualStates);
+  const hiddenForScreenshot = screenshotVisualStates.find(
+    (state) => state.type === "HIDE_FOR_TOOL_USE",
+  );
+  const restoredAfterScreenshot = screenshotVisualStates.find(
+    (state) => state.type === "SHOW_AFTER_TOOL_USE",
+  );
+  if (hiddenForScreenshot?.display !== "none" || restoredAfterScreenshot?.display !== "") {
+    throw new Error(
+      `Screenshot did not hide and restore the visual indicator: ${JSON.stringify(screenshotVisualStates)}`,
+    );
+  }
+
+  const hideResult = await worker.evaluate(
+    async (tabId) =>
+      await chrome.tabs.sendMessage(tabId, { type: "HIDE_AGENT_INDICATORS" }, { frameId: 0 }),
+    fixtureTab.id,
+  );
+  if (!hideResult?.success) {
+    throw new Error(`Visual indicator hide command failed: ${JSON.stringify(hideResult)}`);
+  }
+  await waitFor(
+    () => fixturePage.evaluate(() => document.querySelector("#pi-agent-glow") === null),
+    "visual indicator removal",
+  );
+
+  console.log(
+    JSON.stringify(
+      {
+        chrome: await puppeteer.executablePath(),
+        extensionId,
+        platform: process.platform,
+        result: "pass",
+        screenshotBytes: png.length,
+        serviceWorker: workerTarget.url(),
+      },
+      null,
+      2,
+    ),
+  );
+} catch (error) {
+  failure = error;
+}
+
+const cleanupErrors = [];
+try {
+  if (browser) await browser.close();
+} catch (error) {
+  cleanupErrors.push(error);
+}
+try {
+  if (browserPid) await terminateProcess(browserPid, "Chrome");
+} catch (error) {
+  cleanupErrors.push(error);
+}
+try {
+  await terminateProcessesUsingProfile();
+} catch (error) {
+  cleanupErrors.push(error);
+}
+try {
+  if (server) {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+} catch (error) {
+  cleanupErrors.push(error);
+}
+try {
+  if (existsSync(hostPidPath)) {
+    const hostPid = Number.parseInt(readFileSync(hostPidPath, "utf8"), 10);
+    if (Number.isInteger(hostPid)) await terminateProcess(hostPid, "Surf native host");
+  }
+} catch (error) {
+  cleanupErrors.push(error);
+}
+try {
+  rmSync(scratch, { recursive: true, force: true });
+} catch (error) {
+  cleanupErrors.push(error);
+}
+
+if (failure) {
+  for (const cleanupError of cleanupErrors) console.error("Cleanup error:", cleanupError);
+  throw failure;
+}
+if (cleanupErrors.length > 0) {
+  throw new AggregateError(cleanupErrors, "Real Chrome E2E cleanup failed");
+}

--- a/test/unit/accessibility-tree.test.ts
+++ b/test/unit/accessibility-tree.test.ts
@@ -121,10 +121,12 @@ describe("accessibility tree", () => {
   let messageHandler:
     | ((message: any, sender: any, sendResponse: (response: any) => void) => boolean)
     | undefined;
+  let visualIndicatorHandler: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
     vi.resetModules();
     messageHandler = undefined;
+    visualIndicatorHandler = vi.fn();
 
     (globalThis as any).Element = FakeElement;
     (globalThis as any).HTMLElement = FakeElement;
@@ -144,6 +146,7 @@ describe("accessibility tree", () => {
         opacity: "1",
         cursor: "default",
       }),
+      __piVisualIndicatorMessageHandler: visualIndicatorHandler,
     };
 
     (globalThis as any).document = {
@@ -165,6 +168,27 @@ describe("accessibility tree", () => {
     };
 
     await import("../../src/content/accessibility-tree");
+  });
+
+  it("routes visual indicator commands through the sole content-message listener", () => {
+    let response: any;
+    const listenerResult = messageHandler?.({ type: "SHOW_AGENT_INDICATORS" }, {}, (result) => {
+      response = result;
+    });
+
+    expect(listenerResult).toBe(false);
+    expect(visualIndicatorHandler).toHaveBeenCalledWith("SHOW_AGENT_INDICATORS");
+    expect(response).toEqual({ success: true });
+  });
+
+  it("reports when the visual indicator content script is not loaded", () => {
+    window.__piVisualIndicatorMessageHandler = undefined;
+    let response: any;
+    messageHandler?.({ type: "HIDE_AGENT_INDICATORS" }, {}, (result) => {
+      response = result;
+    });
+
+    expect(response).toEqual({ error: "Visual indicator content script not loaded." });
   });
 
   it("uses nested text for interactive link and button names", () => {

--- a/test/unit/visual-indicator.test.ts
+++ b/test/unit/visual-indicator.test.ts
@@ -1,0 +1,65 @@
+import { vi } from "vitest";
+
+describe("visual indicator content script", () => {
+  let runtimeMessageListener: ReturnType<typeof vi.fn>;
+  let windowListeners: Map<string, () => void>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    runtimeMessageListener = vi.fn();
+    windowListeners = new Map();
+
+    const windowMock: Record<string, unknown> = {
+      addEventListener: vi.fn((type: string, listener: () => void) => {
+        windowListeners.set(type, listener);
+      }),
+      setInterval: vi.fn(() => 1),
+    };
+    windowMock.top = windowMock;
+    (globalThis as any).window = windowMock;
+    (globalThis as any).document = { body: null };
+    (globalThis as any).chrome = {
+      runtime: {
+        onMessage: { addListener: runtimeMessageListener },
+        sendMessage: vi.fn().mockResolvedValue({ success: true }),
+      },
+      storage: {
+        local: { get: vi.fn().mockResolvedValue({}) },
+        onChanged: { addListener: vi.fn() },
+      },
+    };
+
+    await import("../../src/content/visual-indicator");
+  });
+
+  it("exposes visual commands without registering a competing runtime listener", () => {
+    expect(runtimeMessageListener).not.toHaveBeenCalled();
+    expect(window.__piVisualIndicatorMessageHandler).toBeTypeOf("function");
+
+    window.__piVisualIndicatorMessageHandler?.("HIDE_AGENT_INDICATORS");
+    window.__piVisualIndicatorMessageHandler?.("HIDE_FOR_TOOL_USE");
+    window.__piVisualIndicatorMessageHandler?.("SHOW_AFTER_TOOL_USE");
+    window.__piVisualIndicatorMessageHandler?.("HIDE_STATIC_INDICATOR");
+  });
+
+  it("does not resurrect an indicator hidden before the document body is ready", () => {
+    window.__piVisualIndicatorMessageHandler?.("SHOW_AGENT_INDICATORS");
+    const onDocumentReady = windowListeners.get("DOMContentLoaded");
+    expect(onDocumentReady).toBeTypeOf("function");
+
+    window.__piVisualIndicatorMessageHandler?.("HIDE_AGENT_INDICATORS");
+    (document as any).body = {};
+    expect(() => onDocumentReady?.()).not.toThrow();
+  });
+
+  it("restores a pending indicator after tool use finishes", () => {
+    const addEventListener = window.addEventListener as ReturnType<typeof vi.fn>;
+    window.__piVisualIndicatorMessageHandler?.("SHOW_AGENT_INDICATORS");
+    window.__piVisualIndicatorMessageHandler?.("HIDE_FOR_TOOL_USE");
+    window.__piVisualIndicatorMessageHandler?.("SHOW_AFTER_TOOL_USE");
+
+    expect(
+      addEventListener.mock.calls.filter(([type]) => type === "DOMContentLoaded"),
+    ).toHaveLength(2);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,8 +19,7 @@ export default defineConfig({
     rolldownOptions: {
       input: {
         "service-worker/index": resolve(__dirname, "src/service-worker/index.ts"),
-        "content/accessibility-tree": resolve(__dirname, "src/content/accessibility-tree.ts"),
-        "content/visual-indicator": resolve(__dirname, "src/content/visual-indicator.ts"),
+        "content/index": resolve(__dirname, "src/content/index.ts"),
         "options/options": resolve(__dirname, "src/options/options.html"),
       },
       output: {


### PR DESCRIPTION
Chrome can accept only one response for a content message, but Surf loaded accessibility and visual-indicator responders separately. Real Chrome could therefore return `null` before the accessibility response, leaving `page.text` with only its request ID.

This builds one ordered content-script bundle with one authoritative listener, keeps visual behavior top-frame-only, preserves pre-DOM indicator state across tool use, and targets indicator messages to frame 0. It also adds an exact Puppeteer 25.3.0 / Chrome for Testing 150.0.7871.24 Linux job using the production MV3 manifest, a stable test extension ID, localhost fixtures, isolated browser/native-host state, and strict PID/socket/profile cleanup.

The real-browser test covers `tab.list`, `go`, `page.text`, `read`, one click, indicator show/hide plus screenshot hide/restore, and valid PNG output through the CLI/native-host/extension/Chrome chain. Local validation passed 39 test files and 551 tests, lint with only the existing `FakeNode` warning, typecheck, build, critical audit, every CJS syntax check, workflow parsing, staged-diff hygiene, and the macOS Chrome-for-Testing run.

Thanks @cv for opening and shaping the original E2E coverage request.

Closes #7
