### PR TITLE
fix: verify ChatGPT Pro effort selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- **ChatGPT Pro effort verification** - Surf now verifies the selected Pro effort from its visible picker label without letting unrelated metadata reject the accepted value.
 
 ## [2.16.0] - 2026-08-23
 

--- a/native/chatgpt-client-selection.cjs
+++ b/native/chatgpt-client-selection.cjs
@@ -50,12 +50,16 @@ function modelCandidateMatches(item, targetModel) {
 }
 
 function effortCandidateMatches(item, targetEffort) {
-  const variants = new Set(
-    [item?.label, item?.testId]
-      .flatMap((value) => normalizedWords(value))
-      .filter((word) => CHATGPT_EFFORT_CHOICES.includes(word)),
+  const labelVariants = new Set(
+    normalizedWords(item?.label).filter((word) => CHATGPT_EFFORT_CHOICES.includes(word)),
   );
-  return variants.size === 1 && variants.has(targetEffort);
+  if (labelVariants.size > 0) {
+    return labelVariants.size === 1 && labelVariants.has(targetEffort);
+  }
+  const testIdVariants = new Set(
+    normalizedWords(item?.testId).filter((word) => CHATGPT_EFFORT_CHOICES.includes(word)),
+  );
+  return testIdVariants.size === 1 && testIdVariants.has(targetEffort);
 }
 
 function uniqueMatch(items, matches) {

--- a/test/unit/chatgpt-client.test.ts
+++ b/test/unit/chatgpt-client.test.ts
@@ -370,6 +370,18 @@ describe("chatgpt-client", () => {
 
     it.each([
       ["requested effort found", [effortOptions[2]], "extended", "Extended"],
+      [
+        "visible Pro label wins over unrelated test id metadata",
+        [{ role: "button", label: "Pro", testId: "thinking-time-standard" }],
+        "pro",
+        "Pro",
+      ],
+      [
+        "ambiguous visible label stays fail-closed",
+        [{ role: "button", label: "Pro Extended", testId: "thinking-time-pro" }],
+        "pro",
+        null,
+      ],
       ["requested effort missing", [effortOptions[1]], "extended", null],
       ["ambiguous effort state", [effortOptions[2], effortOptions[2]], "extended", null],
       [


### PR DESCRIPTION
## Summary

Fixes ChatGPT effort verification when the visible picker label confirms `Pro` but unrelated element metadata contains another accepted effort word.

Closes #216.

## Validation

- `npm exec -- vitest run test/unit/chatgpt-client.test.ts`
- `npm run check`
- `git diff --check`

## Backlog notes

Fresh review found no issues on the candidate diff. No external contributor credit is required.
