### PR TITLE
fix: resolve oracle pro model alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - **Surf Oracle external-job provider** - Register a stable `surf-oracle` external-job provider for Pi integrations, with durable start/status/result/reattach/follow operations backed by Surf Oracle job state.
 
 ### Fixed
-- **ChatGPT Pro picker** - Support the current GPT-5.5 and GPT-5.6 Sol advanced model menu plus the Pro effort selector for ChatGPT Oracle dispatch.
+- **ChatGPT Pro picker** - Resolve the advertised `--model pro` alias to the current GPT-5.6 Sol model, support explicit GPT-5.5 and GPT-5.6 Sol selection, and retain the Pro effort selector for ChatGPT Oracle dispatch.
 
 ## [2.13.1] - 2026-08-09
 

--- a/native/chatgpt-client-selection.cjs
+++ b/native/chatgpt-client-selection.cjs
@@ -4,7 +4,7 @@ const CHATGPT_MODEL_ALIASES = new Map([
   ["gpt53", "instant"],
   ["thinking", "thinking"],
   ["gpt54thinking", "thinking"],
-  ["pro", "pro"],
+  ["pro", "gpt56sol"],
   ["gpt54pro", "pro"],
   ["55", "gpt55"],
   ["gpt55", "gpt55"],

--- a/test/unit/chatgpt-client.test.ts
+++ b/test/unit/chatgpt-client.test.ts
@@ -195,7 +195,7 @@ describe("chatgpt-client", () => {
       ["gpt-5-3", "instant"],
       ["Thinking", "thinking"],
       ["gpt-5-4-thinking", "thinking"],
-      ["Pro", "pro"],
+      ["Pro", "gpt56sol"],
       ["gpt-5-4-pro", "pro"],
       ["GPT-5.5", "gpt55"],
       ["ChatGPT 5.5", "gpt55"],
@@ -269,6 +269,15 @@ describe("chatgpt-client", () => {
           "gpt-5.5",
         ),
       ).toEqual({ role: "menuitemradio", label: "GPT-5.5", testId: null });
+      expect(
+        chatgptClient.resolveChatGPTModelMenuOption(
+          [
+            { role: "menuitemradio", label: "GPT-5.6 Sol", testId: null },
+            { role: "menuitemradio", label: "GPT-5.5", testId: null },
+          ],
+          "pro",
+        ),
+      ).toEqual({ role: "menuitemradio", label: "GPT-5.6 Sol", testId: null });
     });
 
     it("ignores non-selectable menu rows like section labels and configure", () => {
@@ -317,6 +326,18 @@ describe("chatgpt-client", () => {
           },
         ],
         "gpt-5.6-sol",
+        "ChatGPT 5.6 Sol | Current model is ChatGPT 5.6 Sol",
+      ],
+      [
+        "Pro alias readback",
+        [
+          {
+            role: "button",
+            label: "ChatGPT 5.6 Sol | Current model is ChatGPT 5.6 Sol",
+            testId: null,
+          },
+        ],
+        "pro",
         "ChatGPT 5.6 Sol | Current model is ChatGPT 5.6 Sol",
       ],
       ["requested model missing", modelState, "pro", null],


### PR DESCRIPTION
Fixes #191.

This keeps the advertised `surf oracle --model pro` alias and maps it to the current Pro-class ChatGPT model, `GPT-5.6 Sol`, so model selection and readback verification use the same canonical identity. Explicit `gpt-5.5` and `gpt-5.6-sol` selection stay unchanged, and the separate Pro effort selector stays unchanged.

Validation:
- `npm test -- --run test/unit/chatgpt-client.test.ts`
- `npm run check`
- `git diff --check`

Fresh review: /Users/nicobailon/Documents/docs/issue-191-fresh-review-99f07e4.md