### PR TITLE
feat: add bounded rendered HTML exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 - **Pi extension** - Added optional Pi browser tools backed by Surf's native-host socket, plus optional pi-subagents background reporting for session-owned oracle jobs.
-- **Rendered page HTML** - Added `surf page.html` to print and `surf page.save --output <path>` to save the current rendered document HTML, with skill guidance for saving Claude artifacts or any rendered page as static HTML.
+- **Rendered page HTML** - Added `surf page.html` to print and `surf page.save --output <path>` to save the current rendered document HTML, with `--selector <css>` and `--strip-scripts` for bounded static exports of Claude artifacts or other rendered pages.
 - **Playbook script strategies** - Added opt-in trusted read-op scripts with dynamic `tools.run`/`tools.all` Surf tool orchestration and workflow auto-waits.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -231,12 +231,12 @@ surf read --depth 3 --compact       # Both (60% smaller output)
 surf read --max-bytes 2000          # Cap visible text on a UTF-8 byte boundary
 surf page.text                      # Raw text content only
 surf page.html                      # Rendered document HTML
-surf page.html > artifact.html      # Save Claude artifacts or any rendered page
-surf page.save --output artifact.html # Save rendered HTML to a file
+surf page.html --strip-scripts > artifact.html # Save a safe static Claude artifact
+surf page.save --selector "#artifact" --strip-scripts --output artifact.html # Save one rendered element
 surf page.state                     # Modals, loading state, scroll position
 ```
 
-Use `surf page.html` after the page loads when you need a static HTML export of the current rendered DOM. It targets the active frame when `frame.switch` is active.
+Use `surf page.html --strip-scripts` after the page loads when you need a static export of a Claude artifact or other rendered DOM. Use `--selector <css>` to export one element. Both commands target the active frame when `frame.switch` is active.
 
 Element refs (`e1`, `e2`, `e3`...) are stable identifiers from the accessibility tree - semantic, predictable, and resilient to DOM changes.
 

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -579,12 +579,13 @@ const TOOLS = {
       "page.html": {
         desc: "Print rendered document HTML",
         args: [],
+        opts: { selector: "Export matching CSS selector", "strip-scripts": "Remove script elements" },
         examples: [{ cmd: "page.html", desc: "Print current document HTML" }],
       },
       "page.save": {
         desc: "Save rendered document HTML",
         args: [],
-        opts: { output: "File path" },
+        opts: { output: "File path", selector: "Export matching CSS selector", "strip-scripts": "Remove script elements" },
         examples: [{ cmd: "page.save --output page.html", desc: "Save current document HTML" }],
       },
       "page.state": { desc: "Get page state (modals, loading, etc.)", args: [] },

--- a/native/host-helpers.cjs
+++ b/native/host-helpers.cjs
@@ -937,8 +937,17 @@ function mapToolToMessage(tool, args, tabId) {
     case "page.text":
       return { type: "GET_PAGE_TEXT", ...baseMsg };
     case "page.html":
-    case "page.save":
-      return { type: "GET_PAGE_HTML", ...baseMsg };
+    case "page.save": {
+      if (a.selector !== undefined && (typeof a.selector !== "string" || a.selector.length === 0)) {
+        throw new Error("selector must be a non-empty string");
+      }
+      return {
+        type: "GET_PAGE_HTML",
+        selector: a.selector,
+        stripScripts: a["strip-scripts"] === true,
+        ...baseMsg,
+      };
+    }
     case "page.state":
       return { type: "PAGE_STATE", ...baseMsg };
     case "locate.role":

--- a/skills/surf/SKILL.md
+++ b/skills/surf/SKILL.md
@@ -63,8 +63,8 @@ surf click --x 100 --y 200
 # 4. Type text
 surf type --text "hello"
 
-# 5. Screenshot
-surf screenshot --output /tmp/shot.png
+# 5. Full-page screenshot
+surf screenshot --full-page --output /tmp/shot.png
 
 # Inspect animation/style changes as JSON
 surf animate-audit --selector ".thing" --duration 2000 --fps 10
@@ -292,8 +292,8 @@ surf page.read --depth 3       # Limit tree depth
 surf page.read --compact       # Minimal output for LLM efficiency
 surf page.read --max-bytes 2000 # Cap visible text at a UTF-8 byte boundary
 surf page.text                 # Plain text content only
-surf page.html                 # Rendered document HTML
-surf page.save --output page.html # Save rendered HTML to a file
+surf page.html --strip-scripts # Rendered HTML without scripts
+surf page.save --selector "#artifact" --strip-scripts --output page.html # Save one static element
 surf page.state                # Modals, loading state, scroll info
 ```
 
@@ -305,12 +305,12 @@ Use `page.html` when the user wants a static copy of the current rendered DOM. T
 # Save the active page as HTML.
 surf page.save --output page.html
 
-# Save a Claude artifact or other preview page after it loads.
+# Save a Claude artifact or other preview page after it loads, without scripts.
 surf wait.dom --stable 500
-surf page.html > artifact.html
+surf page.html --selector "#artifact" --strip-scripts > artifact.html
 ```
 
-`page.html` exports the selected frame when `frame.switch` is active. Use `page.read` first when you need refs or visible text. Use `page.html` when you need the actual rendered markup.
+Use `--selector <css>` to export its matching element only. A selector miss fails with an error. `--strip-scripts` removes scripts from exported markup without changing the page. Without `--selector`, `page.html` exports the whole document with its doctype. `page.html` exports the selected frame when `frame.switch` is active. Use `page.read` first when you need refs or visible text.
 
 ## Semantic Element Location
 

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -1137,10 +1137,21 @@ export async function handleMessage(
       if (!tabId) throw new Error("No tabId provided");
       const results = await chrome.scripting.executeScript({
         target: { tabId, frameIds: [getFrameIdForTab(tabId)] },
-        func: () => {
-          const doctype = document.doctype ? `<!doctype ${document.doctype.name}>\n` : "";
-          return doctype + document.documentElement.outerHTML;
+        func: (selector?: unknown, stripScripts?: boolean) => {
+          if (selector !== undefined && (typeof selector !== "string" || selector.length === 0)) {
+            throw new Error("selector must be a non-empty string");
+          }
+          const root = selector === undefined ? document.documentElement : document.querySelector(selector);
+          if (!root) throw new Error(`No element matches selector "${selector}"`);
+          const exportRoot = stripScripts ? root.cloneNode(true) as Element : root;
+          if (stripScripts) {
+            if (exportRoot.matches("script")) return "";
+            exportRoot.querySelectorAll("script").forEach((script) => script.remove());
+          }
+          const doctype = selector === undefined && document.doctype ? `<!doctype ${document.doctype.name}>\n` : "";
+          return doctype + exportRoot.outerHTML;
         },
+        args: [message.selector, message.stripScripts],
       });
       const html = results[0]?.result;
       if (typeof html !== "string") throw new Error("Page HTML extraction returned an invalid result");

--- a/test/unit/cli-args.test.ts
+++ b/test/unit/cli-args.test.ts
@@ -791,19 +791,31 @@ describe("CLI argument parsing", () => {
   });
 
   it("requests and prints rendered page HTML", async () => {
-    const { request, stdout } = await runCli(["page.html"]);
+    const { request, stdout } = await runCli([
+      "page.html",
+      "--selector",
+      "#artifact",
+      "--strip-scripts",
+    ]);
 
     expect(request.params.tool).toBe("page.html");
-    expect(request.params.args).toEqual({});
+    expect(request.params.args).toEqual({ selector: "#artifact", "strip-scripts": true });
     expect(stdout).toBe("<!doctype html>\n<html><body>Rendered</body></html>\n");
   });
 
   it("saves rendered page HTML through the page HTML tool", async () => {
     const output = path.join(os.tmpdir(), `surf-page-save-${process.pid}-${Date.now()}.html`);
     try {
-      const { request, stdout } = await runCli(["page.save", "--output", output]);
+      const { request, stdout } = await runCli([
+        "page.save",
+        "--selector",
+        "#artifact",
+        "--strip-scripts",
+        "--output",
+        output,
+      ]);
       expect(request.params.tool).toBe("page.save");
-      expect(request.params.args).toEqual({});
+      expect(request.params.args).toEqual({ selector: "#artifact", "strip-scripts": true });
       expect(fs.readFileSync(output, "utf8")).toBe(
         "<!doctype html>\n<html><body>Rendered</body></html>",
       );

--- a/test/unit/host-helpers.test.ts
+++ b/test/unit/host-helpers.test.ts
@@ -189,12 +189,24 @@ describe("mapToolToMessage", () => {
   });
 
   describe("page.html command", () => {
-    it("maps page HTML commands to the dedicated message", () => {
+    it("maps page HTML commands and export options to the dedicated message", () => {
       for (const tool of ["page.html", "page.save"]) {
-        expect(helpers.mapToolToMessage(tool, {}, 123)).toEqual({
+        expect(
+          helpers.mapToolToMessage(tool, { selector: "#artifact", "strip-scripts": true }, 123),
+        ).toEqual({
           type: "GET_PAGE_HTML",
+          selector: "#artifact",
+          stripScripts: true,
           tabId: 123,
         });
+      }
+    });
+
+    it("rejects invalid export selectors", () => {
+      for (const selector of ["", false]) {
+        expect(() => helpers.mapToolToMessage("page.html", { selector })).toThrow(
+          "selector must be a non-empty string",
+        );
       }
     });
   });

--- a/test/unit/service-worker/javascript-handlers.test.ts
+++ b/test/unit/service-worker/javascript-handlers.test.ts
@@ -280,6 +280,77 @@ describe("Page HTML handler", () => {
     }
   });
 
+  it("rejects invalid export selector values", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    chrome.scripting.executeScript.mockImplementation(async (injection: any) => [
+      { result: injection.func(...injection.args) },
+    ]);
+
+    await expect(
+      handleMessage({ type: "GET_PAGE_HTML", tabId: 1, selector: false }, {}),
+    ).rejects.toThrow("selector must be a non-empty string");
+  });
+
+  it("fails loudly when the requested export selector does not match", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: { querySelector: () => null },
+    });
+    chrome.scripting.executeScript.mockImplementation(async (injection: any) => [
+      { result: injection.func(...injection.args) },
+    ]);
+
+    try {
+      await expect(
+        handleMessage({ type: "GET_PAGE_HTML", tabId: 1, selector: "#missing" }, {}),
+      ).rejects.toThrow('No element matches selector "#missing"');
+    } finally {
+      if (originalDocument) {
+        Object.defineProperty(globalThis, "document", originalDocument);
+      } else {
+        Reflect.deleteProperty(globalThis, "document");
+      }
+    }
+  });
+
+  it("strips a selected script root", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+    const script = {
+      cloneNode: () => script,
+      matches: (selector: string) => selector === "script",
+      outerHTML: "<script>alert(1)</script>",
+      querySelectorAll: () => [],
+    };
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: { querySelector: () => script },
+    });
+    chrome.scripting.executeScript.mockImplementation(async (injection: any) => [
+      { result: injection.func(...injection.args) },
+    ]);
+
+    try {
+      await expect(
+        handleMessage(
+          { type: "GET_PAGE_HTML", tabId: 1, selector: "script", stripScripts: true },
+          {},
+        ),
+      ).resolves.toEqual({ html: "" });
+    } finally {
+      if (originalDocument) {
+        Object.defineProperty(globalThis, "document", originalDocument);
+      } else {
+        Reflect.deleteProperty(globalThis, "document");
+      }
+    }
+  });
+
   it("rejects malformed page HTML extraction results", async () => {
     const handleMessage = await loadHandleMessage();
     const chrome = (globalThis as any).chrome;


### PR DESCRIPTION
## Summary

Completes the remaining bounded rendered HTML export options from #172.

Adds `--selector <css>` and `--strip-scripts` to both `surf page.html` and `surf page.save --output <path>`. Selector exports fail loudly when the selector is invalid or missing, whole-document exports still include the doctype, and script stripping works on a clone so it does not mutate the live page. The Surf skill also promotes `surf screenshot --full-page` in the first workflow block.

Refs #172.

## Validation

- `npx vitest run test/unit/host-helpers.test.ts test/unit/cli-args.test.ts test/unit/service-worker/javascript-handlers.test.ts`
- `npm run lint` exited 0 with existing Biome schema info and existing static-only test-class warning
- `npm run check`
- `git diff --check origin/main...HEAD`
- Fresh review found two concrete issues; both were fixed.
- Follow-up review found no findings on `127ec79` and said #172 can close after this lands.

## Notes

No release or tag is part of this PR.
