### PR TITLE
chore: make deep-x-research user-invoked

### DIFF
--- a/skills/deep-x-research/SKILL.md
+++ b/skills/deep-x-research/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: deep-x-research
-description: Deep, exhaustive research on a topic across X (Twitter) by driving Grok (x.com/i/grok) through surf. Use when the user wants comprehensive X research on a concept, technique, trend, tool, or creator scene; needs categorized findings with every claim traceable to post URLs; or when a single Grok query is not enough.
+description: Research a topic exhaustively across X (Twitter) using Grok through surf.
+disable-model-invocation: true
 ---
 
 # Deep X Research

--- a/skills/deep-x-research/agents/openai.yaml
+++ b/skills/deep-x-research/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false


### PR DESCRIPTION
## Summary

- mark `deep-x-research` as user-only in skill frontmatter
- add the matching Codex implicit-invocation deny policy
- shorten the description now that it is human-facing

This prevents an expensive, quota-consuming Grok research workflow from being selected automatically.