### PR TITLE
fix: add skill index frontmatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **Pi extension background bridge** - Prefer the official `pi-subagents/background-work` helper when Pi loads Surf with pi-subagents available, while keeping the global fallback for Claude Code, Codex, Cursor, direct CLI use, and other non-Pi harnesses.
 
 ### Fixed
+- **Pi skill discovery** - Added frontmatter to the packaged `skills/README.md` index so Pi no longer reports it as a root skill with a missing description. Thanks to @jagaliano for #177.
 - **Pi oracle wake channel** - Emit `surf-oracle:finished` when Surf observes a terminal oracle result so pi-subagents can wake without waiting for the next snapshot poll.
 
 ## [2.12.0] - 2026-08-07

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,3 +1,9 @@
+---
+name: surf-skills
+description: Package index for Surf skills. Use when you need install or layout notes for the Surf skill bundle.
+disable-model-invocation: true
+---
+
 # Surf Skills
 
 This directory contains skill files for AI coding agents:


### PR DESCRIPTION
## Summary

Adds Pi-compatible frontmatter to the packaged `skills/README.md` index.

The file remains useful install documentation, but Pi can now parse it as a hidden root skill instead of reporting `description is required`. The real `surf` and `deep-x-research` skills remain unchanged.

Fixes #177.

## Validation

- Focused frontmatter parse check for `name` and `description`
- Pi loader validation in fresh review: no diagnostics, `surf-skills` hidden from model prompt
- `npm run check`
- `npm run lint`
- `git diff --check`
