### PR TITLE
Prepare Surf Oracle GPT Pro follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+- **GPT Pro follow-up groundwork** - Surf Oracle now records idempotent request IDs and follow-up lineage for Pi integrations that continue GPT Pro conversations.
+
+### Fixed
+- **Pi GPT Pro polling** - The `surf-oracle` external-job provider now performs bounded result harvesting during status and reattach checks, so Pi polling can observe completed GPT Pro jobs without a separate result call.
+
 ## [2.15.2] - 2026-08-22
 
 ### Highlights

--- a/native/oracle-host.cjs
+++ b/native/oracle-host.cjs
@@ -71,7 +71,9 @@ function createOracleHost({ queueAiRequest, requestCallExtension, buildProviderU
       model,
       effortRequested: args.effort ?? null,
       follow: args.follow ?? null,
+      requestId: args.requestId ?? null,
     });
+    if (created.requestDeduped) return oracleJobs.getJob(created.id);
     let createdTabId = null;
 
     try {
@@ -109,6 +111,8 @@ function createOracleHost({ queueAiRequest, requestCallExtension, buildProviderU
             oracleJobs.appendTurn(parent.id, {
               prompt: args.prompt,
               dispatchedAt: dispatchedJob.dispatchedAt,
+              childJobId: created.id,
+              requestId: args.requestId ?? null,
             });
           }
         },
@@ -259,6 +263,8 @@ function createOracleHost({ queueAiRequest, requestCallExtension, buildProviderU
         oracleJobs.markTurnCaptured(captured.follow, {
           dispatchedAt: captured.dispatchedAt,
           capturedAt: captured.capturedAt,
+          childJobId: captured.id,
+          requestId: captured.requestId ?? null,
         });
       }
       if (captured.tabId) {

--- a/native/oracle-jobs.cjs
+++ b/native/oracle-jobs.cjs
@@ -39,6 +39,32 @@ function promptDigest(prompt) {
   return `sha256:${crypto.createHash("sha256").update(prompt).digest("hex")}`;
 }
 
+function stableJson(value) {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+function requestFingerprint({ prompt, contextManifest, model, effortRequested, follow }) {
+  return promptDigest(stableJson({
+    promptDigest: promptDigest(prompt),
+    contextManifest: contextManifest ?? {},
+    model: model ?? null,
+    effortRequested: effortRequested ?? null,
+    follow: follow ?? null,
+  }));
+}
+
+function normalizedRequestId(requestId) {
+  if (requestId === null || requestId === undefined) return null;
+  if (typeof requestId !== "string" || !requestId.trim() || requestId.trim() !== requestId || requestId.length > 256 || requestId.includes("\0")) {
+    throw codedError("invalid_request", "oracle requestId must be a non-empty trimmed string");
+  }
+  return requestId;
+}
+
 function hydrateJobMetadata(job, root = getPrivateStateRoot()) {
   const prompt = job.promptDigest ? null : readPrivateFile(path.join(jobDirectory(job.id, root), "request.md"), {
     root,
@@ -66,10 +92,25 @@ function readJobs(root = getPrivateStateRoot()) {
     .map((job) => hydrateJobMetadata(job, root));
 }
 
-function createJob({ prompt, contextManifest = {}, model = null, effortRequested = null, follow = null }) {
+function createJob({ prompt, contextManifest = {}, model = null, effortRequested = null, follow = null, requestId = null }) {
   const root = getPrivateStateRoot();
   const base = oracleRoot(root);
   ensurePrivateDir(base, root);
+  const safeRequestId = normalizedRequestId(requestId);
+  const fingerprint = requestFingerprint({ prompt, contextManifest, model, effortRequested, follow });
+  if (safeRequestId) {
+    const existing = readJobs(root).find((job) => job.requestId === safeRequestId);
+    if (existing) {
+      if (existing.requestFingerprint !== fingerprint) {
+        throw codedError(
+          "idempotency_conflict",
+          `oracle requestId ${safeRequestId} was already used for a different request`,
+          { jobId: existing.id },
+        );
+      }
+      return { ...existing, requestDeduped: true };
+    }
+  }
   const inFlight = readJobs(root).find((job) => !TERMINAL_STATES.has(job.state));
   if (inFlight) {
     throw codedError(
@@ -108,6 +149,7 @@ function createJob({ prompt, contextManifest = {}, model = null, effortRequested
       effortRequested,
       effortVerified: null,
       promptDigest: promptDigest(prompt),
+      ...(safeRequestId ? { requestId: safeRequestId, requestFingerprint: fingerprint } : {}),
       createdAt: now.toISOString(),
       dispatchedAt: null,
       awaitingAt: null,
@@ -215,10 +257,14 @@ function updateTabId(id, tabId) {
 
 function appendTurn(id, turn) {
   const job = getJob(id);
+  const duplicate = job.turns.find((existing) => (turn.childJobId && existing.childJobId === turn.childJobId) || (turn.requestId && existing.requestId === turn.requestId));
+  if (duplicate) return job;
   const storedTurn = {
     prompt: turn.prompt,
     dispatchedAt: turn.dispatchedAt ?? null,
     capturedAt: turn.capturedAt ?? null,
+    ...(turn.childJobId ? { childJobId: turn.childJobId } : {}),
+    ...(turn.requestId ? { requestId: turn.requestId } : {}),
   };
   const root = getPrivateStateRoot();
   const directory = jobDirectory(id, root);
@@ -229,9 +275,9 @@ function appendTurn(id, turn) {
   return updated;
 }
 
-function markTurnCaptured(id, { dispatchedAt, capturedAt }) {
+function markTurnCaptured(id, { dispatchedAt, capturedAt, childJobId, requestId }) {
   const job = getJob(id);
-  const turnIndex = job.turns.findIndex((turn) => turn.dispatchedAt === dispatchedAt);
+  const turnIndex = job.turns.findIndex((turn) => (childJobId && turn.childJobId === childJobId) || (requestId && turn.requestId === requestId) || turn.dispatchedAt === dispatchedAt);
   if (turnIndex === -1) {
     throw codedError(
       "invalid_transition",

--- a/package-lock.json
+++ b/package-lock.json
@@ -261,6 +261,27 @@
         "node": ">=14.21.3"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "2.0.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",

--- a/pi-extension/surf.ts
+++ b/pi-extension/surf.ts
@@ -50,6 +50,8 @@ type OracleJob = {
   effortRequested?: string | null;
   effortVerified?: string | null;
   promptDigest?: string | null;
+  requestId?: string | null;
+  follow?: string | null;
   response?: string;
   error?: { code?: string; message?: string } | null;
 };
@@ -75,6 +77,9 @@ type OracleExternalJob = {
   id: string;
   state: string;
   conversationUrl: string | null;
+  follow?: string;
+  requestId?: string;
+  promptDigest?: string;
   resultText?: string;
   failure?: { code: string; message: string };
 };
@@ -97,6 +102,7 @@ type OracleExternalJobProvider = {
   status(id: string): Promise<PiExternalJobHandle>;
   result(id: string): Promise<PiExternalJobResult>;
   reattach(id: string): Promise<PiExternalJobHandle>;
+  followUp?(input: Record<string, unknown>): Promise<PiExternalJobHandle>;
 };
 
 type RegisterExternalJobProvider = (provider: OracleExternalJobProvider) => () => void;
@@ -273,6 +279,9 @@ function oracleExternalJob(job: OracleJob): OracleExternalJob {
     id: job.id,
     state: job.state,
     conversationUrl: job.conversationUrl ?? null,
+    ...(typeof job.follow === "string" ? { follow: job.follow } : {}),
+    ...(typeof job.requestId === "string" ? { requestId: job.requestId } : {}),
+    ...(typeof job.promptDigest === "string" ? { promptDigest: job.promptDigest } : {}),
     ...(resultText === undefined ? {} : { resultText }),
     ...(failure ? { failure } : {}),
   };
@@ -347,6 +356,38 @@ function oracleOption(input: Record<string, unknown>, key: "model" | "effort"): 
   return typeof direct === "string" ? direct : undefined;
 }
 
+function optionalString(input: Record<string, unknown>, key: string): string | undefined {
+  const value = input[key];
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function parentProviderJobId(input: Record<string, unknown>): string {
+  const id = optionalString(input, "parentProviderJobId") ?? optionalString(input, "providerJobId");
+  if (!id) throw new Error("parentProviderJobId required");
+  return id;
+}
+
+function assertFollowJob(job: OracleExternalJob, parentId: string) {
+  if (job.id === parentId) throw new Error(`Surf oracle follow-up reused parent job '${parentId}'`);
+  if (job.follow !== parentId) throw new Error(`Surf oracle follow-up job '${job.id}' is not linked to parent '${parentId}'`);
+}
+
+const ORACLE_STATUS_HARVEST_TIMEOUT_SECONDS = 5;
+
+async function requestOracleJobStatus(request: typeof requestSurf, id: string) {
+  try {
+    return await requestOracleJob(request, "oracle.result", {
+      id,
+      timeout: ORACLE_STATUS_HARVEST_TIMEOUT_SECONDS,
+    });
+  } catch (error) {
+    if (error && typeof error === "object" && "jobId" in error && error.jobId === id) {
+      return requestOracleJob(request, "oracle.status", { id });
+    }
+    throw error;
+  }
+}
+
 export function createOracleExternalJobProvider(
   sessionId: string,
   jobIds: Set<string>,
@@ -356,8 +397,9 @@ export function createOracleExternalJobProvider(
     return true;
   },
   emitTerminal: EmitOracleJob = () => false,
+  options: { followUp?: boolean } = {},
 ): OracleExternalJobProvider {
-  return {
+  const provider: OracleExternalJobProvider = {
     name: "surf-oracle",
     async start(input) {
       const prompt = typeof input.prompt === "string" ? input.prompt : "";
@@ -373,7 +415,7 @@ export function createOracleExternalJobProvider(
       return piExternalJobHandle(job);
     },
     async status(id) {
-      return piExternalJobHandle(await requestOracleJob(request, "oracle.status", { id }));
+      return piExternalJobHandle(await requestOracleJobStatus(request, id));
     },
     result(id) {
       return requestOracleJob(request, "oracle.result", { id })
@@ -387,7 +429,7 @@ export function createOracleExternalJobProvider(
         });
     },
     reattach(id) {
-      return requestOracleJob(request, "oracle.result", { id })
+      return requestOracleJobStatus(request, id)
         .then((job) => {
           rememberJob(job.id);
           emitTerminal({ id: job.id, state: job.state });
@@ -399,6 +441,27 @@ export function createOracleExternalJobProvider(
         });
     },
   };
+  if (options.followUp) {
+    provider.followUp = async (input) => {
+      const prompt = typeof input.prompt === "string" ? input.prompt : "";
+      if (!prompt.trim()) throw new Error("prompt required");
+      const parentId = parentProviderJobId(input);
+      const model = oracleOption(input, "model");
+      const effort = oracleOption(input, "effort");
+      const requestId = optionalString(input, "requestId");
+      const job = await requestOracleJob(request, "oracle.ask", {
+        prompt,
+        follow: parentId,
+        ...(model !== undefined ? { model } : {}),
+        ...(effort !== undefined ? { effort } : {}),
+        ...(requestId !== undefined ? { requestId } : {}),
+      });
+      assertFollowJob(job, parentId);
+      rememberJob(job.id);
+      return piExternalJobHandle(job);
+    };
+  }
+  return provider;
 }
 
 export function registerOptionalBackgroundProvider(sessionId: string, jobIds: Set<string>, listJobs: () => Array<{ id: string; state: string }>, register: RegisterBackgroundWorkProvider) {
@@ -419,7 +482,15 @@ export function registerOptionalExternalJobProvider(
   rememberJob?: RememberOracleJob,
   emitTerminal?: EmitOracleJob,
 ) {
-  return register(createOracleExternalJobProvider(sessionId, jobIds, request, rememberJob, emitTerminal));
+  const provider = createOracleExternalJobProvider(sessionId, jobIds, request, rememberJob, emitTerminal, { followUp: true });
+  try {
+    return register(provider);
+  } catch (error) {
+    if (String(error instanceof Error ? error.message : error).includes("followUp")) {
+      return register(createOracleExternalJobProvider(sessionId, jobIds, request, rememberJob, emitTerminal));
+    }
+    throw error;
+  }
 }
 
 export function rememberOracleJobForSession(jobIds: Set<string>, jobId: unknown, requestGeneration: number, currentGeneration: number, sessionActive: boolean): boolean {

--- a/test/unit/oracle-host.test.ts
+++ b/test/unit/oracle-host.test.ts
@@ -80,6 +80,97 @@ describe("oracle host recovery", () => {
     ).toEqual(contextManifest);
   });
 
+  it("deduplicates repeated oracle.ask requests by requestId", async () => {
+    useTempState();
+    const dispatch = vi
+      .spyOn(chatgptClient, "dispatch")
+      .mockImplementation(async (options: any) => {
+        await options.afterSubmit({ tabId: 7, promptEcho: "review" });
+        return {
+          tabId: 7,
+          conversationUrl: "https://chatgpt.com/c/conversation-id",
+          promptEcho: "review",
+        };
+      });
+    const host = createHost(vi.fn());
+
+    const first = await host.handle(
+      { context: { isRemote: false } },
+      { type: "ORACLE_ASK", prompt: "review", requestId: "request-1" },
+    );
+    const duplicate = await host.handle(
+      { context: { isRemote: false } },
+      { type: "ORACLE_ASK", prompt: "review", requestId: "request-1" },
+    );
+
+    expect(duplicate.id).toBe(first.id);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    await expect(
+      host.handle(
+        { context: { isRemote: false } },
+        { type: "ORACLE_ASK", prompt: "different", requestId: "request-1" },
+      ),
+    ).rejects.toMatchObject({ code: "idempotency_conflict", jobId: first.id });
+  });
+
+  it("records follow turns with child and request identity", async () => {
+    useTempState();
+    const parent = oracleJobs.createJob({ prompt: "first" });
+    oracleJobs.markDispatched(parent.id, { tabId: 6, promptEcho: "first" });
+    oracleJobs.markAwaiting(parent.id, {
+      conversationUrl: "https://chatgpt.com/c/conversation-id",
+      promptEcho: "first",
+    });
+    oracleJobs.markCaptured(parent.id, { response: "first answer" });
+    vi.spyOn(chatgptClient, "dispatch").mockImplementation(async (options: any) => {
+      expect(options.startUrl).toBe("https://chatgpt.com/c/conversation-id");
+      await options.afterSubmit({ tabId: 8, promptEcho: "follow" });
+      return {
+        tabId: 8,
+        conversationUrl: "https://chatgpt.com/c/conversation-id",
+        promptEcho: "follow",
+      };
+    });
+    const host = createHost(vi.fn());
+
+    const child = await host.handle(
+      { context: { isRemote: false } },
+      { type: "ORACLE_ASK", prompt: "follow", follow: parent.id, requestId: "follow-request" },
+    );
+
+    expect(child).toMatchObject({ follow: parent.id, requestId: "follow-request" });
+    expect(oracleJobs.getJob(parent.id).turns).toEqual([
+      expect.objectContaining({
+        prompt: "follow",
+        childJobId: child.id,
+        requestId: "follow-request",
+      }),
+    ]);
+  });
+
+  it("fails closed when a follow parent is missing", async () => {
+    useTempState();
+    const dispatch = vi.spyOn(chatgptClient, "dispatch").mockResolvedValue({
+      tabId: 7,
+      conversationUrl: "https://chatgpt.com/c/conversation-id",
+      promptEcho: "follow",
+    });
+    const host = createHost(vi.fn());
+
+    await expect(
+      host.handle(
+        { context: { isRemote: false } },
+        {
+          type: "ORACLE_ASK",
+          prompt: "follow",
+          follow: "20260729-120000-dead",
+          requestId: "missing-parent",
+        },
+      ),
+    ).rejects.toMatchObject({ code: "not_found" });
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
   it("leaves Cloudflare challenge tabs open for manual clearance", async () => {
     useTempState();
     vi.spyOn(chatgptClient, "dispatch").mockImplementation(async (options: any) => {

--- a/test/unit/oracle-jobs.test.ts
+++ b/test/unit/oracle-jobs.test.ts
@@ -113,6 +113,31 @@ describe("oracle job registry", () => {
     expect(fs.statSync(path.join(directory, "turns")).mode & 0o777).toBe(0o700);
   });
 
+  it("deduplicates exact request ids and rejects conflicting reuse", () => {
+    useTempState();
+    const first = jobs.createJob({
+      prompt: "first",
+      contextManifest: { files: [{ path: "src/a.ts", bytes: 1 }] },
+      model: "gpt-5.6-sol",
+      effortRequested: "pro",
+      requestId: "request-1",
+    });
+
+    const duplicate = jobs.createJob({
+      prompt: "first",
+      contextManifest: { files: [{ bytes: 1, path: "src/a.ts" }] },
+      model: "gpt-5.6-sol",
+      effortRequested: "pro",
+      requestId: "request-1",
+    });
+
+    expect(duplicate).toMatchObject({ id: first.id, requestDeduped: true });
+    expect(jobs.listJobs({})).toHaveLength(1);
+    expect(() => jobs.createJob({ prompt: "different", requestId: "request-1" })).toThrow(
+      expect.objectContaining({ code: "idempotency_conflict", jobId: first.id }),
+    );
+  });
+
   it("rejects capacity while naming the in-flight job", () => {
     useTempState();
     const first = jobs.createJob({ prompt: "first" });
@@ -142,6 +167,14 @@ describe("oracle job registry", () => {
     jobs.appendTurn(parent.id, {
       prompt: "follow",
       dispatchedAt: dispatched.dispatchedAt,
+      childJobId: child.id,
+      requestId: "follow-request",
+    });
+    jobs.appendTurn(parent.id, {
+      prompt: "follow",
+      dispatchedAt: dispatched.dispatchedAt,
+      childJobId: child.id,
+      requestId: "follow-request",
     });
     const updated = jobs.updateTabId(child.id, 8);
     jobs.markAwaiting(child.id, {
@@ -151,8 +184,10 @@ describe("oracle job registry", () => {
     const captured = jobs.markCaptured(child.id, { response: "follow answer" });
 
     const lineage = jobs.markTurnCaptured(parent.id, {
-      dispatchedAt: captured.dispatchedAt,
+      dispatchedAt: "wrong-dispatch-time",
       capturedAt: captured.capturedAt,
+      childJobId: child.id,
+      requestId: "follow-request",
     });
 
     expect(updated).toMatchObject({ follow: parent.id, tabId: 8, promptEcho: "follow" });
@@ -160,6 +195,8 @@ describe("oracle job registry", () => {
       prompt: "follow",
       dispatchedAt: captured.dispatchedAt,
       capturedAt: captured.capturedAt,
+      childJobId: child.id,
+      requestId: "follow-request",
     });
     expect(
       JSON.parse(

--- a/test/unit/pi-extension.test.ts
+++ b/test/unit/pi-extension.test.ts
@@ -225,6 +225,7 @@ describe("Pi extension", () => {
 
     expect(provider?.name).toBe("surf-oracle");
     expect(Object.keys(provider ?? {}).sort()).toEqual([
+      "followUp",
       "name",
       "reattach",
       "result",
@@ -240,18 +241,25 @@ describe("Pi extension", () => {
     const requests: Array<{ tool: string; args: Record<string, unknown> }> = [];
     const request = vi.fn(async (tool: string, args: Record<string, unknown>) => {
       requests.push({ tool, args });
-      const id = tool === "oracle.ask" ? "job-started" : String(args.id);
-      return {
-        content: [{ type: "text", text: "{}" }],
-        details: {
-          id,
-          state: tool === "oracle.result" ? "captured" : "awaiting",
-          conversationUrl: "https://chatgpt.com/c/conversation-id",
-          ...(tool === "oracle.result" ? { response: "answer\n" } : {}),
-        },
+      const details: Record<string, unknown> = {
+        id: tool === "oracle.ask" ? "job-started" : String(args.id),
+        state: "awaiting",
+        conversationUrl: "https://chatgpt.com/c/conversation-id",
       };
+      if (tool === "oracle.result") {
+        details.state = "captured";
+        details.response = "answer\n";
+      }
+      return { content: [{ type: "text", text: "{}" }], details };
     });
-    const provider = createOracleExternalJobProvider("pi-session", jobIds, request);
+    const provider = createOracleExternalJobProvider(
+      "pi-session",
+      jobIds,
+      request,
+      undefined,
+      undefined,
+      { followUp: true },
+    );
 
     await expect(
       provider.start({
@@ -267,7 +275,7 @@ describe("Pi extension", () => {
     });
     await expect(provider.status("job-started")).resolves.toMatchObject({
       providerJobId: "job-started",
-      state: "running",
+      state: "completed",
     });
     await expect(provider.result("job-started")).resolves.toEqual({
       providerJobId: "job-started",
@@ -280,9 +288,93 @@ describe("Pi extension", () => {
     expect(jobIds.has("job-started")).toBe(true);
     expect(requests).toEqual([
       { tool: "oracle.ask", args: { prompt: "review", model: "pro", effort: "pro" } },
-      { tool: "oracle.status", args: { id: "job-started" } },
+      { tool: "oracle.result", args: { id: "job-started", timeout: 5 } },
       { tool: "oracle.result", args: { id: "job-started" } },
-      { tool: "oracle.result", args: { id: "job-started" } },
+      { tool: "oracle.result", args: { id: "job-started", timeout: 5 } },
+    ]);
+  });
+
+  it("falls back to oracle.status when bounded status harvest reports a failed job", async () => {
+    const requests: Array<{ tool: string; args: Record<string, unknown> }> = [];
+    const provider = createOracleExternalJobProvider(
+      "pi-session",
+      new Set(),
+      async (tool: string, args: Record<string, unknown>) => {
+        requests.push({ tool, args });
+        if (tool === "oracle.result") {
+          return {
+            content: [{ type: "text", text: "harvest failed" }],
+            details: { code: "harvest_failed", jobId: "failed-job", message: "harvest failed" },
+            isError: true,
+          };
+        }
+        return {
+          content: [{ type: "text", text: "{}" }],
+          details: {
+            id: "failed-job",
+            state: "failed",
+            error: { code: "harvest_failed", message: "harvest failed" },
+          },
+        };
+      },
+    );
+
+    await expect(provider.status("failed-job")).resolves.toEqual({
+      providerJobId: "failed-job",
+      state: "failed",
+      failureCode: "harvest_failed",
+      failureMessage: "harvest failed",
+    });
+    expect(requests).toEqual([
+      { tool: "oracle.result", args: { id: "failed-job", timeout: 5 } },
+      { tool: "oracle.status", args: { id: "failed-job" } },
+    ]);
+  });
+
+  it("maps external-job follow-ups to Surf Oracle follow requests", async () => {
+    const jobIds = new Set<string>();
+    const requests: Array<{ tool: string; args: Record<string, unknown> }> = [];
+    const provider = createOracleExternalJobProvider(
+      "pi-session",
+      jobIds,
+      async (tool: string, args: Record<string, unknown>) => {
+        requests.push({ tool, args });
+        return {
+          content: [{ type: "text", text: "{}" }],
+          details: {
+            id: "follow-job",
+            state: "awaiting",
+            follow: args.follow,
+            requestId: args.requestId,
+          },
+        };
+      },
+      undefined,
+      undefined,
+      { followUp: true },
+    );
+
+    await expect(
+      provider.followUp?.({
+        parentProviderJobId: "parent-job",
+        prompt: "continue",
+        requestId: "follow-request",
+        options: { model: "pro", effort: "pro" },
+      }),
+    ).resolves.toMatchObject({ providerJobId: "follow-job", state: "running" });
+
+    expect(jobIds.has("follow-job")).toBe(true);
+    expect(requests).toEqual([
+      {
+        tool: "oracle.ask",
+        args: {
+          prompt: "continue",
+          follow: "parent-job",
+          model: "pro",
+          effort: "pro",
+          requestId: "follow-request",
+        },
+      },
     ]);
   });
 


### PR DESCRIPTION
## Summary

Prepares Surf's Oracle provider for the GPT Pro follow-up work tracked in `nicobailon/pi-subagents#1381`.

This PR:

- lets `surf-oracle` external-job `status()` and `reattach()` perform bounded result harvesting through `oracle.result`
- keeps current strict pi-subagents provider registration compatible by retrying without `followUp` when an older bridge rejects that field
- adds optional Surf-side `followUp(input)` mapping to `oracle.ask({ follow, requestId, model, effort })`
- persists Oracle `requestId` fingerprints so duplicate follow-up dispatches can dedupe and conflicting reuse fails closed
- records follow turn lineage with child job id and request id

Closes #204.

## Validation

- `npx vitest run test/unit/pi-extension.test.ts test/unit/pi-external-job-contract.test.ts test/unit/oracle-jobs.test.ts test/unit/oracle-host.test.ts`
- `npm run check`
- `git diff --check`
- `npx biome check CHANGELOG.md pi-extension/surf.ts native/oracle-host.cjs native/oracle-jobs.cjs test/unit/pi-extension.test.ts test/unit/pi-external-job-contract.test.ts test/unit/oracle-jobs.test.ts test/unit/oracle-host.test.ts`

Fresh review: No issues found.
