### PR TITLE
feat: save rendered page HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 - **Pi extension** - Added optional Pi browser tools backed by Surf's native-host socket, plus optional pi-subagents background reporting for session-owned oracle jobs.
-- **Rendered page HTML** - Added `surf page.html` to print the current rendered document HTML, with skill guidance for saving Claude artifacts or any rendered page as static HTML.
+- **Rendered page HTML** - Added `surf page.html` to print and `surf page.save --output <path>` to save the current rendered document HTML, with skill guidance for saving Claude artifacts or any rendered page as static HTML.
 - **Playbook script strategies** - Added opt-in trusted read-op scripts with dynamic `tools.run`/`tools.all` Surf tool orchestration and workflow auto-waits.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ surf read --max-bytes 2000          # Cap visible text on a UTF-8 byte boundary
 surf page.text                      # Raw text content only
 surf page.html                      # Rendered document HTML
 surf page.html > artifact.html      # Save Claude artifacts or any rendered page
+surf page.save --output artifact.html # Save rendered HTML to a file
 surf page.state                     # Modals, loading state, scroll position
 ```
 

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -581,6 +581,12 @@ const TOOLS = {
         args: [],
         examples: [{ cmd: "page.html", desc: "Print current document HTML" }],
       },
+      "page.save": {
+        desc: "Save rendered document HTML",
+        args: [],
+        opts: { output: "File path" },
+        examples: [{ cmd: "page.save --output page.html", desc: "Save current document HTML" }],
+      },
       "page.state": { desc: "Get page state (modals, loading, etc.)", args: [] },
     }
   },
@@ -1469,7 +1475,7 @@ const ALL_SOCKET_TOOLS = [
   "click_type", "click_type_submit", "type", "key", "type_submit",
   "scroll", "scroll_to", "hover", "left_click_drag", "drag", "wait",
   "computer",
-  "page.read", "page.text", "page.html", "page.state",
+  "page.read", "page.text", "page.html", "page.save", "page.state",
   "locate.role", "locate.text", "locate.label",
   "tab.list", "tab.new", "tab.switch", "tab.close", "tab.move", "tab.name", "tab.unname", "tab.named",
   "tab.group", "tab.ungroup", "tab.groups", "tab.reload",
@@ -2823,8 +2829,13 @@ if (tool === "network.export" && outputPath !== undefined) {
   toolArgs.output = outputPath;
 }
 
-if ((tool === "screenshot" || tool === "record" || tool === "perf-audit") && outputPath && typeof outputPath !== "string") {
+if ((tool === "screenshot" || tool === "record" || tool === "perf-audit" || tool === "page.save") && outputPath && typeof outputPath !== "string") {
   console.error("Error: --output requires a file path");
+  process.exit(1);
+}
+
+if (tool === "page.save" && !outputPath) {
+  console.error("Error: page.save requires --output <path>");
   process.exit(1);
 }
 
@@ -3297,6 +3308,17 @@ async function handleResponse(response) {
 
   if (tool === 'aistudio' && typeof data === 'string') {
     data = { response: data };
+  }
+
+  if (tool === "page.save" && typeof data?.html === "string") {
+    const saveTo = path.resolve(outputPath);
+    fs.mkdirSync(path.dirname(saveTo), { recursive: true });
+    fs.writeFileSync(saveTo, data.html);
+    if (!wantJson) {
+      console.log(`Saved rendered page HTML to ${saveTo}`);
+      socket.end();
+      process.exit(0);
+    }
   }
 
   if (tool === "perf-audit" && outputPath) {

--- a/native/host-helpers.cjs
+++ b/native/host-helpers.cjs
@@ -937,6 +937,7 @@ function mapToolToMessage(tool, args, tabId) {
     case "page.text":
       return { type: "GET_PAGE_TEXT", ...baseMsg };
     case "page.html":
+    case "page.save":
       return { type: "GET_PAGE_HTML", ...baseMsg };
     case "page.state":
       return { type: "PAGE_STATE", ...baseMsg };

--- a/skills/surf/SKILL.md
+++ b/skills/surf/SKILL.md
@@ -293,6 +293,7 @@ surf page.read --compact       # Minimal output for LLM efficiency
 surf page.read --max-bytes 2000 # Cap visible text at a UTF-8 byte boundary
 surf page.text                 # Plain text content only
 surf page.html                 # Rendered document HTML
+surf page.save --output page.html # Save rendered HTML to a file
 surf page.state                # Modals, loading state, scroll info
 ```
 
@@ -302,7 +303,7 @@ Use `page.html` when the user wants a static copy of the current rendered DOM. T
 
 ```bash
 # Save the active page as HTML.
-surf page.html > page.html
+surf page.save --output page.html
 
 # Save a Claude artifact or other preview page after it loads.
 surf wait.dom --stable 500

--- a/test/unit/cli-args.test.ts
+++ b/test/unit/cli-args.test.ts
@@ -139,7 +139,7 @@ function createCliFixtureResult(request: any) {
       height: 1,
     };
   }
-  if (request.params.tool === "page.html") {
+  if (request.params.tool === "page.html" || request.params.tool === "page.save") {
     return { html: "<!doctype html>\n<html><body>Rendered</body></html>" };
   }
   return "OK";
@@ -796,6 +796,19 @@ describe("CLI argument parsing", () => {
     expect(request.params.tool).toBe("page.html");
     expect(request.params.args).toEqual({});
     expect(stdout).toBe("<!doctype html>\n<html><body>Rendered</body></html>\n");
+  });
+
+  it("saves rendered page HTML through the page HTML tool", async () => {
+    const output = path.join(os.tmpdir(), `surf-page-save-${process.pid}-${Date.now()}.html`);
+    try {
+      const { request, stdout } = await runCli(["page.save", "--output", output]);
+      expect(request.params.tool).toBe("page.save");
+      expect(request.params.args).toEqual({});
+      expect(fs.readFileSync(output, "utf8")).toBe("<!doctype html>\n<html><body>Rendered</body></html>");
+      expect(stdout).toContain(`Saved rendered page HTML to ${output}`);
+    } finally {
+      fs.rmSync(output, { force: true });
+    }
   });
 
   it("rejects explicit CDP typing with selector targets", async () => {

--- a/test/unit/cli-args.test.ts
+++ b/test/unit/cli-args.test.ts
@@ -804,7 +804,9 @@ describe("CLI argument parsing", () => {
       const { request, stdout } = await runCli(["page.save", "--output", output]);
       expect(request.params.tool).toBe("page.save");
       expect(request.params.args).toEqual({});
-      expect(fs.readFileSync(output, "utf8")).toBe("<!doctype html>\n<html><body>Rendered</body></html>");
+      expect(fs.readFileSync(output, "utf8")).toBe(
+        "<!doctype html>\n<html><body>Rendered</body></html>",
+      );
       expect(stdout).toContain(`Saved rendered page HTML to ${output}`);
     } finally {
       fs.rmSync(output, { force: true });

--- a/test/unit/host-helpers.test.ts
+++ b/test/unit/host-helpers.test.ts
@@ -189,11 +189,13 @@ describe("mapToolToMessage", () => {
   });
 
   describe("page.html command", () => {
-    it("maps to the dedicated page HTML message", () => {
-      expect(helpers.mapToolToMessage("page.html", {}, 123)).toEqual({
-        type: "GET_PAGE_HTML",
-        tabId: 123,
-      });
+    it("maps page HTML commands to the dedicated message", () => {
+      for (const tool of ["page.html", "page.save"]) {
+        expect(helpers.mapToolToMessage(tool, {}, 123)).toEqual({
+          type: "GET_PAGE_HTML",
+          tabId: 123,
+        });
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

Adds `surf page.save --output <path>` as the file-output form of the rendered HTML export from #172.

The command reuses the existing `GET_PAGE_HTML` extraction path, keeps the output path local to the CLI/native side, requires `--output`, and writes the returned HTML to disk. Docs and the packaged Surf skill now show the direct save command.

Refs #172.

## Validation

- `npx vitest run test/unit/host-helpers.test.ts test/unit/cli-args.test.ts`
- `npm run check`
- `git diff --check origin/main...HEAD`
- `node native/cli.cjs page.save --help`
- Fresh exact-head review found no concrete release risks on `8c7de38`

## Notes

This is the minimal `page.save --output` slice. Selector/subtree export and `--strip-scripts` are still outside this PR.
