### PR TITLE
Drop Chrome-specific framing from icon changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Changed
-- **Extension icon** - Replaced the placeholder teal glyph with on-brand artwork matching the project banner: a cartoon wave curl with the surfing robot mascot, tuned to stay legible at 16px in the Chrome toolbar.
+- **Extension icon** - Replaced the placeholder teal glyph with on-brand artwork matching the project banner: a cartoon wave curl with the surfing robot mascot, tuned to stay legible at 16px in the browser toolbar.
 
 ## [2.10.0] - 2026-07-29
 


### PR DESCRIPTION
Follow-up to #161. Surf supports Chromium, Brave, Edge, Arc and Helium alongside Chrome, so the icon entry shouldn't imply the toolbar is Chrome-only.