### PR TITLE
feat: add optional Pi extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- **Pi extension** - Added optional Pi browser tools backed by Surf's native-host socket, plus optional pi-subagents background reporting for session-owned oracle jobs.
 - **Playbook script strategies** - Added opt-in trusted read-op scripts with dynamic `tools.run`/`tools.all` Surf tool orchestration and workflow auto-waits.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -947,6 +947,19 @@ cp -r skills/surf ~/.pi/agent/skills/
 
 See [`skills/README.md`](skills/README.md) for details.
 
+### Pi extension
+
+Surf also includes an optional Pi extension. Install or load Surf as a Pi package, or load it from a checkout:
+
+```bash
+pi install npm:surf-cli
+pi -e /path/to/surf-cli/pi-extension/surf.ts
+```
+
+It registers `surf_read`, `surf_screenshot`, `surf_click`, `surf_type`, `surf_tool`, and the `surf_oracle_*` tools. Browser calls use Surf's native-host socket, not shell commands. If `pi-subagents/background-work` is installed, the extension also reports active oracle jobs started by that Pi session. Pi still loads the browser tools when pi-subagents is not installed.
+
+Surf agents share one browser session. Use read tools for parallel scouts when possible. `surf_click` and `surf_type` can interfere with another agent's browser actions. Browser leases are not available yet.
+
 ## Development
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,11 @@
         "puppeteer": "25.4.0",
         "typescript": "^7.0.2",
         "vite": "^8.1.4",
-        "vitest": "^4.1.9"
+        "vitest": "^4.1.9",
+        "typebox": "^1.3.11"
+      },
+      "peerDependencies": {
+        "typebox": "*"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -4624,6 +4628,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/typebox": {
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.11.tgz",
+      "integrity": "sha512-tZGKIS02Opbh4EYMmAEVuXl+y3EQJ9ZlkitLZ1CmFCY4ZOqr/xWR9dDSCFmIjNDICGMWkOqMh6WxGTyRXqcSGQ==",
+      "license": "MIT",
+      "dev": true
     },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,8 @@
         "typescript": "^7.0.2",
         "vite": "^8.1.4",
         "vitest": "^4.1.9",
-        "typebox": "^1.3.11"
+        "typebox": "^1.3.11",
+        "@types/node": "^26.1.2"
       },
       "peerDependencies": {
         "typebox": "*"
@@ -5134,6 +5135,23 @@
       "peerDependencies": {
         "zod": "^3.25 || ^4"
       }
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "dev": "vite build --watch --mode development",
     "build": "vite build",
-    "check": "tsc --noEmit",
+    "check": "tsc --noEmit && tsc --noEmit -p tsconfig.pi-extension.json",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "lint:test": "biome check test/",
@@ -66,6 +66,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.5.4",
     "@types/chrome": "^0.2.2",
+    "@types/node": "^26.1.2",
     "@vitest/coverage-v8": "^4.1.9",
     "@vitest/ui": "^4.1.9",
     "puppeteer": "25.4.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "agent",
     "cli",
     "cdp",
-    "devtools"
+    "devtools",
+    "pi-package"
   ],
   "author": "Nico Bailon",
   "license": "MIT",
@@ -28,6 +29,7 @@
   },
   "files": [
     "native/",
+    "pi-extension/",
     "playbooks/",
     "scripts/",
     "dist/",
@@ -69,6 +71,18 @@
     "puppeteer": "25.4.0",
     "typescript": "^7.0.2",
     "vite": "^8.1.4",
-    "vitest": "^4.1.9"
+    "vitest": "^4.1.9",
+    "typebox": "^1.3.11"
+  },
+  "pi": {
+    "extensions": [
+      "./pi-extension/surf.ts"
+    ],
+    "skills": [
+      "./skills"
+    ]
+  },
+  "peerDependencies": {
+    "typebox": "*"
   }
 }

--- a/pi-extension/surf.ts
+++ b/pi-extension/surf.ts
@@ -1,0 +1,230 @@
+import { createRequire } from "node:module";
+import { Type } from "typebox";
+
+const require = createRequire(import.meta.url);
+const { openClientTransport } = require("../native/client-transport.cjs") as {
+  openClientTransport(endpoint: SurfEndpoint, options?: { requestTimeoutMs?: number }): Promise<{
+    request(message: Record<string, unknown>, timeoutMs?: number, transferPlan?: Record<string, unknown>): Promise<Record<string, unknown>>;
+    close(): Promise<void>;
+  }>;
+};
+const { selectEndpoint } = require("../native/endpoint.cjs") as {
+  selectEndpoint(args: string[], env?: Record<string, string | undefined>): { endpoint: SurfEndpoint };
+};
+const { resolveRequestDeadlineMs } = require("../native/host-sessions.cjs") as {
+  resolveRequestDeadlineMs(tool: string, args: Record<string, unknown>): number;
+};
+const { prepareRemoteTool, validateLocalToolPaths } = require("../native/file-transfer.cjs") as {
+  prepareRemoteTool(tool: string, args: Record<string, unknown>): { args: Record<string, unknown>; uploads?: unknown[]; downloads?: unknown[]; pathRefs?: unknown[] };
+  validateLocalToolPaths(tool: string, args: Record<string, unknown>): Record<string, unknown>;
+};
+
+const MAX_OUTPUT_CHARS = 20_000;
+const ORACLE_ACTIVE_STATES = new Set(["created", "dispatched", "awaiting"]);
+const BACKGROUND_WORK_PROTOCOL_VERSION = 1;
+const BACKGROUND_WORK_REGISTRY_KEY = "pi-subagents.background-work.v1";
+
+type Pi = {
+  registerTool(tool: Record<string, unknown>): void;
+  on(event: "session_start" | "session_shutdown", handler: (event: unknown, ctx: unknown) => void | Promise<void>): void;
+};
+
+type SurfEndpoint = { kind?: string };
+
+type ToolResult = { content: Array<{ type: "text" | "image"; text?: string; data?: string; mimeType?: string }>; details?: unknown; isError?: boolean };
+
+type BackgroundWorkProvider = {
+  name: string;
+  wakeChannels: string[];
+  listActiveWork(): Array<{ id: string; sessionId: string }>;
+};
+
+type BackgroundWorkRegistry = {
+  version: typeof BACKGROUND_WORK_PROTOCOL_VERSION;
+  providers: Map<string, BackgroundWorkProvider>;
+};
+
+function textResult(value: unknown, isError = false): ToolResult {
+  const text = typeof value === "string" ? value : JSON.stringify(value, null, 2);
+  const bounded = text.length > MAX_OUTPUT_CHARS
+    ? `${text.slice(0, MAX_OUTPUT_CHARS)}\n\n[Surf output truncated at ${MAX_OUTPUT_CHARS} characters]`
+    : text;
+  return { content: [{ type: "text", text: bounded }], ...(isError ? { isError: true } : {}) };
+}
+
+function resultFromHost(response: Record<string, unknown>): ToolResult {
+  const error = response.error as { content?: Array<{ text?: string }> } | undefined;
+  if (error) return textResult(error.content?.map((item) => item.text ?? "").join("\n") || "Surf request failed", true);
+  const result = response.result as { content?: ToolResult["content"] } | undefined;
+  if (!result?.content) return textResult(result ?? "OK");
+  const content = result.content.map((item) => item.type === "text" && item.text && item.text.length > MAX_OUTPUT_CHARS
+    ? { ...item, text: `${item.text.slice(0, MAX_OUTPUT_CHARS)}\n\n[Surf output truncated at ${MAX_OUTPUT_CHARS} characters]` }
+    : item);
+  const text = content.find((item) => item.type === "text")?.text;
+  let details: unknown;
+  try {
+    details = text ? JSON.parse(text) : undefined;
+  } catch {
+    details = undefined;
+  }
+  return { content, details };
+}
+
+export function createToolRequest(tool: string, args: Record<string, unknown>, tabId?: number) {
+  return {
+    type: "tool_request",
+    method: "execute_tool",
+    params: { tool, args, ...(tabId === undefined ? {} : { tabId }) },
+    id: `pi-surf-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  };
+}
+
+function prepareRequest(endpoint: SurfEndpoint, tool: string, args: Record<string, unknown>) {
+  if (endpoint.kind === "remote") return prepareRemoteTool(tool, args);
+  return { args: validateLocalToolPaths(tool, args), uploads: [], downloads: [], pathRefs: [] };
+}
+
+export async function requestSurf(tool: string, args: Record<string, unknown>, tabId?: number): Promise<ToolResult> {
+  const { endpoint } = selectEndpoint([], process.env);
+  const timeoutMs = resolveRequestDeadlineMs(tool, args);
+  const transport = await openClientTransport(endpoint, { requestTimeoutMs: timeoutMs });
+  try {
+    const prepared = prepareRequest(endpoint, tool, args);
+    const response = await transport.request(createToolRequest(tool, prepared.args, tabId), timeoutMs, prepared);
+    return resultFromHost(response);
+  } finally {
+    await transport.close();
+  }
+}
+
+export function surfRequest(tool: string, args: Record<string, unknown>, tabId?: number) {
+  return requestSurf(tool, args, tabId);
+}
+
+export function registerGlobalBackgroundProvider(provider: BackgroundWorkProvider): () => void {
+  const key = Symbol.for(BACKGROUND_WORK_REGISTRY_KEY);
+  const globalObject = globalThis as Record<PropertyKey, unknown>;
+  const existing = globalObject[key];
+  let registry: BackgroundWorkRegistry;
+
+  if (existing === undefined) {
+    registry = { version: BACKGROUND_WORK_PROTOCOL_VERSION, providers: new Map() };
+    globalObject[key] = registry;
+  } else if (
+    existing &&
+    typeof existing === "object" &&
+    !Array.isArray(existing) &&
+    (existing as Partial<BackgroundWorkRegistry>).version === BACKGROUND_WORK_PROTOCOL_VERSION &&
+    (existing as Partial<BackgroundWorkRegistry>).providers instanceof Map
+  ) {
+    registry = existing as BackgroundWorkRegistry;
+  } else {
+    throw new Error(`Unsupported background-work registry at Symbol.for("${BACKGROUND_WORK_REGISTRY_KEY}").`);
+  }
+
+  registry.providers.set(provider.name, provider);
+  return () => {
+    if (registry.providers.get(provider.name) === provider) registry.providers.delete(provider.name);
+  };
+}
+
+export function registerOptionalBackgroundProvider(sessionId: string, jobIds: Set<string>, listJobs: () => Array<{ id: string; state: string }>, register: (provider: BackgroundWorkProvider) => () => void) {
+  return register({
+    name: "surf-oracle",
+    wakeChannels: ["surf-oracle:finished"],
+    listActiveWork: () => listJobs()
+      .filter((job) => jobIds.has(job.id) && ORACLE_ACTIVE_STATES.has(job.state))
+      .map((job) => ({ id: job.id, sessionId })),
+  });
+}
+
+export function rememberOracleJobForSession(jobIds: Set<string>, jobId: unknown, requestGeneration: number, currentGeneration: number, sessionActive: boolean): boolean {
+  if (typeof jobId !== "string" || !sessionActive || requestGeneration !== currentGeneration) return false;
+  jobIds.add(jobId);
+  return true;
+}
+
+function registerTool(pi: Pi, name: string, description: string, parameters: unknown, map: (args: Record<string, unknown>) => [string, Record<string, unknown>, number | undefined]) {
+  pi.registerTool({
+    name,
+    label: name,
+    description,
+    parameters,
+    async execute(_id: string, args: Record<string, unknown>) {
+      try {
+        const [tool, toolArgs, tabId] = map(args);
+        return await requestSurf(tool, toolArgs, tabId);
+      } catch (error) {
+        return textResult(error instanceof Error ? error.message : String(error), true);
+      }
+    },
+  });
+}
+
+export default function surfExtension(pi: Pi) {
+  registerTool(pi, "surf_read", "Read the current Surf browser page. Read tools are safer for parallel scouts than browser actions.", Type.Object({
+    tabId: Type.Optional(Type.Number()), filter: Type.Optional(Type.String()), depth: Type.Optional(Type.Number()), ref: Type.Optional(Type.String()), compact: Type.Optional(Type.Boolean()), maxBytes: Type.Optional(Type.Number()),
+  }), (args) => ["page.read", { filter: args.filter, depth: args.depth, ref: args.ref, compact: args.compact, "max-bytes": args.maxBytes }, args.tabId as number | undefined]);
+  registerTool(pi, "surf_screenshot", "Capture a bounded Surf browser screenshot.", Type.Object({
+    tabId: Type.Optional(Type.Number()), output: Type.Optional(Type.String()), fullpage: Type.Optional(Type.Boolean()), annotate: Type.Optional(Type.Boolean()), maxSize: Type.Optional(Type.Number()),
+  }), (args) => ["screenshot", { output: args.output, fullpage: args.fullpage, annotate: args.annotate, "max-size": args.maxSize }, args.tabId as number | undefined]);
+  registerTool(pi, "surf_click", "Click a Surf browser element by ref, selector, or coordinates. This can interfere with other agents in the shared browser session.", Type.Object({
+    tabId: Type.Optional(Type.Number()), ref: Type.Optional(Type.String()), selector: Type.Optional(Type.String()), x: Type.Optional(Type.Number()), y: Type.Optional(Type.Number()), button: Type.Optional(Type.String({ description: "left, right, or double" })),
+  }), (args) => [args.button === "right" ? "right_click" : args.button === "double" ? "double_click" : "click", args, args.tabId as number | undefined]);
+  registerTool(pi, "surf_type", "Type text in the Surf browser. This can interfere with other agents in the shared browser session.", Type.Object({
+    tabId: Type.Optional(Type.Number()), text: Type.String(), ref: Type.Optional(Type.String()), selector: Type.Optional(Type.String()), clear: Type.Optional(Type.Boolean()), submit: Type.Optional(Type.Boolean()),
+  }), (args) => ["type", args, args.tabId as number | undefined]);
+  registerTool(pi, "surf_tool", "Run one existing Surf browser tool through the native host. Prefer the dedicated read, screenshot, click, and type tools when they fit.", Type.Object({
+    tool: Type.String(), args: Type.Optional(Type.Record(Type.String(), Type.Unknown())), tabId: Type.Optional(Type.Number()),
+  }), (args) => [args.tool as string, (args.args as Record<string, unknown>) ?? {}, args.tabId as number | undefined]);
+  registerTool(pi, "surf_oracle_status", "Get the status of a Surf oracle job, or the newest job.", Type.Object({ id: Type.Optional(Type.String()) }), (args) => ["oracle.status", args, undefined]);
+  registerTool(pi, "surf_oracle_result", "Capture the result of a Surf oracle job.", Type.Object({ id: Type.String(), timeout: Type.Optional(Type.Number()) }), (args) => ["oracle.result", args, undefined]);
+
+  const oracleJobIds = new Set<string>();
+  let sessionGeneration = 0;
+  let sessionActive = false;
+  pi.registerTool({
+    name: "surf_oracle_ask",
+    label: "surf_oracle_ask",
+    description: "Start a durable local Surf ChatGPT oracle job.",
+    parameters: Type.Object({ prompt: Type.String(), model: Type.Optional(Type.String()), effort: Type.Optional(Type.String()), follow: Type.Optional(Type.String()) }),
+    async execute(_id: string, args: Record<string, unknown>) {
+      const requestGeneration = sessionGeneration;
+      try {
+        const result = await requestSurf("oracle.ask", args);
+        const job = result.details as { id?: string } | undefined;
+        rememberOracleJobForSession(oracleJobIds, job?.id, requestGeneration, sessionGeneration, sessionActive);
+        return result;
+      } catch (error) {
+        return textResult(error instanceof Error ? error.message : String(error), true);
+      }
+    },
+  });
+
+  let dispose: (() => void) | undefined;
+  pi.on("session_start", (_event, ctx) => {
+    sessionGeneration++;
+    sessionActive = false;
+    dispose?.();
+    dispose = undefined;
+    oracleJobIds.clear();
+
+    const session = ctx as { sessionManager?: { getSessionId?: () => string }; sessionId?: string };
+    const sessionId = session.sessionId ?? session.sessionManager?.getSessionId?.();
+    if (!sessionId) return;
+    try {
+      const jobs = require("../native/oracle-jobs.cjs") as { listJobs(): Array<{ id: string; state: string }> };
+      dispose = registerOptionalBackgroundProvider(sessionId, oracleJobIds, jobs.listJobs, registerGlobalBackgroundProvider);
+      sessionActive = true;
+    } catch {
+      // pi-subagents is optional. Browser tools work without it.
+    }
+  });
+  pi.on("session_shutdown", () => {
+    sessionGeneration++;
+    sessionActive = false;
+    dispose?.();
+    dispose = undefined;
+    oracleJobIds.clear();
+  });
+}

--- a/test/unit/pi-extension.test.ts
+++ b/test/unit/pi-extension.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+const {
+  createToolRequest,
+  registerGlobalBackgroundProvider,
+  registerOptionalBackgroundProvider,
+  rememberOracleJobForSession,
+} = require("../../pi-extension/surf.ts");
+
+const backgroundWorkKey = Symbol.for("pi-subagents.background-work.v1");
+
+describe("Pi extension", () => {
+  it("maps browser tools to the native host request frame", () => {
+    const request = createToolRequest("page.read", { filter: "interactive" }, 42);
+
+    expect(request).toMatchObject({
+      type: "tool_request",
+      method: "execute_tool",
+      params: { tool: "page.read", args: { filter: "interactive" }, tabId: 42 },
+    });
+    expect(request.id).toMatch(/^pi-surf-/);
+  });
+
+  it("reports only active oracle jobs started by its Pi session", () => {
+    let provider: { listActiveWork(): Array<{ id: string; sessionId: string }> } | undefined;
+    const jobIds = new Set(["mine"]);
+    const dispose = registerOptionalBackgroundProvider(
+      "pi-session",
+      jobIds,
+      () => [
+        { id: "mine", state: "awaiting" },
+        { id: "done", state: "captured" },
+        { id: "other", state: "dispatched" },
+      ],
+      (registered: { listActiveWork(): Array<{ id: string; sessionId: string }> }) => {
+        provider = registered;
+        return () => {
+          provider = undefined;
+        };
+      },
+    );
+
+    expect(provider?.listActiveWork()).toEqual([{ id: "mine", sessionId: "pi-session" }]);
+    jobIds.clear();
+    expect(provider?.listActiveWork()).toEqual([]);
+    dispose();
+    expect(provider).toBeUndefined();
+  });
+
+  it("does not remember oracle jobs that resolve after a session reset", () => {
+    const jobIds = new Set<string>();
+
+    expect(rememberOracleJobForSession(jobIds, "old-job", 1, 2, true)).toBe(false);
+    expect([...jobIds]).toEqual([]);
+    expect(rememberOracleJobForSession(jobIds, "current-job", 2, 2, true)).toBe(true);
+    expect([...jobIds]).toEqual(["current-job"]);
+    expect(rememberOracleJobForSession(jobIds, "inactive-job", 2, 2, false)).toBe(false);
+    expect([...jobIds]).toEqual(["current-job"]);
+  });
+
+  it("creates the optional pi-subagents background registry lazily", () => {
+    delete (globalThis as Record<PropertyKey, unknown>)[backgroundWorkKey];
+    const provider = { name: "surf-oracle", wakeChannels: [], listActiveWork: () => [] };
+
+    const dispose = registerGlobalBackgroundProvider(provider);
+    const registry = (
+      globalThis as unknown as Record<PropertyKey, { providers: Map<string, unknown> }>
+    )[backgroundWorkKey];
+
+    expect(registry.providers.get("surf-oracle")).toBe(provider);
+    dispose();
+    expect(registry.providers.has("surf-oracle")).toBe(false);
+    delete (globalThis as Record<PropertyKey, unknown>)[backgroundWorkKey];
+  });
+});

--- a/tsconfig.pi-extension.json
+++ b/tsconfig.pi-extension.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["pi-extension/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Adds an optional Surf Pi extension that exposes a small browser tool surface through Pi package metadata.

The extension uses Surf's existing socket protocol for browser commands and adds optional `pi-subagents` background-work integration for Surf oracle jobs. The provider is session-scoped and creates the optional registry lazily when it is not already present.

Refs #171.

## Validation

- `npm run check`
- `npm test -- --run test/unit/pi-extension.test.ts`
- `git diff --check origin/main...HEAD`
- `npm run lint` exited 0 with the existing Biome schema info and existing accessibility-tree warning
- `npm pack --dry-run --json` includes `pi-extension/surf.ts`
- Fresh review found no remaining provider/session lifecycle findings on `6b0515f`

## Notes

No merge, tag, release, or issue closure is requested by this PR alone.