### PR TITLE
fix: accept already-selected ChatGPT Pro effort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [Unreleased]
-- **ChatGPT Pro effort verification** - Surf now verifies the selected Pro effort from the composer picker label and readback state without letting unrelated metadata reject the accepted value.
+- **ChatGPT Pro effort verification** - Surf now verifies already-selected Pro effort from the composer picker label and readback state without letting unrelated metadata reject the accepted value.
 
 ## [2.16.0] - 2026-08-23
 

--- a/native/chatgpt-client-ui.cjs
+++ b/native/chatgpt-client-ui.cjs
@@ -395,6 +395,10 @@ async function selectEffort(cdp, desiredEffort, timeoutMs = 8000, signal) {
   throwIfAborted(signal);
   const normalizedEffort = normalizeChatGPTEffortChoice(desiredEffort);
   if (!normalizedEffort) throw verificationError("effort", desiredEffort, [], true);
+  const current = await readPicker(cdp, "effort");
+  const currentVerified = verifyChatGPTEffortSelection(current?.items, normalizedEffort);
+  if (currentVerified) return currentVerified.displayLabel || currentVerified.label;
+
   const picker = await readPicker(cdp, "effort", true);
   if (picker?.items?.length !== 1) throw verificationError("effort", desiredEffort);
   await delay(300, signal);

--- a/test/unit/chatgpt-client.test.ts
+++ b/test/unit/chatgpt-client.test.ts
@@ -478,6 +478,23 @@ describe("chatgpt-client", () => {
       await expect(chatgptClientUi.selectEffort(cdp, "pro", 100)).resolves.toBe("Pro");
     });
 
+    it("does not reopen the effort menu when Pro is already selected", async () => {
+      const cdp = async (expression: string) => {
+        if (expression.includes('const kind = "effort"')) {
+          return {
+            result: {
+              value: {
+                items: [{ role: "button", label: "Pro", displayLabel: "Pro", testId: null }],
+              },
+            },
+          };
+        }
+        throw new Error(`Unexpected expression: ${expression}`);
+      };
+
+      await expect(chatgptClientUi.selectEffort(cdp, "pro", 100)).resolves.toBe("Pro");
+    });
+
     it("resolves effort options and accepts only the documented vocabulary", () => {
       expect(chatgptClient.resolveChatGPTEffortMenuOption(effortOptions, "extended")).toEqual(
         effortOptions[2],


### PR DESCRIPTION
Refs #216.

This follow-up handles one confirmed live state: ChatGPT can already show the composer effort pill as `Pro`. Surf now verifies that current readback before opening the effort menu, so it does not disturb an already-correct state or fail closed before prompt submission.

This is a safe guardrail, not proof that all #216 smoke paths are fixed. Keep #216 open until the `gpt-pro` smoke passes against the merged main branch.

Validation:
- `npm exec -- vitest run test/unit/chatgpt-client.test.ts` (76 passed)
- `npm run check`
- `npm exec -- biome check CHANGELOG.md native/chatgpt-client-ui.cjs test/unit/chatgpt-client.test.ts`
- `git diff --check`
- live direct helper against the active ChatGPT tab returned `effort Pro`

Fresh review found no issues.