### PR TITLE
fix: tighten Pi background bridge integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- **Pi extension background bridge** - Prefer the official `pi-subagents/background-work` helper when Pi loads Surf with pi-subagents available, while keeping the global fallback for Claude Code, Codex, Cursor, direct CLI use, and other non-Pi harnesses.
+
 ## [2.12.0] - 2026-08-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changed
 - **Pi extension background bridge** - Prefer the official `pi-subagents/background-work` helper when Pi loads Surf with pi-subagents available, while keeping the global fallback for Claude Code, Codex, Cursor, direct CLI use, and other non-Pi harnesses.
 
+### Fixed
+- **Pi oracle wake channel** - Emit `surf-oracle:finished` when Surf observes a terminal oracle result so pi-subagents can wake without waiting for the next snapshot poll.
+
 ## [2.12.0] - 2026-08-07
 
 ### Added

--- a/pi-extension/surf.ts
+++ b/pi-extension/surf.ts
@@ -23,6 +23,7 @@ const MAX_OUTPUT_CHARS = 20_000;
 const ORACLE_ACTIVE_STATES = new Set(["created", "dispatched", "awaiting"]);
 const BACKGROUND_WORK_PROTOCOL_VERSION = 1;
 const BACKGROUND_WORK_REGISTRY_KEY = "pi-subagents.background-work.v1";
+const BACKGROUND_WORK_MODULE_SPECIFIER = "pi-subagents/background-work";
 
 type Pi = {
   registerTool(tool: Record<string, unknown>): void;
@@ -37,6 +38,12 @@ type BackgroundWorkProvider = {
   name: string;
   wakeChannels: string[];
   listActiveWork(): Array<{ id: string; sessionId: string }>;
+};
+
+type RegisterBackgroundWorkProvider = (provider: BackgroundWorkProvider) => () => void;
+
+type BackgroundWorkModule = {
+  registerBackgroundWorkProvider?: unknown;
 };
 
 type BackgroundWorkRegistry = {
@@ -128,7 +135,21 @@ export function registerGlobalBackgroundProvider(provider: BackgroundWorkProvide
   };
 }
 
-export function registerOptionalBackgroundProvider(sessionId: string, jobIds: Set<string>, listJobs: () => Array<{ id: string; state: string }>, register: (provider: BackgroundWorkProvider) => () => void) {
+export async function resolveBackgroundWorkRegister(
+  loadModule: () => Promise<BackgroundWorkModule> = () => import(BACKGROUND_WORK_MODULE_SPECIFIER) as Promise<BackgroundWorkModule>,
+): Promise<RegisterBackgroundWorkProvider> {
+  try {
+    const module = await loadModule();
+    if (typeof module.registerBackgroundWorkProvider === "function") {
+      return module.registerBackgroundWorkProvider as RegisterBackgroundWorkProvider;
+    }
+  } catch {
+    // The Pi bridge is optional. Surf also runs in other coding-agent harnesses and as a direct CLI.
+  }
+  return registerGlobalBackgroundProvider;
+}
+
+export function registerOptionalBackgroundProvider(sessionId: string, jobIds: Set<string>, listJobs: () => Array<{ id: string; state: string }>, register: RegisterBackgroundWorkProvider) {
   return register({
     name: "surf-oracle",
     wakeChannels: ["surf-oracle:finished"],
@@ -204,6 +225,7 @@ export default function surfExtension(pi: Pi) {
   let dispose: (() => void) | undefined;
   pi.on("session_start", (_event, ctx) => {
     sessionGeneration++;
+    const generation = sessionGeneration;
     sessionActive = false;
     dispose?.();
     dispose = undefined;
@@ -216,8 +238,22 @@ export default function surfExtension(pi: Pi) {
       const jobs = require("../native/oracle-jobs.cjs") as { listJobs(): Array<{ id: string; state: string }> };
       dispose = registerOptionalBackgroundProvider(sessionId, oracleJobIds, jobs.listJobs, registerGlobalBackgroundProvider);
       sessionActive = true;
+      void resolveBackgroundWorkRegister().then((register) => {
+        try {
+          if (register === registerGlobalBackgroundProvider || generation !== sessionGeneration) return;
+          const nextDispose = registerOptionalBackgroundProvider(sessionId, oracleJobIds, jobs.listJobs, register);
+          if (generation !== sessionGeneration) {
+            nextDispose();
+            return;
+          }
+          dispose?.();
+          dispose = nextDispose;
+        } catch {
+          // Keep the already-registered fallback provider.
+        }
+      });
     } catch {
-      // pi-subagents is optional. Browser tools work without it.
+      // The Pi bridge is optional. Browser tools work without pi-subagents.
     }
   });
   pi.on("session_shutdown", () => {

--- a/pi-extension/surf.ts
+++ b/pi-extension/surf.ts
@@ -21,6 +21,8 @@ const { prepareRemoteTool, validateLocalToolPaths } = require("../native/file-tr
 
 const MAX_OUTPUT_CHARS = 20_000;
 const ORACLE_ACTIVE_STATES = new Set(["created", "dispatched", "awaiting"]);
+const ORACLE_TERMINAL_STATES = new Set(["captured", "failed"]);
+const ORACLE_FINISHED_CHANNEL = "surf-oracle:finished";
 const BACKGROUND_WORK_PROTOCOL_VERSION = 1;
 const BACKGROUND_WORK_REGISTRY_KEY = "pi-subagents.background-work.v1";
 const BACKGROUND_WORK_MODULE_SPECIFIER = "pi-subagents/background-work";
@@ -28,6 +30,7 @@ const BACKGROUND_WORK_MODULE_SPECIFIER = "pi-subagents/background-work";
 type Pi = {
   registerTool(tool: Record<string, unknown>): void;
   on(event: "session_start" | "session_shutdown", handler: (event: unknown, ctx: unknown) => void | Promise<void>): void;
+  events?: { emit(event: string, data: unknown): void };
 };
 
 type SurfEndpoint = { kind?: string };
@@ -59,21 +62,21 @@ function textResult(value: unknown, isError = false): ToolResult {
   return { content: [{ type: "text", text: bounded }], ...(isError ? { isError: true } : {}) };
 }
 
-function resultFromHost(response: Record<string, unknown>): ToolResult {
+export function resultFromHost(response: Record<string, unknown>): ToolResult {
   const error = response.error as { content?: Array<{ text?: string }> } | undefined;
   if (error) return textResult(error.content?.map((item) => item.text ?? "").join("\n") || "Surf request failed", true);
   const result = response.result as { content?: ToolResult["content"] } | undefined;
   if (!result?.content) return textResult(result ?? "OK");
-  const content = result.content.map((item) => item.type === "text" && item.text && item.text.length > MAX_OUTPUT_CHARS
-    ? { ...item, text: `${item.text.slice(0, MAX_OUTPUT_CHARS)}\n\n[Surf output truncated at ${MAX_OUTPUT_CHARS} characters]` }
-    : item);
-  const text = content.find((item) => item.type === "text")?.text;
+  const text = result.content.find((item) => item.type === "text")?.text;
   let details: unknown;
   try {
     details = text ? JSON.parse(text) : undefined;
   } catch {
     details = undefined;
   }
+  const content = result.content.map((item) => item.type === "text" && item.text && item.text.length > MAX_OUTPUT_CHARS
+    ? { ...item, text: `${item.text.slice(0, MAX_OUTPUT_CHARS)}\n\n[Surf output truncated at ${MAX_OUTPUT_CHARS} characters]` }
+    : item);
   return { content, details };
 }
 
@@ -152,7 +155,7 @@ export async function resolveBackgroundWorkRegister(
 export function registerOptionalBackgroundProvider(sessionId: string, jobIds: Set<string>, listJobs: () => Array<{ id: string; state: string }>, register: RegisterBackgroundWorkProvider) {
   return register({
     name: "surf-oracle",
-    wakeChannels: ["surf-oracle:finished"],
+    wakeChannels: [ORACLE_FINISHED_CHANNEL],
     listActiveWork: () => listJobs()
       .filter((job) => jobIds.has(job.id) && ORACLE_ACTIVE_STATES.has(job.state))
       .map((job) => ({ id: job.id, sessionId })),
@@ -162,6 +165,15 @@ export function registerOptionalBackgroundProvider(sessionId: string, jobIds: Se
 export function rememberOracleJobForSession(jobIds: Set<string>, jobId: unknown, requestGeneration: number, currentGeneration: number, sessionActive: boolean): boolean {
   if (typeof jobId !== "string" || !sessionActive || requestGeneration !== currentGeneration) return false;
   jobIds.add(jobId);
+  return true;
+}
+
+export function emitOracleFinished(pi: Pi, job: unknown): boolean {
+  if (!job || typeof job !== "object" || Array.isArray(job)) return false;
+  const { id, state } = job as { id?: unknown; state?: unknown };
+  if (typeof id !== "string" || typeof state !== "string" || !ORACLE_TERMINAL_STATES.has(state)) return false;
+  if (!pi.events) return false;
+  pi.events.emit(ORACLE_FINISHED_CHANNEL, { id, state });
   return true;
 }
 
@@ -199,7 +211,21 @@ export default function surfExtension(pi: Pi) {
     tool: Type.String(), args: Type.Optional(Type.Record(Type.String(), Type.Unknown())), tabId: Type.Optional(Type.Number()),
   }), (args) => [args.tool as string, (args.args as Record<string, unknown>) ?? {}, args.tabId as number | undefined]);
   registerTool(pi, "surf_oracle_status", "Get the status of a Surf oracle job, or the newest job.", Type.Object({ id: Type.Optional(Type.String()) }), (args) => ["oracle.status", args, undefined]);
-  registerTool(pi, "surf_oracle_result", "Capture the result of a Surf oracle job.", Type.Object({ id: Type.String(), timeout: Type.Optional(Type.Number()) }), (args) => ["oracle.result", args, undefined]);
+  pi.registerTool({
+    name: "surf_oracle_result",
+    label: "surf_oracle_result",
+    description: "Capture the result of a Surf oracle job.",
+    parameters: Type.Object({ id: Type.String(), timeout: Type.Optional(Type.Number()) }),
+    async execute(_id: string, args: Record<string, unknown>) {
+      try {
+        const result = await requestSurf("oracle.result", args);
+        emitOracleFinished(pi, result.details ?? { id: args.id, state: result.isError ? "failed" : undefined });
+        return result;
+      } catch (error) {
+        return textResult(error instanceof Error ? error.message : String(error), true);
+      }
+    },
+  });
 
   const oracleJobIds = new Set<string>();
   let sessionGeneration = 0;

--- a/test/unit/pi-extension.test.ts
+++ b/test/unit/pi-extension.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 const {
   createToolRequest,
   registerGlobalBackgroundProvider,
   registerOptionalBackgroundProvider,
   rememberOracleJobForSession,
+  resolveBackgroundWorkRegister,
 } = require("../../pi-extension/surf.ts");
 
 const backgroundWorkKey = Symbol.for("pi-subagents.background-work.v1");
@@ -71,5 +72,23 @@ describe("Pi extension", () => {
     dispose();
     expect(registry.providers.has("surf-oracle")).toBe(false);
     delete (globalThis as Record<PropertyKey, unknown>)[backgroundWorkKey];
+  });
+
+  it("prefers the pi-subagents background-work helper when it is available", async () => {
+    const register = vi.fn(() => vi.fn());
+
+    await expect(
+      resolveBackgroundWorkRegister(async () => ({
+        registerBackgroundWorkProvider: register,
+      })),
+    ).resolves.toBe(register);
+  });
+
+  it("keeps the global fallback when pi-subagents is not available", async () => {
+    await expect(
+      resolveBackgroundWorkRegister(async () => {
+        throw new Error("not installed");
+      }),
+    ).resolves.toBe(registerGlobalBackgroundProvider);
   });
 });

--- a/test/unit/pi-extension.test.ts
+++ b/test/unit/pi-extension.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it, vi } from "vitest";
 
 const {
   createToolRequest,
+  emitOracleFinished,
   registerGlobalBackgroundProvider,
   registerOptionalBackgroundProvider,
   rememberOracleJobForSession,
   resolveBackgroundWorkRegister,
+  resultFromHost,
 } = require("../../pi-extension/surf.ts");
 
 const backgroundWorkKey = Symbol.for("pi-subagents.background-work.v1");
@@ -23,7 +25,9 @@ describe("Pi extension", () => {
   });
 
   it("reports only active oracle jobs started by its Pi session", () => {
-    let provider: { listActiveWork(): Array<{ id: string; sessionId: string }> } | undefined;
+    let provider:
+      | { wakeChannels: string[]; listActiveWork(): Array<{ id: string; sessionId: string }> }
+      | undefined;
     const jobIds = new Set(["mine"]);
     const dispose = registerOptionalBackgroundProvider(
       "pi-session",
@@ -33,7 +37,10 @@ describe("Pi extension", () => {
         { id: "done", state: "captured" },
         { id: "other", state: "dispatched" },
       ],
-      (registered: { listActiveWork(): Array<{ id: string; sessionId: string }> }) => {
+      (registered: {
+        wakeChannels: string[];
+        listActiveWork(): Array<{ id: string; sessionId: string }>;
+      }) => {
         provider = registered;
         return () => {
           provider = undefined;
@@ -41,6 +48,7 @@ describe("Pi extension", () => {
       },
     );
 
+    expect(provider?.wakeChannels).toEqual(["surf-oracle:finished"]);
     expect(provider?.listActiveWork()).toEqual([{ id: "mine", sessionId: "pi-session" }]);
     jobIds.clear();
     expect(provider?.listActiveWork()).toEqual([]);
@@ -57,6 +65,36 @@ describe("Pi extension", () => {
     expect([...jobIds]).toEqual(["current-job"]);
     expect(rememberOracleJobForSession(jobIds, "inactive-job", 2, 2, false)).toBe(false);
     expect([...jobIds]).toEqual(["current-job"]);
+  });
+
+  it("keeps details parseable when display text is truncated", () => {
+    const job = { id: "long-job", state: "captured", response: "x".repeat(21_000) };
+
+    const result = resultFromHost({
+      result: { content: [{ type: "text", text: JSON.stringify(job) }] },
+    });
+
+    expect(result.details).toEqual(job);
+    expect(result.content[0]?.text).toContain("Surf output truncated");
+  });
+
+  it("emits the oracle finished wake channel only for terminal jobs", () => {
+    const emitted: Array<{ event: string; data: unknown }> = [];
+    const pi = {
+      events: {
+        emit: (event: string, data: unknown) => emitted.push({ event, data }),
+      },
+    };
+
+    expect(emitOracleFinished(pi, { id: "running", state: "awaiting" })).toBe(false);
+    expect(emitOracleFinished({}, { id: "done", state: "captured" })).toBe(false);
+    expect(emitOracleFinished(pi, { id: "done", state: "captured" })).toBe(true);
+    expect(emitOracleFinished(pi, { id: "failed", state: "failed" })).toBe(true);
+
+    expect(emitted).toEqual([
+      { event: "surf-oracle:finished", data: { id: "done", state: "captured" } },
+      { event: "surf-oracle:finished", data: { id: "failed", state: "failed" } },
+    ]);
   });
 
   it("creates the optional pi-subagents background registry lazily", () => {


### PR DESCRIPTION
## Summary

This tightens the optional Surf Pi integration without making `pi-subagents` a Surf dependency.

Surf now prefers the official `pi-subagents/background-work` helper when Pi loads Surf and that package is available. It keeps the existing process-global fallback so Surf continues to work in Claude Code, Codex, Cursor, direct CLI use, and other non-Pi harnesses.

The PR also makes the advertised `surf-oracle:finished` wake channel real. Surf emits it when `surf_oracle_result` observes a terminal oracle job. Background snapshots remain authoritative.

## Validation

- `npx vitest --root /Users/nicobailon/Documents/development/surf-cli-lanes/pi-background-wake-integration run test/unit/pi-extension.test.ts`
- `npm run check --prefix /Users/nicobailon/Documents/development/surf-cli-lanes/pi-background-wake-integration`
- `npm run lint --prefix /Users/nicobailon/Documents/development/surf-cli-lanes/pi-background-wake-integration`
- `git diff --check`

Fresh reviews completed with no open findings after the long-result wake fix.
