### PR TITLE
fix: type ChatGPT prompt before Pro effort check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [Unreleased]
-- **ChatGPT Pro effort verification** - Surf now verifies already-selected Pro effort from the composer picker label and readback state without letting unrelated metadata reject the accepted value.
+- **ChatGPT Pro effort verification** - Surf now clears stale composer text, types the prompt before Pro effort verification, and reads the composer picker state without letting unrelated metadata reject the accepted value.
 
 ## [2.16.0] - 2026-08-23
 

--- a/native/chatgpt-client-ui.cjs
+++ b/native/chatgpt-client-ui.cjs
@@ -436,6 +436,13 @@ async function typePrompt(cdp, inputCdp, prompt, signal) {
         const node = document.querySelector(selector);
         if (!node) continue;
         dispatchClickSequence(node);
+        if ('value' in node) {
+          node.value = '';
+          node.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'deleteContentBackward' }));
+        } else {
+          node.textContent = '';
+          node.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'deleteContentBackward' }));
+        }
         if (typeof node.focus === 'function') node.focus();
         const doc = node.ownerDocument;
         const selection = doc?.getSelection?.();

--- a/native/chatgpt-client.cjs
+++ b/native/chatgpt-client.cjs
@@ -152,10 +152,6 @@ async function dispatch(options) {
       modelVerified = await selectModel(cdp, model, 8000, signal);
       log(`Verified model: ${modelVerified}`);
     }
-    if (effort) {
-      effortVerified = await selectEffort(cdp, effort, 8000, signal);
-      log(`Verified effort: ${effortVerified}`);
-    }
     if (file) {
       if (!uploadFile) {
         throw new Error(
@@ -177,6 +173,10 @@ async function dispatch(options) {
     }
     await typePrompt(cdp, inputCdp, prompt, signal);
     log("Prompt typed");
+    if (effort) {
+      effortVerified = await selectEffort(cdp, effort, 8000, signal);
+      log(`Verified effort: ${effortVerified}`);
+    }
     const baseline = normalizeResponseSnapshot(await readChatGPTResponseSnapshot(cdp));
     if (beforeSubmit) await raceAbort(beforeSubmit, signal);
     await clickSend(cdp, inputCdp, signal);

--- a/test/unit/chatgpt-client.test.ts
+++ b/test/unit/chatgpt-client.test.ts
@@ -495,6 +495,60 @@ describe("chatgpt-client", () => {
       await expect(chatgptClientUi.selectEffort(cdp, "pro", 100)).resolves.toBe("Pro");
     });
 
+    it("clears stale composer text before typing the prompt", async () => {
+      class FakeEventTarget {
+        dispatchEvent() {
+          return true;
+        }
+      }
+      class FakeInputEvent {
+        constructor(
+          readonly type: string,
+          readonly init: unknown,
+        ) {}
+      }
+      class FakeMouseEvent extends FakeInputEvent {}
+      let focused = false;
+      const textarea = new (class extends FakeEventTarget {
+        tagName = "TEXTAREA";
+        value = "stale text";
+        innerText = "";
+        textContent = "";
+        ownerDocument = {
+          getSelection: () => null,
+        };
+
+        focus() {
+          focused = true;
+        }
+      })();
+      const document = {
+        querySelector: (selector: string) => (selector === "#prompt-textarea" ? textarea : null),
+      };
+      const cdp = async (expression: string) => ({
+        result: {
+          value: Function(
+            "document",
+            "EventTarget",
+            "MouseEvent",
+            "PointerEvent",
+            "InputEvent",
+            "window",
+            `return ${expression};`,
+          )(document, FakeEventTarget, FakeMouseEvent, undefined, FakeInputEvent, {}),
+        },
+      });
+      const inputCdp = async (_method: string, params: { text: string }) => {
+        textarea.value += params.text;
+        return {};
+      };
+
+      await chatgptClientUi.typePrompt(cdp, inputCdp, "Reply with exactly: READY");
+
+      expect(textarea.value).toBe("Reply with exactly: READY");
+      expect(focused).toBe(true);
+    });
+
     it("resolves effort options and accepts only the documented vocabulary", () => {
       expect(chatgptClient.resolveChatGPTEffortMenuOption(effortOptions, "extended")).toEqual(
         effortOptions[2],


### PR DESCRIPTION
## Summary

This fixes the confirmed ChatGPT Pro smoke failure from #216.

Surf now clears stale composer text before inserting the prompt. It verifies the model first, uploads files if needed, types the real prompt, then verifies the Pro effort before submit. This matches the current ChatGPT UI, where the Pro effort/send composer state is only stable after text exists in the composer.

Refs #216.

## Validation

- `npm exec -- vitest run test/unit/chatgpt-client.test.ts`
- `npm run check`
- `npm exec -- biome check CHANGELOG.md native/chatgpt-client.cjs native/chatgpt-client-ui.cjs test/unit/chatgpt-client.test.ts`
- `git diff --check`
- Fresh read-only review: `/Users/nicobailon/Documents/docs/surf-216-confirmed-gpt-pro-fix-review.md` returned `No issues found`.
- Exact local smoke after native host restart: job `20260823-195538-4eb6` verified `GPT-5.6 Sol`, verified `Pro`, submitted prompt echo `Reply with exactly: READY`, and captured response `READY`.
