### PR TITLE
fix: support current ChatGPT Pro picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **ChatGPT Pro picker** - Support the current GPT-5.5 and GPT-5.6 Sol advanced model menu plus the Pro effort selector for ChatGPT Oracle dispatch.
+
 ## [2.13.1] - 2026-08-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ Query AI models using your browser's logged-in session:
 # ChatGPT
 surf chatgpt "explain this code"
 surf chatgpt "summarize" --with-page     # Include page context
-surf chatgpt "analyze" --model gpt-4o    # Specify model
+surf chatgpt "analyze" --model gpt-5.5   # Specify model
 surf chatgpt "review" --file code.ts     # Attach file
 
 # Gemini
@@ -505,10 +505,10 @@ surf aistudio.build "game" --keep-open --timeout 600          # Keep tab open, 1
 
 #### Oracle
 
-Use `surf oracle` for a durable, local ChatGPT consult instead of a quick `surf chatgpt` one-shot. It persists jobs by conversation URL, supports repeatable file-context globs, and verifies requested model and reasoning effort before submission.
+Use `surf oracle` for a durable, local ChatGPT consult instead of a quick `surf chatgpt` one-shot. It persists jobs by conversation URL, supports repeatable file-context globs, and verifies requested model and reasoning effort before submission. ChatGPT model aliases include `instant`, `thinking`, `pro`, `gpt-5.5`, and `gpt-5.6-sol`.
 
 ```bash
-surf oracle ask "review this change" --files "src/**/*.ts" --model pro --effort extended --detach --json
+surf oracle ask "review this change" --files "src/**/*.ts" --model gpt-5.5 --effort pro --detach --json
 surf oracle status <job-id> --json
 surf oracle result <job-id> --wait --json
 surf oracle follow <job-id> "challenge that recommendation" --detach --json

--- a/native/chatgpt-client-selection.cjs
+++ b/native/chatgpt-client-selection.cjs
@@ -1,15 +1,25 @@
-const CHATGPT_EFFORT_CHOICES = ["light", "standard", "extended", "heavy"];
+const CHATGPT_EFFORT_CHOICES = ["light", "standard", "extended", "heavy", "pro"];
+const CHATGPT_MODEL_ALIASES = new Map([
+  ["instant", "instant"],
+  ["gpt53", "instant"],
+  ["thinking", "thinking"],
+  ["gpt54thinking", "thinking"],
+  ["pro", "pro"],
+  ["gpt54pro", "pro"],
+  ["55", "gpt55"],
+  ["gpt55", "gpt55"],
+  ["chatgpt55", "gpt55"],
+  ["56sol", "gpt56sol"],
+  ["gpt56sol", "gpt56sol"],
+  ["chatgpt56sol", "gpt56sol"],
+]);
 
 function normalizeChatGPTModelChoice(desiredModel) {
   const normalized = String(desiredModel || "")
     .toLowerCase()
     .replace(/[^a-z0-9]/g, "");
 
-  if (["instant", "gpt53"].includes(normalized)) return "instant";
-  if (["thinking", "gpt54thinking"].includes(normalized)) return "thinking";
-  if (["pro", "gpt54pro"].includes(normalized)) return "pro";
-
-  return normalized;
+  return CHATGPT_MODEL_ALIASES.get(normalized) || normalized;
 }
 
 function normalizeChatGPTEffortChoice(desiredEffort) {
@@ -29,7 +39,9 @@ function normalizedWords(value) {
 function modelCandidateMatches(item, targetModel) {
   const values = [item?.label, item?.testId?.replace(/^model-switcher-/, "")].filter(Boolean);
   return values.some((value) => {
-    if (normalizeChatGPTModelChoice(value) === targetModel) return true;
+    const normalizedValue = normalizeChatGPTModelChoice(value);
+    if (normalizedValue === targetModel) return true;
+    if (targetModel.startsWith("gpt") && normalizedValue.includes(targetModel)) return true;
     const variants = ["instant", "thinking", "pro"].filter((variant) =>
       normalizedWords(value).includes(variant),
     );
@@ -58,9 +70,7 @@ function resolveChatGPTModelMenuOption(items, desiredModel) {
   return uniqueMatch(
     items,
     (item) =>
-      item?.role === "menuitemradio" &&
-      typeof item?.testId === "string" &&
-      item.testId.startsWith("model-switcher-") &&
+      ["button", "menuitem", "menuitemradio", "radio"].includes(item?.role) &&
       modelCandidateMatches(item, targetModel),
   );
 }

--- a/native/chatgpt-client-ui.cjs
+++ b/native/chatgpt-client-ui.cjs
@@ -18,9 +18,10 @@ const SELECTORS = {
   loginCta: 'a[href*="/auth/login"], button',
   sendButton:
     'button[data-testid="send-button"], button[data-testid*="composer-send"], form button[type="submit"]',
-  modelButton: '[data-testid="model-switcher-dropdown-button"]',
+  modelButton:
+    '[data-testid="model-switcher-dropdown-button"], [data-testid="composer-footer-actions"] button[aria-haspopup="menu"], button.__composer-pill[aria-haspopup="menu"], .__composer-pill-composite button[aria-haspopup="menu"]',
   modelMenu: '[role="menu"][data-radix-menu-content]',
-  modelMenuItem: '[role="menuitemradio"][data-testid^="model-switcher-"]',
+  modelMenuItem: 'button, [role="menuitem"], [role="menuitemradio"]',
   menuItemPrimaryLabel: '.min-w-0 > span',
   effortButton:
     '[data-testid="composer-footer-actions"] button[aria-haspopup="menu"], button.__composer-pill[aria-haspopup="menu"], .__composer-pill-composite button[aria-haspopup="menu"]',
@@ -191,8 +192,8 @@ async function readPicker(cdp, kind, click = false) {
       ${buildClickDispatcher()}
       const kind = ${JSON.stringify(kind)};
       const nodes = Array.from(document.querySelectorAll(${JSON.stringify(selector)})).filter((node) => {
-        if (kind === 'model') return true;
         const value = ((node.getAttribute?.('aria-label') || '') + ' ' + (node.textContent || '')).toLowerCase();
+        if (kind === 'model') return value.includes('gpt') || value.includes('pro') || value.includes('thinking') || value.includes('instant');
         return value.includes('thinking') || value.includes('pro');
       });
       const items = nodes.map((node) => {
@@ -224,13 +225,31 @@ async function readMenu(cdp, kind, allowSubmenu) {
       const choices = ${JSON.stringify(CHATGPT_EFFORT_CHOICES)};
       const containers = Array.from(document.querySelectorAll(${JSON.stringify(menuSelector)}));
       const normalize = (value) => String(value || '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
-      let menu = isModel ? containers[0] : containers.find((container) => {
+      let menu = isModel ? containers.find((container) => {
+        const labels = Array.from(container.querySelectorAll(${JSON.stringify(itemSelector)}))
+          .filter((item) => item.getAttribute?.('aria-haspopup') !== 'menu')
+          .map((item) => normalize((item.getAttribute?.('aria-label') || '') + ' ' + (item.textContent || '')));
+        return labels.some((label) => label.includes('gpt') || /^o[0-9]/.test(label));
+      }) : containers.find((container) => {
         const label = normalize(container.querySelector?.(${JSON.stringify(SELECTORS.effortMenuLabel)})?.textContent);
         const levels = new Set(Array.from(container.querySelectorAll(${JSON.stringify(itemSelector)}))
           .flatMap((item) => normalize(item.textContent).split(/\\s+/))
           .filter((word) => choices.includes(word)));
         return label.includes('thinking time') || levels.size >= 2;
       });
+      if (!menu && isModel && ${allowSubmenu}) {
+        for (const container of containers) {
+          const trigger = Array.from(container.querySelectorAll(${JSON.stringify(SELECTORS.effortSubmenuTrigger)}))
+            .find((item) => {
+              const label = normalize((item.getAttribute?.('aria-label') || '') + ' ' + (item.textContent || ''));
+              return label.includes('model') || label.includes('advanced');
+            });
+          if (trigger) {
+            dispatchClickSequence(trigger);
+            return { found: false, submenuOpened: true, items: [] };
+          }
+        }
+      }
       if (!menu && !isModel && ${allowSubmenu}) {
         for (const container of containers) {
           const trigger = Array.from(container.querySelectorAll(${JSON.stringify(SELECTORS.effortSubmenuTrigger)}))
@@ -299,7 +318,7 @@ async function clickMenuItem(cdp, kind, match) {
           .replace(/\\s+/g, ' ').trim().slice(0, 80);
         return label === expectedLabel;
       });
-      return matches.length === 1 ? dispatchClickSequence(matches[0]) : false;
+      return matches.length >= 1 ? dispatchClickSequence(matches[0]) : false;
     })()`,
   );
 }
@@ -317,8 +336,17 @@ async function selectModel(cdp, desiredModel, timeoutMs = 8000, signal) {
   await delay(200, signal);
   const state = await readPicker(cdp, "model");
   const verified = verifyChatGPTModelSelection(state?.items, desiredModel);
-  if (!verified) throw verificationError("model", desiredModel, menu.items);
-  return verified.displayLabel || verified.label;
+  if (verified) return verified.displayLabel || verified.label;
+
+  const reopened = await readPicker(cdp, "model", true);
+  if (reopened?.items?.length !== 1) throw verificationError("model", desiredModel, menu.items);
+  const readbackMenu = await waitForMenu(cdp, "model", timeoutMs, signal);
+  const readbackVerified = verifyChatGPTModelSelection(
+    readbackMenu.items.filter((item) => item.selected),
+    desiredModel,
+  );
+  if (!readbackVerified) throw verificationError("model", desiredModel, readbackMenu.items);
+  return readbackVerified.label;
 }
 
 async function selectEffort(cdp, desiredEffort, timeoutMs = 8000, signal) {

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -270,7 +270,7 @@ const TOOLS = {
         args: ["query"],
         opts: {
           "with-page": "Include current page context",
-          model: "Model: gpt-4o, o1, etc.",
+          model: "Model: instant, thinking, pro, gpt-5.5, gpt-5.6-sol, or a visible model label",
           file: "Attach file",
           timeout: "Timeout in seconds (default: 2700 = 45min)"
         },
@@ -278,7 +278,7 @@ const TOOLS = {
           { cmd: 'chatgpt "explain this code"', desc: "Basic query" },
           { cmd: 'chatgpt "summarize" --with-page', desc: "With page context" },
           { cmd: 'chatgpt "review" --file code.ts', desc: "With file" },
-          { cmd: 'chatgpt "analyze" --model gpt-4o', desc: "Specify model" },
+          { cmd: 'chatgpt "analyze" --model gpt-5.5', desc: "Specify model" },
         ]
       },
       "gemini": {

--- a/native/mcp-server.cjs
+++ b/native/mcp-server.cjs
@@ -269,7 +269,7 @@ const TOOL_SCHEMAS = {
     desc: "Ask ChatGPT through the browser session",
     schema: {
       query: z.string().describe("Question or prompt"),
-      model: z.string().optional().describe("ChatGPT model"),
+      model: z.string().optional().describe("ChatGPT model: instant, thinking, pro, gpt-5.5, gpt-5.6-sol, or a visible model label"),
       "with-page": z.boolean().optional().describe("Include current page context"),
       file: z.string().optional().describe("One attachment path"),
       timeout: z.number().optional().describe("Timeout in seconds")

--- a/native/oracle-cli.cjs
+++ b/native/oracle-cli.cjs
@@ -30,8 +30,8 @@ Commands:
 
 Ask/follow options:
   --files <glob>          Add context files (repeatable)
-  --model <model>         Select a ChatGPT model
-  --effort <effort>       Select reasoning effort
+  --model <model>         Select model: instant, thinking, pro, gpt-5.5, gpt-5.6-sol
+  --effort <effort>       Select effort: light, standard, extended, heavy, pro
   --detach                Return after dispatch
   --allow-sensitive       Allow deny-listed context files
 

--- a/skills/surf/SKILL.md
+++ b/skills/surf/SKILL.md
@@ -78,7 +78,7 @@ Query AI models using your browser's logged-in session. Must be logged into the 
 ```bash
 surf chatgpt "explain this code"
 surf chatgpt "summarize" --with-page              # Include current page context
-surf chatgpt "review" --model gpt-4o              # Specify model
+surf chatgpt "review" --model gpt-5.5             # Specify model
 surf chatgpt "analyze" --file document.pdf        # With file attachment
 ```
 
@@ -91,7 +91,7 @@ For agent workflows, detach after dispatch and keep the returned `.id`:
 ```bash
 surf oracle ask "Review this change and identify release risks" \
   --files "src/**/*.ts" --files "package.json" \
-  --model pro --effort extended --detach --json
+  --model gpt-5.5 --effort pro --detach --json
 
 surf oracle status <job-id> --json
 surf oracle result <job-id> --json
@@ -101,7 +101,7 @@ surf oracle result <job-id> --wait --json
 
 `status` reads persisted state without touching Chrome. `result` attempts to harvest the answer and returns the job object with `response` once its state is `captured`. A Ctrl-C during waiting exits with status 130 and prints `Recover with: surf oracle result <id>`. Once the job is `awaiting`, the persisted ChatGPT conversation URL is its durable key, so `surf oracle result <id>` can recover after CLI exit, native-host restart, or Chrome restart by reopening that conversation.
 
-Treat Pro quota as scarce. Oracle never selects Pro implicitly; request it with `--model pro`. Accepted `--effort` values are `light`, `standard`, `extended`, and `heavy`. Requested model and effort selections are read back before submission, and an unverifiable selection fails with `model_verification_failed` instead of silently continuing. Capacity is one non-terminal oracle job. A `capacity` error includes the in-flight job ID; poll that job or wait for it to finish rather than submitting the same consult again.
+Treat Pro quota as scarce. Oracle never selects Pro implicitly; request it with `--model pro` or `--effort pro`. ChatGPT model aliases include `instant`, `thinking`, `pro`, `gpt-5.5`, and `gpt-5.6-sol`. Accepted `--effort` values are `light`, `standard`, `extended`, `heavy`, and `pro`. Requested model and effort selections are read back before submission, and an unverifiable selection fails with `model_verification_failed` instead of silently continuing. Capacity is one non-terminal oracle job. A `capacity` error includes the in-flight job ID; poll that job or wait for it to finish rather than submitting the same consult again.
 
 Context comes from repeatable `--files` globs. Surf fails closed when a glob matches nothing or a matched file is unreadable, binary, or invalid UTF-8. It also blocks gitignored files and basenames matching `.env*`, `*.pem`, `*.key`, `id_rsa*`, `id_ed25519*`, `*.p12`, `*.pfx`, `credentials*`, or `secrets*`. Use `--allow-sensitive` only after intentionally reviewing those files; it overrides the block rather than redacting content. Context up to 60,000 evidence characters is inserted inline, while larger context becomes one private text attachment. The assembly manifest records each path, byte count, SHA-256, inline or bundle disposition, and deny-list outcome.
 

--- a/test/unit/chatgpt-client.test.ts
+++ b/test/unit/chatgpt-client.test.ts
@@ -197,6 +197,12 @@ describe("chatgpt-client", () => {
       ["gpt-5-4-thinking", "thinking"],
       ["Pro", "pro"],
       ["gpt-5-4-pro", "pro"],
+      ["GPT-5.5", "gpt55"],
+      ["ChatGPT 5.5", "gpt55"],
+      ["5.5", "gpt55"],
+      ["GPT-5.6 Sol", "gpt56sol"],
+      ["ChatGPT 5.6 Sol", "gpt56sol"],
+      ["5.6 Sol", "gpt56sol"],
       ["something-else", "somethingelse"],
     ])("normalizes %s", (input, expected) => {
       expect(chatgptClient.normalizeChatGPTModelChoice(input)).toBe(expected);
@@ -242,6 +248,29 @@ describe("chatgpt-client", () => {
       });
     });
 
+    it("matches nested advanced model options without model-switcher test ids", () => {
+      expect(
+        chatgptClient.resolveChatGPTModelMenuOption(
+          [
+            { role: "menuitemradio", label: "GPT-5.6 Sol", testId: null },
+            { role: "menuitemradio", label: "GPT-5.5", testId: null },
+            { role: "menuitemradio", label: "o3 Leaving on August 26", testId: null },
+          ],
+          "gpt-5.6-sol",
+        ),
+      ).toEqual({ role: "menuitemradio", label: "GPT-5.6 Sol", testId: null });
+      expect(
+        chatgptClient.resolveChatGPTModelMenuOption(
+          [
+            { role: "menuitemradio", label: "GPT-5.6 Sol", testId: null },
+            { role: "menuitemradio", label: "GPT-5.5", testId: null },
+            { role: "menuitemradio", label: "o3 Leaving on August 26", testId: null },
+          ],
+          "gpt-5.5",
+        ),
+      ).toEqual({ role: "menuitemradio", label: "GPT-5.5", testId: null });
+    });
+
     it("ignores non-selectable menu rows like section labels and configure", () => {
       expect(
         chatgptClient.resolveChatGPTModelMenuOption(
@@ -272,6 +301,24 @@ describe("chatgpt-client", () => {
 
     it.each([
       ["requested model found", modelState, "thinking", "ChatGPT 5.4 Thinking"],
+      [
+        "GPT-5.5 readback",
+        [{ role: "button", label: "ChatGPT 5.5 | Current model is ChatGPT 5.5", testId: null }],
+        "gpt-5.5",
+        "ChatGPT 5.5 | Current model is ChatGPT 5.5",
+      ],
+      [
+        "GPT-5.6 Sol readback",
+        [
+          {
+            role: "button",
+            label: "ChatGPT 5.6 Sol | Current model is ChatGPT 5.6 Sol",
+            testId: null,
+          },
+        ],
+        "gpt-5.6-sol",
+        "ChatGPT 5.6 Sol | Current model is ChatGPT 5.6 Sol",
+      ],
       ["requested model missing", modelState, "pro", null],
       ["ambiguous model state", [...modelState, ...modelState], "thinking", null],
       ["unreadable model state", [{ role: "button", label: "", testId: null }], "thinking", null],
@@ -302,6 +349,7 @@ describe("chatgpt-client", () => {
         effortOptions[2],
       );
       expect(chatgptClient.normalizeChatGPTEffortChoice("STANDARD")).toBe("standard");
+      expect(chatgptClient.normalizeChatGPTEffortChoice("Pro")).toBe("pro");
       expect(chatgptClient.normalizeChatGPTEffortChoice("maximum")).toBeNull();
     });
   });


### PR DESCRIPTION
## Summary
- support the current ChatGPT advanced model menu for `GPT-5.6 Sol`
- accept `Pro` as a ChatGPT effort value
- add focused picker tests and an Unreleased changelog entry

## Validation
- `npm test -- test/unit/chatgpt-client.test.ts`
- `npm run check`
- `npm test`
- `git diff --check`
- `npm run lint` (completed with an existing warning in `test/unit/accessibility-tree.test.ts`)

Live Oracle smoke with `--model gpt56sol --effort pro` is still blocked by the active issue #1188 Pro planning job capacity. The current UI was manually verified as `GPT-5.6 Sol` + `Pro`, and the local fix was used to continue the workflow path far enough to expose the separate upload/native-host mismatch.
