### PR TITLE
fix: polish Surf Oracle external job handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - **Pi GPT Pro polling** - The `surf-oracle` external-job provider now performs bounded result harvesting during status and reattach checks, so Pi polling can observe completed GPT Pro jobs without a separate result call.
+- **Pi GPT Pro cancellation** - Aborted Surf Oracle requests now stay non-terminal and keep their cancellation error instead of emitting a failed-job wake event.
 
 ## [2.15.2] - 2026-08-22
 

--- a/native/oracle-jobs.cjs
+++ b/native/oracle-jobs.cjs
@@ -97,7 +97,9 @@ function createJob({ prompt, contextManifest = {}, model = null, effortRequested
   const base = oracleRoot(root);
   ensurePrivateDir(base, root);
   const safeRequestId = normalizedRequestId(requestId);
-  const fingerprint = requestFingerprint({ prompt, contextManifest, model, effortRequested, follow });
+  const fingerprint = safeRequestId
+    ? requestFingerprint({ prompt, contextManifest, model, effortRequested, follow })
+    : null;
   if (safeRequestId) {
     const existing = readJobs(root).find((job) => job.requestId === safeRequestId);
     if (existing) {

--- a/pi-extension/surf.ts
+++ b/pi-extension/surf.ts
@@ -43,17 +43,10 @@ type ToolResult = { content: Array<{ type: "text" | "image"; text?: string; data
 type OracleJob = {
   id: string;
   state: string;
-  conversationUrl?: string | null;
-  model?: string | null;
-  modelRequested?: string | null;
-  modelVerified?: string | null;
-  effortRequested?: string | null;
-  effortVerified?: string | null;
-  promptDigest?: string | null;
-  requestId?: string | null;
-  follow?: string | null;
+  conversationUrl: string | null;
+  follow: string | null;
   response?: string;
-  error?: { code?: string; message?: string } | null;
+  error: { code?: string; message?: string } | null;
 };
 
 type BackgroundWorkProvider = {
@@ -78,8 +71,6 @@ type OracleExternalJob = {
   state: string;
   conversationUrl: string | null;
   follow?: string;
-  requestId?: string;
-  promptDigest?: string;
   resultText?: string;
   failure?: { code: string; message: string };
 };
@@ -263,11 +254,40 @@ export async function resolveExternalJobProviderRegister(
   return registerGlobalExternalJobProvider;
 }
 
+function optionalOracleString(value: unknown, field: string): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "string") throw new Error(`Surf oracle response included an invalid ${field}`);
+  return value;
+}
+
+function oracleFailure(value: unknown): OracleJob["error"] {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Surf oracle response included invalid failure details");
+  }
+  const details = value as Record<string, unknown>;
+  const code = optionalOracleString(details.code, "failure code");
+  const message = optionalOracleString(details.message, "failure message");
+  return { ...(code === undefined ? {} : { code }), ...(message === undefined ? {} : { message }) };
+}
+
 function asOracleJob(value: unknown): OracleJob {
   if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Surf oracle response did not include job metadata");
-  const job = value as Partial<OracleJob>;
-  if (typeof job.id !== "string" || typeof job.state !== "string") throw new Error("Surf oracle response did not include job id and state");
-  return job as OracleJob;
+  const job = value as Record<string, unknown>;
+  if (typeof job.id !== "string" || !job.id || job.id.trim() !== job.id || typeof job.state !== "string") {
+    throw new Error("Surf oracle response did not include a valid job id and state");
+  }
+  const conversationUrl = optionalOracleString(job.conversationUrl, "conversation URL");
+  const follow = optionalOracleString(job.follow, "follow job id");
+  const response = optionalOracleString(job.response, "result text");
+  return {
+    id: job.id,
+    state: job.state,
+    conversationUrl: conversationUrl ?? null,
+    follow: follow ?? null,
+    error: oracleFailure(job.error),
+    ...(response === undefined ? {} : { response }),
+  };
 }
 
 function oracleExternalJob(job: OracleJob): OracleExternalJob {
@@ -280,8 +300,6 @@ function oracleExternalJob(job: OracleJob): OracleExternalJob {
     state: job.state,
     conversationUrl: job.conversationUrl ?? null,
     ...(typeof job.follow === "string" ? { follow: job.follow } : {}),
-    ...(typeof job.requestId === "string" ? { requestId: job.requestId } : {}),
-    ...(typeof job.promptDigest === "string" ? { promptDigest: job.promptDigest } : {}),
     ...(resultText === undefined ? {} : { resultText }),
     ...(failure ? { failure } : {}),
   };
@@ -342,6 +360,7 @@ async function requestOracleJob(request: typeof requestSurf, tool: string, args:
 }
 
 function emitFailedOracleJob(error: unknown, emitTerminal: EmitOracleJob) {
+  if (error && typeof error === "object" && "code" in error && error.code === "SURF_REQUEST_ABORTED") return;
   if (!error || typeof error !== "object" || !("jobId" in error) || typeof error.jobId !== "string") return;
   emitTerminal({ id: error.jobId, state: "failed" });
 }
@@ -381,7 +400,9 @@ async function requestOracleJobStatus(request: typeof requestSurf, id: string) {
       timeout: ORACLE_STATUS_HARVEST_TIMEOUT_SECONDS,
     });
   } catch (error) {
-    if (error && typeof error === "object" && "jobId" in error && error.jobId === id) {
+    if (!error || typeof error !== "object") throw error;
+    if ("code" in error && error.code === "SURF_REQUEST_ABORTED") throw error;
+    if ("jobId" in error && error.jobId === id) {
       return requestOracleJob(request, "oracle.status", { id });
     }
     throw error;
@@ -389,7 +410,6 @@ async function requestOracleJobStatus(request: typeof requestSurf, id: string) {
 }
 
 export function createOracleExternalJobProvider(
-  sessionId: string,
   jobIds: Set<string>,
   request: typeof requestSurf = requestSurf,
   rememberJob: RememberOracleJob = (jobId) => {
@@ -415,7 +435,9 @@ export function createOracleExternalJobProvider(
       return piExternalJobHandle(job);
     },
     async status(id) {
-      return piExternalJobHandle(await requestOracleJobStatus(request, id));
+      const job = await requestOracleJobStatus(request, id);
+      emitTerminal({ id: job.id, state: job.state });
+      return piExternalJobHandle(job);
     },
     result(id) {
       return requestOracleJob(request, "oracle.result", { id })
@@ -475,19 +497,18 @@ export function registerOptionalBackgroundProvider(sessionId: string, jobIds: Se
 }
 
 export function registerOptionalExternalJobProvider(
-  sessionId: string,
   jobIds: Set<string>,
   register: RegisterExternalJobProvider,
   request: typeof requestSurf = requestSurf,
   rememberJob?: RememberOracleJob,
   emitTerminal?: EmitOracleJob,
 ) {
-  const provider = createOracleExternalJobProvider(sessionId, jobIds, request, rememberJob, emitTerminal, { followUp: true });
+  const provider = createOracleExternalJobProvider(jobIds, request, rememberJob, emitTerminal, { followUp: true });
   try {
     return register(provider);
   } catch (error) {
     if (String(error instanceof Error ? error.message : error).includes("followUp")) {
-      return register(createOracleExternalJobProvider(sessionId, jobIds, request, rememberJob, emitTerminal));
+      return register(createOracleExternalJobProvider(jobIds, request, rememberJob, emitTerminal));
     }
     throw error;
   }
@@ -604,7 +625,7 @@ export default function surfExtension(pi: Pi) {
       const rememberForGeneration = (jobId: string) => rememberOracleJobForSession(oracleJobIds, jobId, generation, sessionGeneration, sessionActive);
       const emitFinished = (job: Pick<OracleExternalJob, "id" | "state">) => emitOracleFinished(pi, job);
       dispose = registerOptionalBackgroundProvider(sessionId, oracleJobIds, jobs.listJobs, registerGlobalBackgroundProvider);
-      disposeExternal = registerOptionalExternalJobProvider(sessionId, oracleJobIds, registerGlobalExternalJobProvider, requestSurf, rememberForGeneration, emitFinished);
+      disposeExternal = registerOptionalExternalJobProvider(oracleJobIds, registerGlobalExternalJobProvider, requestSurf, rememberForGeneration, emitFinished);
       sessionActive = true;
       void resolveBackgroundWorkRegister().then((register) => {
         try {
@@ -623,7 +644,7 @@ export default function surfExtension(pi: Pi) {
       void resolveExternalJobProviderRegister().then((register) => {
         try {
           if (register === registerGlobalExternalJobProvider || generation !== sessionGeneration) return;
-          const nextDispose = registerOptionalExternalJobProvider(sessionId, oracleJobIds, register, requestSurf, rememberForGeneration, emitFinished);
+          const nextDispose = registerOptionalExternalJobProvider(oracleJobIds, register, requestSurf, rememberForGeneration, emitFinished);
           if (generation !== sessionGeneration) {
             nextDispose();
             return;

--- a/test/unit/oracle-host.test.ts
+++ b/test/unit/oracle-host.test.ts
@@ -3,7 +3,24 @@ import { afterEach, vi } from "vitest";
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
-const chatgptClient = require("../../native/chatgpt-client.cjs");
+type ChatGptDispatchOptions = {
+  startUrl?: string | null;
+  createTab(): Promise<{ tabId?: number }>;
+  afterSubmit(result: {
+    tabId: number;
+    promptEcho: string;
+    modelVerified?: string;
+    effortVerified?: string;
+  }): unknown;
+};
+const chatgptClient = require("../../native/chatgpt-client.cjs") as {
+  dispatch(options: ChatGptDispatchOptions): Promise<{
+    tabId: number;
+    conversationUrl: string;
+    promptEcho: string;
+  }>;
+  harvest(options: Record<string, unknown>): Promise<{ response: string }>;
+};
 const oracleJobs = require("../../native/oracle-jobs.cjs");
 const { assertLocalOracleRequest, createOracleHost } = require("../../native/oracle-host.cjs");
 
@@ -56,7 +73,7 @@ describe("oracle host request guard", () => {
 describe("oracle host recovery", () => {
   it("persists the context manifest received by oracle.ask", async () => {
     const root = useTempState();
-    vi.spyOn(chatgptClient, "dispatch").mockImplementation(async (options: any) => {
+    vi.spyOn(chatgptClient, "dispatch").mockImplementation(async (options) => {
       await options.afterSubmit({ tabId: 7, promptEcho: "review" });
       return {
         tabId: 7,
@@ -82,16 +99,14 @@ describe("oracle host recovery", () => {
 
   it("deduplicates repeated oracle.ask requests by requestId", async () => {
     useTempState();
-    const dispatch = vi
-      .spyOn(chatgptClient, "dispatch")
-      .mockImplementation(async (options: any) => {
-        await options.afterSubmit({ tabId: 7, promptEcho: "review" });
-        return {
-          tabId: 7,
-          conversationUrl: "https://chatgpt.com/c/conversation-id",
-          promptEcho: "review",
-        };
-      });
+    const dispatch = vi.spyOn(chatgptClient, "dispatch").mockImplementation(async (options) => {
+      await options.afterSubmit({ tabId: 7, promptEcho: "review" });
+      return {
+        tabId: 7,
+        conversationUrl: "https://chatgpt.com/c/conversation-id",
+        promptEcho: "review",
+      };
+    });
     const host = createHost(vi.fn());
 
     const first = await host.handle(
@@ -122,7 +137,7 @@ describe("oracle host recovery", () => {
       promptEcho: "first",
     });
     oracleJobs.markCaptured(parent.id, { response: "first answer" });
-    vi.spyOn(chatgptClient, "dispatch").mockImplementation(async (options: any) => {
+    vi.spyOn(chatgptClient, "dispatch").mockImplementation(async (options) => {
       expect(options.startUrl).toBe("https://chatgpt.com/c/conversation-id");
       await options.afterSubmit({ tabId: 8, promptEcho: "follow" });
       return {
@@ -173,7 +188,7 @@ describe("oracle host recovery", () => {
 
   it("leaves Cloudflare challenge tabs open for manual clearance", async () => {
     useTempState();
-    vi.spyOn(chatgptClient, "dispatch").mockImplementation(async (options: any) => {
+    vi.spyOn(chatgptClient, "dispatch").mockImplementation(async (options) => {
       await options.createTab();
       throw Object.assign(new Error("Cloudflare challenge detected - complete in browser"), {
         code: "cloudflare",

--- a/test/unit/oracle-jobs.test.ts
+++ b/test/unit/oracle-jobs.test.ts
@@ -191,6 +191,7 @@ describe("oracle job registry", () => {
     });
 
     expect(updated).toMatchObject({ follow: parent.id, tabId: 8, promptEcho: "follow" });
+    expect(lineage.turns).toHaveLength(1);
     expect(lineage.turns[0]).toMatchObject({
       prompt: "follow",
       dispatchedAt: captured.dispatchedAt,

--- a/test/unit/pi-extension.test.ts
+++ b/test/unit/pi-extension.test.ts
@@ -155,7 +155,7 @@ describe("Pi extension", () => {
 
   it("creates the optional pi-subagents external-job provider registry lazily", () => {
     delete (globalThis as Record<PropertyKey, unknown>)[externalJobProviderKey];
-    const provider = createOracleExternalJobProvider("pi-session", new Set(), vi.fn());
+    const provider = createOracleExternalJobProvider(new Set(), vi.fn());
 
     const dispose = registerGlobalExternalJobProvider(provider);
     const registry = (
@@ -212,7 +212,6 @@ describe("Pi extension", () => {
         }
       | undefined;
     const dispose = registerOptionalExternalJobProvider(
-      "pi-session",
       new Set(),
       (registered: typeof provider) => {
         provider = registered;
@@ -252,14 +251,9 @@ describe("Pi extension", () => {
       }
       return { content: [{ type: "text", text: "{}" }], details };
     });
-    const provider = createOracleExternalJobProvider(
-      "pi-session",
-      jobIds,
-      request,
-      undefined,
-      undefined,
-      { followUp: true },
-    );
+    const provider = createOracleExternalJobProvider(jobIds, request, undefined, undefined, {
+      followUp: true,
+    });
 
     await expect(
       provider.start({
@@ -297,7 +291,6 @@ describe("Pi extension", () => {
   it("falls back to oracle.status when bounded status harvest reports a failed job", async () => {
     const requests: Array<{ tool: string; args: Record<string, unknown> }> = [];
     const provider = createOracleExternalJobProvider(
-      "pi-session",
       new Set(),
       async (tool: string, args: Record<string, unknown>) => {
         requests.push({ tool, args });
@@ -331,11 +324,40 @@ describe("Pi extension", () => {
     ]);
   });
 
+  it("preserves aborted oracle requests without fallback or terminal wake events", async () => {
+    const emitted: Array<{ id: string; state: string }> = [];
+    const request = vi.fn(async () => ({
+      content: [{ type: "text", text: "request aborted" }],
+      details: { code: "SURF_REQUEST_ABORTED", jobId: "running-job", message: "request aborted" },
+      isError: true,
+    }));
+    const provider = createOracleExternalJobProvider(
+      new Set(),
+      request,
+      undefined,
+      (job: { id: string; state: string }) => {
+        emitted.push(job);
+        return true;
+      },
+    );
+
+    await expect(provider.status("running-job")).rejects.toMatchObject({
+      code: "SURF_REQUEST_ABORTED",
+      jobId: "running-job",
+    });
+    await expect(provider.result("running-job")).rejects.toMatchObject({
+      code: "SURF_REQUEST_ABORTED",
+      jobId: "running-job",
+    });
+
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(emitted).toEqual([]);
+  });
+
   it("maps external-job follow-ups to Surf Oracle follow requests", async () => {
     const jobIds = new Set<string>();
     const requests: Array<{ tool: string; args: Record<string, unknown> }> = [];
     const provider = createOracleExternalJobProvider(
-      "pi-session",
       jobIds,
       async (tool: string, args: Record<string, unknown>) => {
         requests.push({ tool, args });
@@ -380,20 +402,23 @@ describe("Pi extension", () => {
 
   it("maps failed oracle jobs to pi failure fields and rejects unknown states", async () => {
     const provider = createOracleExternalJobProvider(
-      "pi-session",
       new Set(),
-      async (_tool: string, args: Record<string, unknown>) => ({
-        content: [{ type: "text", text: "{}" }],
-        details:
-          args.id === "weird-job"
-            ? { id: "weird-job", state: "harvesting" }
-            : {
-                id: "failed-job",
-                state: "failed",
-                conversationUrl: null,
-                error: { code: "harvest_failed", message: " harvest failed " },
-              },
-      }),
+      async (_tool: string, args: Record<string, unknown>) => {
+        let details: Record<string, unknown>;
+        if (args.id === "weird-job") {
+          details = { id: "weird-job", state: "harvesting" };
+        } else if (args.id === "malformed-job") {
+          details = { id: "malformed-job", state: "failed", error: { code: 500 } };
+        } else {
+          details = {
+            id: "failed-job",
+            state: "failed",
+            conversationUrl: null,
+            error: { code: "harvest_failed", message: " harvest failed " },
+          };
+        }
+        return { content: [{ type: "text", text: "{}" }], details };
+      },
     );
 
     await expect(provider.status("failed-job")).resolves.toEqual({
@@ -403,11 +428,12 @@ describe("Pi extension", () => {
       failureMessage: "harvest failed",
     });
     await expect(provider.status("weird-job")).rejects.toThrow(/unknown state 'harvesting'/);
+    await expect(provider.status("malformed-job")).rejects.toThrow(/invalid failure code/);
   });
 
   it("registers reattached active jobs as background work", async () => {
     const jobIds = new Set<string>();
-    const provider = createOracleExternalJobProvider("pi-session", jobIds, async () => ({
+    const provider = createOracleExternalJobProvider(jobIds, async () => ({
       content: [{ type: "text", text: "{}" }],
       details: {
         id: "existing-job",
@@ -438,7 +464,6 @@ describe("Pi extension", () => {
   it("emits the oracle finished wake channel for provider result capture", async () => {
     const emitted: Array<{ id: string; state: string }> = [];
     const provider = createOracleExternalJobProvider(
-      "pi-session",
       new Set(),
       async () => ({
         content: [{ type: "text", text: "{}" }],
@@ -451,10 +476,12 @@ describe("Pi extension", () => {
       },
     );
 
+    await provider.status("done");
     await provider.result("done");
     await provider.reattach("done");
 
     expect(emitted).toEqual([
+      { id: "done", state: "captured" },
       { id: "done", state: "captured" },
       { id: "done", state: "captured" },
     ]);
@@ -463,7 +490,6 @@ describe("Pi extension", () => {
   it("emits the oracle finished wake channel for provider result failures", async () => {
     const emitted: Array<{ id: string; state: string }> = [];
     const provider = createOracleExternalJobProvider(
-      "pi-session",
       new Set(),
       async () => ({
         content: [{ type: "text", text: "harvest failed" }],
@@ -494,7 +520,6 @@ describe("Pi extension", () => {
   it("does not emit terminal wake events for request errors without job ids", async () => {
     const emitted: Array<{ id: string; state: string }> = [];
     const provider = createOracleExternalJobProvider(
-      "pi-session",
       new Set(),
       async () => ({
         content: [{ type: "text", text: "oracle job not found" }],
@@ -525,12 +550,8 @@ describe("Pi extension", () => {
           resolveRequest = resolve;
         }),
     );
-    const provider = createOracleExternalJobProvider(
-      "old-session",
-      jobIds,
-      request,
-      (jobId: string) =>
-        rememberOracleJobForSession(jobIds, jobId, 1, currentGeneration, sessionActive),
+    const provider = createOracleExternalJobProvider(jobIds, request, (jobId: string) =>
+      rememberOracleJobForSession(jobIds, jobId, 1, currentGeneration, sessionActive),
     );
 
     const started = provider.start({ prompt: "review" });
@@ -556,7 +577,7 @@ describe("Pi extension", () => {
       },
       isError: true,
     }));
-    const provider = createOracleExternalJobProvider("pi-session", new Set(), request);
+    const provider = createOracleExternalJobProvider(new Set(), request);
 
     await expect(provider.start({ prompt: "review" })).rejects.toMatchObject({
       code: "capacity",

--- a/test/unit/pi-external-job-contract.test.ts
+++ b/test/unit/pi-external-job-contract.test.ts
@@ -18,7 +18,7 @@ function oracleResponse(details: Record<string, unknown>) {
 describe("pi-subagents external-job contract", () => {
   it("registers the provider object with pi's validator", () => {
     delete (globalThis as Record<PropertyKey, unknown>)[externalJobProviderKey];
-    const provider = createOracleExternalJobProvider("pi-session", new Set(), vi.fn());
+    const provider = createOracleExternalJobProvider(new Set(), vi.fn());
 
     const dispose = registerExternalJobProvider(provider);
 
@@ -27,9 +27,15 @@ describe("pi-subagents external-job contract", () => {
   });
 
   it("returns payloads that pass pi's handle and result validation for every oracle state", async () => {
-    for (const oracleState of ["created", "dispatched", "awaiting", "captured", "failed"]) {
+    const states = [
+      ["created", "queued"],
+      ["dispatched", "running"],
+      ["awaiting", "running"],
+      ["captured", "completed"],
+      ["failed", "failed"],
+    ] as const;
+    for (const [oracleState, state] of states) {
       const provider = createOracleExternalJobProvider(
-        "pi-session",
         new Set(),
         oracleResponse({
           id: "job-1",
@@ -47,16 +53,19 @@ describe("pi-subagents external-job contract", () => {
         validateExternalJobHandle("surf-oracle", await provider.status("job-1")),
       ).toMatchObject({
         providerJobId: "job-1",
+        state,
       });
       expect(
         validateExternalJobHandle("surf-oracle", await provider.reattach("job-1")),
       ).toMatchObject({
         providerJobId: "job-1",
+        state,
       });
       expect(
         validateExternalJobResult("surf-oracle", await provider.result("job-1")),
       ).toMatchObject({
         providerJobId: "job-1",
+        state,
         ...(oracleState === "captured" ? { output: "answer text" } : {}),
       });
     }
@@ -64,7 +73,6 @@ describe("pi-subagents external-job contract", () => {
 
   it("returns a start handle that passes pi's handle validation", async () => {
     const provider = createOracleExternalJobProvider(
-      "pi-session",
       new Set(),
       oracleResponse({ id: "job-2", state: "created", conversationUrl: null }),
     );


### PR DESCRIPTION
## Summary

This cleanup pass polishes the unreleased Surf Oracle external-job work and the last-release delta.

It preserves cancellation as non-terminal, emits the terminal wake path when status harvesting completes a job, validates consumed native Oracle fields at the extension boundary, removes unused adapter metadata, computes idempotency fingerprints only when request IDs exist, and tightens the focused regression tests.

## Validation

- `npm test -- --run test/unit/pi-extension.test.ts test/unit/pi-external-job-contract.test.ts test/unit/oracle-host.test.ts test/unit/oracle-jobs.test.ts`
- `npm run check`
- `npm run lint` (passes with one pre-existing warning and one schema-version info notice)
- `git diff --check`
- Fresh review of the working-tree cleanup: no issues found
- Exact-head review is running for commit `8add51d`
