### PR TITLE
refactor: tighten TypeScript boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - **Playbook script strategies** - Added opt-in trusted read-op scripts with dynamic `tools.run`/`tools.all` Surf tool orchestration and workflow auto-waits.
 
+### Changed
+- **TypeScript boundary cleanup** - Replaced content element ref expandos with a WeakMap and validated native API stream response frames before dispatch.
+
 ## [2.11.0] - 2026-07-29
 
 ### Added

--- a/src/content/accessibility-tree.ts
+++ b/src/content/accessibility-tree.ts
@@ -154,16 +154,23 @@ function getResolvedRole(element: Element): string {
 
 if (!window.__piElementMap) window.__piElementMap = {};
 
+interface ElementRef {
+  role: string;
+  name: string;
+  ref: string;
+}
+
+const elementRefs = new WeakMap<Element, ElementRef>();
 let globalRefCounter = 0;
 
 function getOrAssignRef(element: Element, role: string, name: string): string {
-  const existing = (element as any)._piRef as { role: string; name: string; ref: string } | undefined;
+  const existing = elementRefs.get(element);
   if (existing && existing.role === role && existing.name === name) {
     return existing.ref;
   }
   
   const ref = `e${++globalRefCounter}`;
-  (element as any)._piRef = { role, name, ref };
+  elementRefs.set(element, { role, name, ref });
   return ref;
 }
 

--- a/src/native/native-api-transport.ts
+++ b/src/native/native-api-transport.ts
@@ -10,10 +10,25 @@ export interface ApiStreamCallbacks {
 const streamCallbacks = new Map<string, ApiStreamCallbacks>();
 let streamIdCounter = 0;
 
-export function handleNativeApiResponse(msg: any): boolean {
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  return isRecord(value) && Object.values(value).every((entry) => typeof entry === "string");
+}
+
+function failStream(callbacks: ApiStreamCallbacks, streamId: string, error: string): true {
+  callbacks.onError(error);
+  streamCallbacks.delete(streamId);
+  return true;
+}
+
+export function handleNativeApiResponse(msg: unknown): boolean {
+  if (!isRecord(msg)) return false;
   const { type, streamId } = msg;
   
-  if (!streamId || !streamCallbacks.has(streamId)) {
+  if (typeof streamId !== "string" || !streamCallbacks.has(streamId)) {
     return false;
   }
   
@@ -21,9 +36,15 @@ export function handleNativeApiResponse(msg: any): boolean {
   
   switch (type) {
     case "API_RESPONSE_START":
+      if (typeof msg.status !== "number" || !isStringRecord(msg.headers)) {
+        return failStream(callbacks, streamId, "Malformed API response start");
+      }
       callbacks.onStart(msg.status, msg.headers);
       return true;
     case "API_RESPONSE_CHUNK":
+      if (typeof msg.chunk !== "string") {
+        return failStream(callbacks, streamId, "Malformed API response chunk");
+      }
       callbacks.onChunk(msg.chunk);
       return true;
     case "API_RESPONSE_END":
@@ -31,6 +52,9 @@ export function handleNativeApiResponse(msg: any): boolean {
       streamCallbacks.delete(streamId);
       return true;
     case "API_RESPONSE_ERROR":
+      if (typeof msg.error !== "string") {
+        return failStream(callbacks, streamId, "Malformed API response error");
+      }
       callbacks.onError(msg.error);
       streamCallbacks.delete(streamId);
       return true;


### PR DESCRIPTION
## Summary

Tightens two TypeScript boundary seams without broad rewrites.

- Replaces the accessibility-tree element `_piRef` expando with a `WeakMap<Element, ElementRef>`.
- Changes native API stream response handling from `any` to `unknown` with explicit frame validation.
- Fails malformed active stream frames through `onError` and closes the stream instead of passing undefined payloads to callbacks.

## Validation

- `npm run check`
- `npm test -- --run test/unit/accessibility-tree.test.ts test/unit/client-transport.test.ts`
- `git diff --check`
- `npm run lint` completed with only the existing Biome schema info and existing `test/unit/accessibility-tree.test.ts` warning
- Fresh review found no findings
