### PR TITLE
fix: verify ChatGPT Pro effort readback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [Unreleased]
-- **ChatGPT Pro effort verification** - Surf now verifies the selected Pro effort from its visible picker label without letting unrelated metadata reject the accepted value.
+- **ChatGPT Pro effort verification** - Surf now verifies the selected Pro effort from the composer picker label and readback state without letting unrelated metadata reject the accepted value.
 
 ## [2.16.0] - 2026-08-23
 

--- a/native/chatgpt-client-ui.cjs
+++ b/native/chatgpt-client-ui.cjs
@@ -191,14 +191,33 @@ async function readPicker(cdp, kind, click = false) {
     `(() => {
       ${buildClickDispatcher()}
       const kind = ${JSON.stringify(kind)};
+      const effortChoices = new Set(${JSON.stringify(CHATGPT_EFFORT_CHOICES)});
+      const effortOwnerLabels = new Set([...effortChoices, 'thinking']);
+      const normalize = (value) => String(value || '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+      const labelFor = (node) => {
+        const labelledBy = String(node.getAttribute?.('aria-labelledby') || '')
+          .split(/\s+/)
+          .map((id) => document.getElementById(id)?.textContent || '')
+          .join(' ');
+        const text = (node.innerText || node.textContent || '').replace(/\s+/g, ' ').trim();
+        const aria = (node.getAttribute?.('aria-label') || '').replace(/\s+/g, ' ').trim();
+        const title = (node.getAttribute?.('title') || '').replace(/\s+/g, ' ').trim();
+        return [text, aria, labelledBy, title].filter(Boolean).join(' | ');
+      };
       let nodes = Array.from(document.querySelectorAll(${JSON.stringify(selector)})).filter((node) => {
-        const value = ((node.getAttribute?.('aria-label') || '') + ' ' + (node.textContent || '')).toLowerCase();
-        if (kind !== 'model') return value.includes('thinking') || value.includes('pro');
+        const value = normalize(labelFor(node));
+        if (kind !== 'model') {
+          const words = value.split(/\s+/).filter(Boolean);
+          const hasEffort = words.some((word) => effortOwnerLabels.has(word));
+          const looksLikeModel = node.getAttribute?.('data-testid') === 'model-switcher-dropdown-button' ||
+            value.includes('current model') || value.includes('gpt') || value.includes('instant');
+          return hasEffort && !looksLikeModel;
+        }
         return value.includes('gpt') || value.includes('thinking') || value.includes('instant');
       });
       if (kind === 'model' && nodes.length === 0) {
         nodes = Array.from(document.querySelectorAll(${JSON.stringify(selector)})).filter((node) => {
-          const value = ((node.getAttribute?.('aria-label') || '') + ' ' + (node.textContent || '')).toLowerCase();
+          const value = normalize(labelFor(node));
           return value.includes('pro');
         });
       }
@@ -208,13 +227,19 @@ async function readPicker(cdp, kind, click = false) {
         );
       }
       const items = nodes.map((node) => {
-        const text = (node.textContent || '').replace(/\\s+/g, ' ').trim();
+        const text = (node.innerText || node.textContent || '').replace(/\\s+/g, ' ').trim();
         const aria = (node.getAttribute?.('aria-label') || '').replace(/\\s+/g, ' ').trim();
+        const labelledBy = String(node.getAttribute?.('aria-labelledby') || '')
+          .split(/\\s+/)
+          .map((id) => document.getElementById(id)?.textContent || '')
+          .join(' ')
+          .replace(/\\s+/g, ' ')
+          .trim();
         const title = (node.getAttribute?.('title') || '').replace(/\\s+/g, ' ').trim();
         return {
           role: node.getAttribute?.('role') || (node.tagName === 'BUTTON' ? 'button' : null),
-          label: [text, aria, title].filter(Boolean).join(' | ').slice(0, 240),
-          displayLabel: (text || aria || title).slice(0, 80),
+          label: [text, aria, labelledBy, title].filter(Boolean).join(' | ').slice(0, 240),
+          displayLabel: (text || aria || labelledBy || title).slice(0, 80),
           testId: node.getAttribute?.('data-testid') || null,
         };
       });

--- a/test/unit/chatgpt-client.test.ts
+++ b/test/unit/chatgpt-client.test.ts
@@ -1,6 +1,8 @@
 import { vi } from "vitest";
 // @ts-expect-error - CommonJS module without type definitions
 import * as chatgptClient from "../../native/chatgpt-client.cjs";
+// @ts-expect-error - CommonJS module without type definitions
+import * as chatgptClientUi from "../../native/chatgpt-client-ui.cjs";
 
 function createReadyChatGptEvaluate(
   loginStatus: Record<string, unknown> = { status: 200, hasLoginCta: false },
@@ -394,6 +396,86 @@ describe("chatgpt-client", () => {
       expect(chatgptClient.verifyChatGPTEffortSelection(items, requested)?.label ?? null).toBe(
         expectedLabel,
       );
+    });
+
+    it("verifies Pro after opening a Thinking composer effort pill", async () => {
+      class FakeEventTarget {
+        dispatchEvent() {
+          return true;
+        }
+      }
+      class FakeButton extends FakeEventTarget {
+        tagName = "BUTTON";
+        textContent: string;
+        innerText: string;
+        attributes: Record<string, string>;
+
+        constructor(textContent: string, attributes: Record<string, string>) {
+          super();
+          this.textContent = textContent;
+          this.innerText = textContent;
+          this.attributes = attributes;
+        }
+
+        getAttribute(name: string) {
+          return this.attributes[name] ?? null;
+        }
+      }
+      class FakeMouseEvent {
+        constructor(
+          readonly type: string,
+          readonly init: unknown,
+        ) {}
+      }
+
+      const modelButton = new FakeButton("Pro", {
+        "aria-haspopup": "menu",
+        "data-testid": "model-switcher-dropdown-button",
+      });
+      const effortButton = new FakeButton("", {
+        "aria-haspopup": "menu",
+        "aria-labelledby": "effort-label",
+      });
+      let effortLabel = "Thinking";
+      const document = {
+        getElementById: (id: string) =>
+          id === "effort-label" ? { textContent: effortLabel } : null,
+        querySelectorAll: () => [modelButton, effortButton],
+      };
+
+      const cdp = async (expression: string) => {
+        if (expression.includes('const kind = "effort"')) {
+          return {
+            result: {
+              value: Function(
+                "document",
+                "EventTarget",
+                "MouseEvent",
+                "PointerEvent",
+                "window",
+                `return ${expression};`,
+              )(document, FakeEventTarget, FakeMouseEvent, undefined, {}),
+            },
+          };
+        }
+        if (expression.includes("const containers = Array.from")) {
+          return {
+            result: {
+              value: {
+                found: true,
+                items: [{ role: "menuitemradio", label: "Pro", testId: null, selected: false }],
+              },
+            },
+          };
+        }
+        if (expression.includes("const expectedLabel")) {
+          effortLabel = "Pro";
+          return { result: { value: true } };
+        }
+        throw new Error(`Unexpected expression: ${expression}`);
+      };
+
+      await expect(chatgptClientUi.selectEffort(cdp, "pro", 100)).resolves.toBe("Pro");
     });
 
     it("resolves effort options and accepts only the documented vocabulary", () => {


### PR DESCRIPTION
Fixes #216.

This follow-up fixes the post-click ChatGPT Pro effort readback path. The picker reader now keeps the model switcher out of effort ownership, reads `aria-labelledby` labels, accepts a `Thinking` composer effort pill as the owner that opens the effort menu, and verifies the final `Pro` readback from the composer pill.

Validation:
- `npm exec -- vitest run test/unit/chatgpt-client.test.ts` (75 passed)
- `npm run check`
- `npm exec -- biome check CHANGELOG.md native/chatgpt-client-ui.cjs test/unit/chatgpt-client.test.ts`
- `git diff --check`

Fresh review found no issues after the follow-up fix.