### PR TITLE
feat: add rendered page HTML export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 - **Pi extension** - Added optional Pi browser tools backed by Surf's native-host socket, plus optional pi-subagents background reporting for session-owned oracle jobs.
-- **Rendered page HTML** - Added `surf page.html` to print the current rendered document HTML.
+- **Rendered page HTML** - Added `surf page.html` to print the current rendered document HTML, with skill guidance for saving Claude artifacts or any rendered page as static HTML.
 - **Playbook script strategies** - Added opt-in trusted read-op scripts with dynamic `tools.run`/`tools.all` Surf tool orchestration and workflow auto-waits.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - **Pi extension** - Added optional Pi browser tools backed by Surf's native-host socket, plus optional pi-subagents background reporting for session-owned oracle jobs.
+- **Rendered page HTML** - Added `surf page.html` to print the current rendered document HTML.
 - **Playbook script strategies** - Added opt-in trusted read-op scripts with dynamic `tools.run`/`tools.all` Surf tool orchestration and workflow auto-waits.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ surf read --compact                 # Remove empty structural elements
 surf read --depth 3 --compact       # Both (60% smaller output)
 surf read --max-bytes 2000          # Cap visible text on a UTF-8 byte boundary
 surf page.text                      # Raw text content only
+surf page.html                      # Rendered document HTML
 surf page.state                     # Modals, loading state, scroll position
 ```
 

--- a/README.md
+++ b/README.md
@@ -231,8 +231,11 @@ surf read --depth 3 --compact       # Both (60% smaller output)
 surf read --max-bytes 2000          # Cap visible text on a UTF-8 byte boundary
 surf page.text                      # Raw text content only
 surf page.html                      # Rendered document HTML
+surf page.html > artifact.html      # Save Claude artifacts or any rendered page
 surf page.state                     # Modals, loading state, scroll position
 ```
+
+Use `surf page.html` after the page loads when you need a static HTML export of the current rendered DOM. It targets the active frame when `frame.switch` is active.
 
 Element refs (`e1`, `e2`, `e3`...) are stable identifiers from the accessibility tree - semantic, predictable, and resilient to DOM changes.
 

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -3380,7 +3380,7 @@ async function handleResponse(response) {
     console.log(data.pageContent);
   } else if (tool === "page.text" && data?.text) {
     console.log(data.text);
-  } else if (tool === "page.html" && data?.html) {
+  } else if (tool === "page.html" && typeof data?.html === "string") {
     console.log(data.html);
   } else if (tool === "emulate.device" && data?.devices) {
     console.log("Available devices:\n");

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -533,7 +533,7 @@ const TOOLS = {
       "scroll": {
         desc: "Scroll in direction",
         args: ["direction", "pixels"],
-        opts: { direction: "up|down|left|right", amount: "Scroll amount (1-10)" },
+        opts: { direction: "up|down|left|right", amount: "Scroll amount in 100 px steps (1-10)" },
         examples: [
           { cmd: "scroll down 800", desc: "Scroll down 800px" },
           { cmd: "scroll --direction down --amount 3", desc: "Scroll down" },

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -576,6 +576,11 @@ const TOOLS = {
       },
       "read": { desc: "Alias for page.read", args: [], alias: "page.read" },
       "page.text": { desc: "Extract all text from page", args: [] },
+      "page.html": {
+        desc: "Print rendered document HTML",
+        args: [],
+        examples: [{ cmd: "page.html", desc: "Print current document HTML" }],
+      },
       "page.state": { desc: "Get page state (modals, loading, etc.)", args: [] },
     }
   },
@@ -1464,7 +1469,7 @@ const ALL_SOCKET_TOOLS = [
   "click_type", "click_type_submit", "type", "key", "type_submit",
   "scroll", "scroll_to", "hover", "left_click_drag", "drag", "wait",
   "computer",
-  "page.read", "page.text", "page.state",
+  "page.read", "page.text", "page.html", "page.state",
   "locate.role", "locate.text", "locate.label",
   "tab.list", "tab.new", "tab.switch", "tab.close", "tab.move", "tab.name", "tab.unname", "tab.named",
   "tab.group", "tab.ungroup", "tab.groups", "tab.reload",
@@ -3375,6 +3380,8 @@ async function handleResponse(response) {
     console.log(data.pageContent);
   } else if (tool === "page.text" && data?.text) {
     console.log(data.text);
+  } else if (tool === "page.html" && data?.html) {
+    console.log(data.html);
   } else if (tool === "emulate.device" && data?.devices) {
     console.log("Available devices:\n");
     const devices = data.devices;

--- a/native/host-helpers.cjs
+++ b/native/host-helpers.cjs
@@ -936,6 +936,8 @@ function mapToolToMessage(tool, args, tabId) {
     }
     case "page.text":
       return { type: "GET_PAGE_TEXT", ...baseMsg };
+    case "page.html":
+      return { type: "GET_PAGE_HTML", ...baseMsg };
     case "page.state":
       return { type: "PAGE_STATE", ...baseMsg };
     case "locate.role":

--- a/skills/surf/SKILL.md
+++ b/skills/surf/SKILL.md
@@ -292,8 +292,24 @@ surf page.read --depth 3       # Limit tree depth
 surf page.read --compact       # Minimal output for LLM efficiency
 surf page.read --max-bytes 2000 # Cap visible text at a UTF-8 byte boundary
 surf page.text                 # Plain text content only
+surf page.html                 # Rendered document HTML
 surf page.state                # Modals, loading state, scroll info
 ```
+
+### Export Rendered HTML
+
+Use `page.html` when the user wants a static copy of the current rendered DOM. This works for Claude artifact pages and ordinary web pages.
+
+```bash
+# Save the active page as HTML.
+surf page.html > page.html
+
+# Save a Claude artifact or other preview page after it loads.
+surf wait.dom --stable 500
+surf page.html > artifact.html
+```
+
+`page.html` exports the selected frame when `frame.switch` is active. Use `page.read` first when you need refs or visible text. Use `page.html` when you need the actual rendered markup.
 
 ## Semantic Element Location
 
@@ -687,10 +703,11 @@ surf wait.element ".missing" --auto-capture --timeout 2000
 12. **Window isolation** - Use `window.new` + `--window-id` or `--tab-id` to keep agent work separate from your browsing
 13. **Request lock** - Non-streaming browser CLI requests serialize per socket; use `--no-lock` only when you intentionally want to bypass it
 14. **Native host diagnostics** - If commands fail with socket/native-host errors, run `surf doctor` or `surf doctor --browser all` before guessing at reinstall steps
-15. **Animation capture** - Use `surf record --duration 2000 --fps 10 --output /tmp/anim.gif` when the agent needs to see motion; use `animate-audit` for numeric timelines and `perf-audit` for jank/layout-shift snapshots
-16. **Hard isolation** - Use separate browser/profile instances plus separate `SURF_SOCKET` values when agents must not share a host or target
-17. **Semantic locators** - `locate.role`, `locate.text`, `locate.label` for more robust element finding
-18. **Frame context** - Use `frame.switch` before interacting with iframe content
+15. **HTML export** - Use `surf page.html > artifact.html` to save Claude artifacts or any rendered page as static HTML
+16. **Animation capture** - Use `surf record --duration 2000 --fps 10 --output /tmp/anim.gif` when the agent needs to see motion; use `animate-audit` for numeric timelines and `perf-audit` for jank/layout-shift snapshots
+17. **Hard isolation** - Use separate browser/profile instances plus separate `SURF_SOCKET` values when agents must not share a host or target
+18. **Semantic locators** - `locate.role`, `locate.text`, `locate.label` for more robust element finding
+19. **Frame context** - Use `frame.switch` before interacting with iframe content
 
 ## Socket API
 

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -1142,7 +1142,9 @@ export async function handleMessage(
           return doctype + document.documentElement.outerHTML;
         },
       });
-      return { html: results[0]?.result };
+      const html = results[0]?.result;
+      if (typeof html !== "string") throw new Error("Page HTML extraction returned an invalid result");
+      return { html };
     }
 
     case "LOCATE_ROLE": {

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -1133,6 +1133,18 @@ export async function handleMessage(
       }
     }
 
+    case "GET_PAGE_HTML": {
+      if (!tabId) throw new Error("No tabId provided");
+      const results = await chrome.scripting.executeScript({
+        target: { tabId, frameIds: [getFrameIdForTab(tabId)] },
+        func: () => {
+          const doctype = document.doctype ? `<!doctype ${document.doctype.name}>\n` : "";
+          return doctype + document.documentElement.outerHTML;
+        },
+      });
+      return { html: results[0]?.result };
+    }
+
     case "LOCATE_ROLE": {
       if (!tabId) throw new Error("No tabId provided");
       if (!message.role) throw new Error("role required");

--- a/test/unit/cli-args.test.ts
+++ b/test/unit/cli-args.test.ts
@@ -139,6 +139,9 @@ function createCliFixtureResult(request: any) {
       height: 1,
     };
   }
+  if (request.params.tool === "page.html") {
+    return { html: "<!doctype html>\n<html><body>Rendered</body></html>" };
+  }
   return "OK";
 }
 
@@ -268,6 +271,14 @@ describe("CLI argument parsing", () => {
     expect(stderr).toBe("");
     expect(stdout).toContain("surf --llm-context");
     expect(stdout).toContain("--remote <host>:<port>");
+  });
+
+  it("shows page.html command help without a socket", async () => {
+    const { code, stdout, stderr } = await runCliWithoutSocket(["page.html", "--help"]);
+
+    expect(code).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("page.html - Print rendered document HTML");
   });
 
   it("keeps remote credential management local when remote routing is configured", async () => {
@@ -777,6 +788,14 @@ describe("CLI argument parsing", () => {
 
     expect(request.params.tool).toBe("page.read");
     expect(request.params.args).toMatchObject({ compact: true, "max-bytes": 1200 });
+  });
+
+  it("requests and prints rendered page HTML", async () => {
+    const { request, stdout } = await runCli(["page.html"]);
+
+    expect(request.params.tool).toBe("page.html");
+    expect(request.params.args).toEqual({});
+    expect(stdout).toBe("<!doctype html>\n<html><body>Rendered</body></html>\n");
   });
 
   it("rejects explicit CDP typing with selector targets", async () => {

--- a/test/unit/host-helpers.test.ts
+++ b/test/unit/host-helpers.test.ts
@@ -188,6 +188,15 @@ describe("mapToolToMessage", () => {
     });
   });
 
+  describe("page.html command", () => {
+    it("maps to the dedicated page HTML message", () => {
+      expect(helpers.mapToolToMessage("page.html", {}, 123)).toEqual({
+        type: "GET_PAGE_HTML",
+        tabId: 123,
+      });
+    });
+  });
+
   describe("type command", () => {
     it("routes a selector target to SMART_TYPE", () => {
       const msg = helpers.mapToolToMessage("type", { text: "hello", selector: "#i" });

--- a/test/unit/service-worker/javascript-handlers.test.ts
+++ b/test/unit/service-worker/javascript-handlers.test.ts
@@ -239,6 +239,73 @@ describe("JavaScript command handlers", () => {
   });
 });
 
+describe("Page HTML handler", () => {
+  beforeEach(() => {
+    resetChromeMock();
+  });
+
+  it("serializes the selected frame document with its doctype", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: {
+        doctype: { name: "html" },
+        documentElement: { outerHTML: "<html><body>Rendered</body></html>" },
+      },
+    });
+    chrome.webNavigation.getAllFrames.mockResolvedValue([
+      { frameId: 0, url: "https://example.com" },
+      { frameId: 7, url: "https://frame.example.com" },
+    ]);
+    chrome.scripting.executeScript.mockImplementation(async (injection: any) => [
+      { result: injection.func() },
+    ]);
+
+    try {
+      await handleMessage({ type: "FRAME_SWITCH", tabId: 1, index: 0 }, {});
+      const result = await handleMessage({ type: "GET_PAGE_HTML", tabId: 1 }, {});
+
+      expect(result).toEqual({ html: "<!doctype html>\n<html><body>Rendered</body></html>" });
+      expect(chrome.scripting.executeScript).toHaveBeenCalledWith(
+        expect.objectContaining({ target: { tabId: 1, frameIds: [7] } }),
+      );
+    } finally {
+      if (originalDocument) {
+        Object.defineProperty(globalThis, "document", originalDocument);
+      } else {
+        Reflect.deleteProperty(globalThis, "document");
+      }
+    }
+  });
+
+  it("omits the doctype prefix when the document has no doctype", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: { doctype: null, documentElement: { outerHTML: "<html></html>" } },
+    });
+    chrome.scripting.executeScript.mockImplementation(async (injection: any) => [
+      { result: injection.func() },
+    ]);
+
+    try {
+      await expect(handleMessage({ type: "GET_PAGE_HTML", tabId: 1 }, {})).resolves.toEqual({
+        html: "<html></html>",
+      });
+    } finally {
+      if (originalDocument) {
+        Object.defineProperty(globalThis, "document", originalDocument);
+      } else {
+        Reflect.deleteProperty(globalThis, "document");
+      }
+    }
+  });
+});
+
 describe("Animation audit handler", () => {
   beforeEach(() => {
     resetChromeMock();

--- a/test/unit/service-worker/javascript-handlers.test.ts
+++ b/test/unit/service-worker/javascript-handlers.test.ts
@@ -280,6 +280,16 @@ describe("Page HTML handler", () => {
     }
   });
 
+  it("rejects malformed page HTML extraction results", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    chrome.scripting.executeScript.mockResolvedValue([{ result: undefined }]);
+
+    await expect(handleMessage({ type: "GET_PAGE_HTML", tabId: 1 }, {})).rejects.toThrow(
+      "Page HTML extraction returned an invalid result",
+    );
+  });
+
   it("omits the doctype prefix when the document has no doctype", async () => {
     const handleMessage = await loadHandleMessage();
     const chrome = (globalThis as any).chrome;


### PR DESCRIPTION
## Summary

Adds `surf page.html` for exporting the current rendered document HTML.

This prints the selected frame's rendered DOM as raw HTML, including a doctype prefix when present. The PR also updates the packaged Surf skill so agents can save Claude artifact pages or any rendered page with `surf page.html > artifact.html`, and clarifies that `scroll --amount` uses 100 px steps.

Refs #172. This is the `page.html` slice only. `page.save`, selector export, `--strip-scripts`, and other export options stay deferred.

## Validation

- `npx vitest run test/unit/host-helpers.test.ts test/unit/cli-args.test.ts test/unit/service-worker/javascript-handlers.test.ts`
- `npm run check`
- `git diff --check origin/main...HEAD`
- `node native/cli.cjs page.html --help`
- Fresh review found no concrete current-diff findings on the `page.html` implementation

## Notes

No merge, tag, release, or issue closure is requested by this PR alone.
