### PR TITLE
fix: skip private state mode check on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Windows private state** - Skip unsupported POSIX permission-bit checks when reading private state files on Windows. Thanks to Andrey Oz (@ozand) for #181.
+
 ## [2.13.0] - 2026-08-08
 
 ### Added

--- a/native/private-state.cjs
+++ b/native/private-state.cjs
@@ -132,7 +132,7 @@ function readPrivateFile(filePath, options = {}) {
   const stat = assertNotSymlink(resolved, options.allowMissing === true);
   if (!stat) return options.fallback;
   if (!stat.isFile()) throw new Error(`private state path is not a file: ${resolved}`);
-  if ((stat.mode & 0o077) !== 0) throw new Error(`private state file permissions are too broad: ${resolved}`);
+  if (process.platform !== "win32" && (stat.mode & 0o077) !== 0) throw new Error(`private state file permissions are too broad: ${resolved}`);
   return fs.readFileSync(resolved, options.encoding || null);
 }
 

--- a/test/unit/private-state.test.ts
+++ b/test/unit/private-state.test.ts
@@ -45,4 +45,30 @@ describe("private state boundary", () => {
     fs.symlinkSync(target, link);
     expect(() => state.ensurePrivateDir(path.join(link, "nested"), root)).toThrow(/symbolic link/);
   });
+
+  it("enforces private file mode checks on POSIX but skips them on Windows", () => {
+    const parent = fs.mkdtempSync(path.join(os.tmpdir(), "surf-private-state-"));
+    roots.push(parent);
+    const root = path.join(parent, "state");
+    state.ensurePrivateDir(root, root);
+    const file = path.join(root, "private.json");
+    fs.writeFileSync(file, "private");
+    fs.chmodSync(file, 0o644);
+    const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+    if (!platformDescriptor) {
+      throw new Error("process.platform descriptor is unavailable");
+    }
+
+    try {
+      Object.defineProperty(process, "platform", { value: "linux" });
+      expect(() => state.readPrivateFile(file, { root, encoding: "utf8" })).toThrow(
+        /permissions are too broad/,
+      );
+
+      Object.defineProperty(process, "platform", { value: "win32" });
+      expect(state.readPrivateFile(file, { root, encoding: "utf8" })).toBe("private");
+    } finally {
+      Object.defineProperty(process, "platform", platformDescriptor);
+    }
+  });
 });


### PR DESCRIPTION
Fix the Windows native-host startup failure reported in #181.

Private state reads now skip the POSIX group and other mode-bit check on Windows. Root-boundary, symlink, and regular-file checks remain unchanged. The focused regression test exercises both simulated POSIX and Windows behavior on every CI host.

Validation:
- `npm exec vitest run test/unit/private-state.test.ts`
- `npm run check`
- `git diff --check`
- fresh security review on `affa0dc`

Thanks to Andrey Oz (@ozand) for the report, root-cause analysis, and Windows validation.

Fixes #181
