### PR TITLE
Add idle session cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **One-shot session cleanup** - Added opt-in `surf session.cleanup --idle-after <duration> [--dry-run]` to remove gone or idle session bindings, closing only inactive Surf-created targets. Reported by @marcoatpaladin in #233.
+
 ## [2.17.0] - 2026-08-28
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -378,9 +378,13 @@ SURF_SESSION=research surf screenshot               # environment selector
 surf session.list --refresh                         # all bindings + queue state
 surf session.info research --refresh                # target and scheduler details
 surf session.close research                         # closes Surf-created target
+surf session.cleanup --idle-after 1h --dry-run      # preview forgotten sessions
+surf session.cleanup --idle-after 1h                 # remove idle bindings
 surf session.rebind research --tab-id 789            # adopt an existing tab
 surf session.reopen research                         # recreate from last URL
 ```
+
+`session.cleanup` is an explicit, one-shot cleanup operation; `--idle-after` is required. It inspects current bindings first, removes gone or stale records, and removes live inactive bindings older than the threshold. Only Surf-created targets are closed. Adopted targets remain open while their session binding is removed. Use `--dry-run` to report the exact bindings and target actions without changing the store or browser.
 
 Commands for the same session tab run FIFO. Commands for different session tabs can overlap. Browser-wide mutations—such as creating, moving, closing, or focusing tabs/windows and writing cookies—wait for active tab lanes to drain. Add `--no-wait` to return `tab_busy` or `browser_busy` immediately instead of queueing.
 

--- a/native/browser-session-store.cjs
+++ b/native/browser-session-store.cjs
@@ -9,6 +9,24 @@ const { surfError } = require("./surf-error.cjs");
 
 const STORE_VERSION = 1;
 const SESSION_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+const SESSION_DURATION_PATTERN = /^(\d+(?:\.\d+)?)(s|m|h|d)?$/i;
+
+function parseDurationMs(value) {
+  if (typeof value === "boolean" || value === undefined || value === null) {
+    throw new Error("--idle-after requires a positive duration such as 30s, 5m, 1h, or 1d");
+  }
+  const match = String(value).trim().match(SESSION_DURATION_PATTERN);
+  if (!match) {
+    throw new Error("--idle-after must be a duration such as 30s, 5m, 1h, or 1d (plain seconds are also accepted)");
+  }
+  const amount = Number(match[1]);
+  const multiplier = { s: 1000, m: 60000, h: 3600000, d: 86400000 }[(match[2] || "s").toLowerCase()];
+  const milliseconds = amount * multiplier;
+  if (!Number.isFinite(milliseconds) || milliseconds <= 0) {
+    throw new Error("--idle-after must be a positive duration");
+  }
+  return Math.max(1, Math.round(milliseconds));
+}
 
 function normalizeName(name) {
   return String(name || "").toLowerCase();
@@ -114,6 +132,7 @@ class BrowserSessionStore {
       browserEpoch: identity.browserEpoch,
       createdAt: timestamp,
       updatedAt: timestamp,
+      lastAccessedAt: values.lastAccessedAt || timestamp,
       lastValidatedAt: values.lastValidatedAt || timestamp,
     };
     bucket.sessions[key] = record;
@@ -137,6 +156,7 @@ class BrowserSessionStore {
       browserEpoch: identity.browserEpoch,
       createdAt: existing?.createdAt || timestamp,
       updatedAt: timestamp,
+      lastAccessedAt: values.lastAccessedAt || timestamp,
       lastValidatedAt: values.lastValidatedAt || timestamp,
     };
     delete record.invalidReason;
@@ -149,7 +169,13 @@ class BrowserSessionStore {
   update(identity, name, patch) {
     const existing = this.get(identity, name);
     if (!existing) throw surfError("session_unknown", `unknown session: ${name}`, { session: name });
-    return this.replace(identity, name, { ...existing, ...patch, updatedAt: this.now() });
+    const timestamp = this.now();
+    return this.replace(identity, name, {
+      ...existing,
+      ...patch,
+      updatedAt: timestamp,
+      lastAccessedAt: patch?.lastAccessedAt || timestamp,
+    });
   }
 
   remove(identity, name) {
@@ -212,7 +238,8 @@ class BrowserSessionStore {
     let changed = false;
     for (const record of Object.values(bucket.sessions || {})) {
       if (record.tabId !== tabId) continue;
-      Object.assign(record, patch, { updatedAt: this.now() });
+      const timestamp = this.now();
+      Object.assign(record, patch, { updatedAt: timestamp, lastAccessedAt: patch?.lastAccessedAt || timestamp });
       changed = true;
     }
     if (changed) this.save(state);
@@ -266,6 +293,7 @@ module.exports = {
   BrowserSessionStore,
   SESSION_NAME_PATTERN,
   STORE_VERSION,
+  parseDurationMs,
   normalizeName,
   validateSessionName,
 };

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -313,6 +313,14 @@ const TOOLS = {
         args: [],
         opts: { refresh: "Validate every binding against Chrome" },
       },
+      "session.cleanup": {
+        desc: "Remove idle session bindings and close only Surf-created targets",
+        args: [],
+        opts: {
+          "idle-after": "Required threshold such as 30s, 5m, 1h, or 1d",
+          "dry-run": "Report matches without removing bindings or closing targets",
+        },
+      },
       "session.info": {
         desc: "Show one session, target, and scheduler queue state",
         args: ["name"],
@@ -1561,7 +1569,7 @@ Exclude text content:
 };
 
 const ALL_SOCKET_TOOLS = [
-  "session.new", "session.ensure", "session.list", "session.info", "session.close", "session.rebind", "session.reopen",
+  "session.new", "session.ensure", "session.list", "session.cleanup", "session.info", "session.close", "session.rebind", "session.reopen",
   "ai", "screenshot", "record", "animate-audit", "perf-audit", "navigate",
   "form_input", "find_and_type", "autocomplete", "set_value", "smart_type",
   "scroll_to_position", "get_scroll_info", "close_dialogs", "page_state",
@@ -1641,6 +1649,7 @@ Usage: surf <command> [args] [options]
 
 Common Commands:
   session.ensure <name> [url]  Idempotently create or reuse a tab-bound session
+  session.cleanup --idle-after <duration>  Remove idle sessions (opt-in; use --dry-run first)
   navigate <url>     Go to URL (alias: go)
   click <ref>        Click element by ref or selector
   type <text>        Type text at cursor or into element
@@ -1707,6 +1716,7 @@ Device/viewport: surf emulate.device "iPhone 14" | surf resize 375 812
 Cookies: surf cookie list | surf cookie get "name" | surf cookie delete "name"
 Session targeting: surf --session research read | SURF_SESSION=research surf read
 Session status/queue: surf session.info research | surf session.list --refresh
+Session cleanup: surf session.cleanup --idle-after 1h [--dry-run]
 Recovery: run the exact command printed after Recovery: on tab_gone, session_epoch_stale, tab_busy, or browser_busy
 Concurrency: commands for different session tabs can overlap; each tab remains FIFO; provider flows are browser-exclusive
 Doctor: surf doctor --browser all              # native host/socket diagnostics
@@ -2686,6 +2696,7 @@ if (tool === "session" && firstArg) {
     new: "session.new",
     ensure: "session.ensure",
     list: "session.list",
+    cleanup: "session.cleanup",
     info: "session.info",
     close: "session.close",
     rebind: "session.rebind",
@@ -3613,6 +3624,21 @@ async function handleResponse(response) {
           queueSummary(entry.queue),
           entry.lastUrl || "",
         ].join("\t"));
+      }
+    }
+  } else if (finalTool === "session.cleanup" && data?.success) {
+    const removed = Array.isArray(data.removed) ? data.removed : [];
+    if (removed.length === 0) {
+      console.log("No browser sessions matched the idle cleanup threshold.");
+    } else {
+      const verb = data.dryRun ? "Would remove" : "Removed";
+      for (const entry of removed) {
+        const target = entry.targetAction === "close"
+          ? "target closed"
+          : entry.targetAction === "keep"
+            ? "target kept"
+            : "target already gone";
+        console.log(`${verb} session ${entry.name} tab=${entry.tabId ?? "-"} (${target})`);
       }
     }
   } else if (finalTool === "session.info" && data?.session) {

--- a/native/host-helpers.cjs
+++ b/native/host-helpers.cjs
@@ -51,7 +51,7 @@ function formatToolContent(result, log = () => {}, options = {}) {
   
   if (!result) return text("OK");
 
-  if (result.session || Array.isArray(result.sessions) || Object.hasOwn(result, "targetClosed")) {
+  if (result.session || Array.isArray(result.sessions) || Array.isArray(result.removed) || Object.hasOwn(result, "targetClosed")) {
     return text(JSON.stringify(result, null, 2));
   }
   

--- a/native/host.cjs
+++ b/native/host.cjs
@@ -49,7 +49,7 @@ const { resolveArgs, runPlaybookOp } = require("./playbook-runtime.cjs");
 const { resolveOp } = require("./playbooks.cjs");
 const { commandMetadata, redactCommandArgs } = require("./workflow-definition.cjs");
 const { BrowserScheduler } = require("./browser-scheduler.cjs");
-const { BrowserSessionStore, validateSessionName } = require("./browser-session-store.cjs");
+const { BrowserSessionStore, parseDurationMs, validateSessionName } = require("./browser-session-store.cjs");
 const { classifyTool } = require("./tool-scope.cjs");
 const { fromExtensionError, surfError } = require("./surf-error.cjs");
 const MAX_CLIENT_FRAME_BYTES = MAX_FRAME_BYTES;
@@ -756,11 +756,13 @@ async function resolveSessionTarget(request, identity, name) {
       recoveryCommand: `surf session.rebind ${record.name} --tab-id ${record.tabId} --replace`,
     });
   }
+  const accessedAt = new Date().toISOString();
   const updated = browserSessionStore.replace(identity, record.name, {
     ...record,
     lastUrl: inspected.url || record.lastUrl,
     lastTitle: inspected.title || record.lastTitle,
-    lastValidatedAt: new Date().toISOString(),
+    lastAccessedAt: accessedAt,
+    lastValidatedAt: accessedAt,
   });
   return {
     source: "session",
@@ -891,6 +893,7 @@ async function sessionRecordStatus(identity, request, record, refresh = false) {
           ...record,
           lastUrl: inspected.url || record.lastUrl,
           lastTitle: inspected.title || record.lastTitle,
+          lastAccessedAt: record.lastAccessedAt || record.updatedAt || record.createdAt,
           lastValidatedAt: new Date().toISOString(),
         });
       }
@@ -907,6 +910,158 @@ async function sessionRecordStatus(identity, request, record, refresh = false) {
     currentUrl: inspected?.url,
     currentTitle: inspected?.title,
     queue: sessionQueueState(identity, record),
+  };
+}
+
+function sessionActivity(record) {
+  const value = record.lastAccessedAt || record.updatedAt || record.createdAt;
+  if (typeof value !== "string" || !value) return null;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? { value, timestamp } : null;
+}
+
+function cleanupEntry(record, { reason, targetAction, idleMs, lastAccessedAt, ...details }) {
+  return {
+    name: record.name,
+    tabId: record.tabId,
+    windowId: record.windowId,
+    ownership: record.ownership || "adopted",
+    reason,
+    targetAction,
+    targetClosed: targetAction === "close",
+    ...(lastAccessedAt ? { lastAccessedAt } : {}),
+    ...(idleMs !== undefined ? { idleMs } : {}),
+    ...details,
+  };
+}
+
+async function cleanupBrowserSessions(identity, request, args) {
+  const rawIdleAfter = args["idle-after"];
+  const idleAfterMs = parseDurationMs(rawIdleAfter);
+  const dryRun = args["dry-run"] === true;
+  const now = Date.now();
+  const records = browserSessionStore.list(identity);
+  const operations = [];
+  const retained = [];
+  let inspected = 0;
+
+  for (const record of records) {
+    const activity = sessionActivity(record);
+    const common = {
+      lastAccessedAt: activity?.value || record.lastAccessedAt || record.updatedAt || record.createdAt,
+    };
+
+    if (record.browserEpoch !== identity.browserEpoch) {
+      operations.push({
+        record,
+        closeTarget: false,
+        entry: cleanupEntry(record, { ...common, reason: "epoch-stale", targetAction: "already-gone" }),
+      });
+      continue;
+    }
+
+    if (record.invalidReason === "tab_gone" || record.invalidReason === "window_gone") {
+      operations.push({
+        record,
+        closeTarget: false,
+        entry: cleanupEntry(record, { ...common, reason: "target-gone", targetAction: "already-gone" }),
+      });
+      continue;
+    }
+
+    if (record.invalidReason) {
+      retained.push(cleanupEntry(record, { ...common, reason: "invalid", targetAction: "kept" }));
+      continue;
+    }
+
+    let inspectedTarget;
+    try {
+      inspectedTarget = await inspectBrowserTab(request, record.tabId);
+      inspected += 1;
+    } catch (error) {
+      if (error?.code === "tab_gone") {
+        operations.push({
+          record,
+          closeTarget: false,
+          entry: cleanupEntry(record, { ...common, reason: "target-gone", targetAction: "already-gone" }),
+        });
+        continue;
+      }
+      throw error;
+    }
+
+    if (record.windowId && inspectedTarget.windowId !== record.windowId) {
+      retained.push(cleanupEntry(record, {
+        ...common,
+        reason: "binding-mismatch",
+        targetAction: "kept",
+        currentWindowId: inspectedTarget.windowId,
+      }));
+      continue;
+    }
+
+    if (inspectedTarget.active !== false) {
+      retained.push(cleanupEntry(record, { ...common, reason: "active", targetAction: "kept" }));
+      continue;
+    }
+
+    if (!activity || now <= activity.timestamp) {
+      retained.push(cleanupEntry(record, { ...common, reason: "activity-unknown", targetAction: "kept" }));
+      continue;
+    }
+
+    const idleMs = now - activity.timestamp;
+    if (idleMs <= idleAfterMs) {
+      retained.push(cleanupEntry(record, { ...common, reason: "not-idle", targetAction: "kept", idleMs }));
+      continue;
+    }
+
+    const closeTarget = record.ownership === "surf-created";
+    operations.push({
+      record,
+      closeTarget,
+      entry: cleanupEntry(record, {
+        ...common,
+        reason: "idle",
+        targetAction: closeTarget ? "close" : "keep",
+        idleMs,
+      }),
+    });
+  }
+
+  if (!dryRun) {
+    for (const operation of operations) {
+      if (operation.closeTarget) {
+        try {
+          const result = await requestExtensionOrThrow(request, "session.cleanup", {
+            type: "SESSION_CLOSE_TARGET",
+            tabId: operation.record.tabId,
+          }, 30000, true);
+          if (result?.alreadyGone === true) {
+            operation.entry.targetAction = "already-gone";
+            operation.entry.targetClosed = false;
+            operation.entry.reason = "target-gone";
+          }
+        } catch (error) {
+          if (error?.code !== "tab_gone") throw error;
+          operation.entry.targetAction = "already-gone";
+          operation.entry.targetClosed = false;
+          operation.entry.reason = "target-gone";
+        }
+      }
+      browserSessionStore.remove(identity, operation.record.name);
+    }
+  }
+
+  return {
+    success: true,
+    dryRun,
+    idleAfter: String(rawIdleAfter).trim(),
+    idleAfterMs,
+    scanned: records.length,
+    inspected,
+    removed: operations.map(({ entry }) => entry),
+    retained,
   };
 }
 
@@ -931,6 +1086,7 @@ async function createSessionBinding(request, identity, name, args, previous = nu
       browserEpoch: identity.browserEpoch,
       mode,
       ownership: "surf-created",
+      lastAccessedAt: new Date().toISOString(),
       lastUrl: created.url || url,
       lastTitle: created.title,
       groupId: created.groupId,
@@ -953,7 +1109,7 @@ async function createSessionBinding(request, identity, name, args, previous = nu
 async function handleBrowserSessionCommand(tool, args, request) {
   const identity = await requireBrowserIdentity();
   const name = args.name;
-  if (tool !== "session.list") validateSessionName(name);
+  if (tool !== "session.list" && tool !== "session.cleanup") validateSessionName(name);
 
   if (tool === "session.new") {
     if (browserSessionStore.get(identity, name)) {
@@ -990,6 +1146,10 @@ async function handleBrowserSessionCommand(tool, args, request) {
     const sessions = [];
     for (const record of records) sessions.push(await sessionRecordStatus(identity, request, record, args.refresh === true));
     return { sessions, browser: identity, scheduler: browserScheduler.stats() };
+  }
+
+  if (tool === "session.cleanup") {
+    return cleanupBrowserSessions(identity, request, args);
   }
 
   const existing = browserSessionStore.get(identity, name);
@@ -1047,6 +1207,7 @@ async function handleBrowserSessionCommand(tool, args, request) {
       browserEpoch: identity.browserEpoch,
       mode: "tab",
       ownership: "adopted",
+      lastAccessedAt: new Date().toISOString(),
       lastUrl: inspected.url,
       lastTitle: inspected.title,
       frameContext: null,

--- a/native/tool-scope.cjs
+++ b/native/tool-scope.cjs
@@ -21,7 +21,7 @@ const BROWSER_READ_TOOLS = new Set([
 ]);
 
 const BROWSER_WRITE_TOOLS = new Set([
-  "session.new", "session.ensure", "session.close", "session.rebind", "session.reopen",
+  "session.new", "session.ensure", "session.cleanup", "session.close", "session.rebind", "session.reopen",
   "tab.new", "new_tab", "tabs_create",
   "tab.move", "tab.switch", "switch_tab",
   "tab.group", "tab.ungroup",

--- a/native/workflow-definition.cjs
+++ b/native/workflow-definition.cjs
@@ -40,6 +40,7 @@ const COMMANDS = {
   "session.ensure": { primaryArg: "name", effect: "navigation", recordable: false, argKinds: { name: "name", url: "url" } },
   "session.list": { effect: "read", recordable: false },
   "session.info": { primaryArg: "name", effect: "read", recordable: false, argKinds: { name: "name" } },
+  "session.cleanup": { effect: "page-write", recordable: false, argKinds: { "idle-after": "duration" } },
   "session.close": { primaryArg: "name", effect: "page-write", recordable: false, argKinds: { name: "name" } },
   "session.rebind": { primaryArg: "name", effect: "page-write", recordable: false, argKinds: { name: "name", tabId: "tab-id" } },
   "session.reopen": { primaryArg: "name", effect: "navigation", recordable: false, argKinds: { name: "name", url: "url" } },

--- a/test/e2e/cli-host-fake-extension.test.ts
+++ b/test/e2e/cli-host-fake-extension.test.ts
@@ -57,6 +57,10 @@ type NativeMessage = Record<string, unknown> & {
   fullpage?: boolean;
 };
 
+type FakeHostOptions = {
+  targetActive?: boolean;
+};
+
 type CliResult = {
   code: number | null;
   stdout: string;
@@ -76,8 +80,9 @@ const { spawn } = require("node:child_process") as {
 const fs = require("node:fs") as {
   mkdirSync(targetPath: string, options: { recursive: boolean }): void;
   mkdtempSync(prefix: string): string;
+  readFileSync(targetPath: string, encoding: "utf8"): string;
   rmSync(targetPath: string, options: { recursive: boolean; force: boolean }): void;
-  writeFileSync(targetPath: string, content: string): void;
+  writeFileSync(targetPath: string, content: string, options?: { mode?: number }): void;
 };
 const os = require("node:os") as { tmpdir(): string };
 const path = require("node:path") as { join(...paths: string[]): string };
@@ -113,7 +118,7 @@ function writeNativeMessage(stdin: WritableLike, message: NativeMessage) {
   stdin.write(BufferCtor.concat([header, BufferCtor.from(json, "utf8")]));
 }
 
-function buildExtensionResponse(message: NativeMessage, currentUrl: string) {
+function buildExtensionResponse(message: NativeMessage, currentUrl: string, targetActive: boolean) {
   switch (message.type) {
     case "TARGET_RESOLVE":
     case "TARGET_INSPECT":
@@ -123,9 +128,11 @@ function buildExtensionResponse(message: NativeMessage, currentUrl: string) {
         windowId: 7,
         title: "Contract Fixture",
         url: currentUrl,
-        active: true,
+        active: targetActive,
         restricted: false,
       };
+    case "SESSION_CLOSE_TARGET":
+      return { id: message.id, success: true, tabId: message.tabId };
     case "LIST_TABS":
       return {
         id: message.id,
@@ -175,7 +182,7 @@ function buildExtensionResponse(message: NativeMessage, currentUrl: string) {
   }
 }
 
-function startHost(socketPath: string) {
+function startHost(socketPath: string, options: FakeHostOptions = {}) {
   const hostPath = path.join(process.cwd(), "native", "host.cjs");
   const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "surf-e2e-state-"));
   tempDirs.push(stateDir);
@@ -188,6 +195,7 @@ function startHost(socketPath: string) {
   const waiters: MessageWaiter[] = [];
   let stdoutBuffer = BufferCtor.alloc(0);
   let currentUrl = "about:blank";
+  const targetActive = options.targetActive !== false;
   let stderr = "";
   let closed = false;
 
@@ -243,7 +251,7 @@ function startHost(socketPath: string) {
       if (message.type === "EXECUTE_NAVIGATE" && message.url) {
         currentUrl = message.url;
       }
-      writeNativeMessage(child.stdin, buildExtensionResponse(message, currentUrl));
+      writeNativeMessage(child.stdin, buildExtensionResponse(message, currentUrl, targetActive));
     }
   });
 
@@ -261,6 +269,7 @@ function startHost(socketPath: string) {
 
   return {
     child,
+    stateDir,
     messages,
     waitForMessage(
       predicate: (message: NativeMessage) => boolean,
@@ -350,6 +359,48 @@ afterEach(() => {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
 });
+
+function seedOldSession(stateDir: string, ownership = "surf-created") {
+  const browserEpoch = `contract-epoch-${process.pid}`;
+  fs.writeFileSync(
+    path.join(stateDir, "browser-sessions.json"),
+    JSON.stringify({
+      version: 1,
+      browsers: {
+        "contract-browser": {
+          sessions: {
+            old: {
+              bindingId: "old-binding",
+              name: "old",
+              browserInstanceId: "contract-browser",
+              browserEpoch,
+              tabId: 42,
+              windowId: 7,
+              mode: "window",
+              ownership,
+              lastUrl: "https://fixture.test/old",
+              createdAt: "2000-01-01T00:00:00.000Z",
+              updatedAt: "2000-01-01T00:00:00.000Z",
+              lastAccessedAt: "2000-01-01T00:00:00.000Z",
+              lastValidatedAt: "2000-01-01T00:00:00.000Z",
+            },
+          },
+          namedTabs: {},
+        },
+      },
+    }),
+    { mode: 0o600 },
+  );
+}
+
+function sessionAccessTime(stateDir: string) {
+  const state = JSON.parse(
+    fs.readFileSync(path.join(stateDir, "browser-sessions.json"), "utf8"),
+  ) as {
+    browsers: { "contract-browser": { sessions: { old: { lastAccessedAt?: string } } } };
+  };
+  return state.browsers["contract-browser"].sessions.old.lastAccessedAt;
+}
 
 describe("CLI/native-host/fake-extension E2E contract", () => {
   it("runs browser-like navigation, page text, and screenshot flows without Chrome", async () => {
@@ -469,6 +520,111 @@ describe("CLI/native-host/fake-extension E2E contract", () => {
       expect(host.messages.filter((message) => message.type === "EXECUTE_JAVASCRIPT")).toHaveLength(
         2,
       );
+    } finally {
+      await host.dispose();
+    }
+  });
+
+  it("removes an old live Surf-created session and its target", async () => {
+    const socketPath = createSocketPath();
+    const host = startHost(socketPath, { targetActive: false });
+
+    try {
+      await host.waitForMessage((message) => message.type === "HOST_READY");
+      seedOldSession(host.stateDir);
+
+      const cleanup = await runCli(socketPath, ["session.cleanup", "--idle-after", "1s", "--json"]);
+      expect(cleanup).toMatchObject({ code: 0, stderr: "" });
+      expect(JSON.parse(cleanup.stdout)).toMatchObject({
+        dryRun: false,
+        removed: [{ name: "old", targetAction: "close", targetClosed: true }],
+      });
+      expect(host.messages).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: "SESSION_CLOSE_TARGET", tabId: 42 }),
+        ]),
+      );
+
+      const listed = await runCli(socketPath, ["session.list", "--json"]);
+      expect(JSON.parse(listed.stdout).sessions).toEqual([]);
+    } finally {
+      await host.dispose();
+    }
+  });
+
+  it("keeps an old session and target during cleanup dry-run", async () => {
+    const socketPath = createSocketPath();
+    const host = startHost(socketPath, { targetActive: false });
+
+    try {
+      await host.waitForMessage((message) => message.type === "HOST_READY");
+      seedOldSession(host.stateDir);
+
+      const cleanup = await runCli(socketPath, [
+        "session.cleanup",
+        "--idle-after",
+        "1s",
+        "--dry-run",
+        "--json",
+      ]);
+      expect(cleanup).toMatchObject({ code: 0, stderr: "" });
+      expect(JSON.parse(cleanup.stdout)).toMatchObject({
+        dryRun: true,
+        removed: [{ name: "old", targetAction: "close", targetClosed: true }],
+      });
+      expect(host.messages.some((message) => message.type === "SESSION_CLOSE_TARGET")).toBe(false);
+
+      const listed = await runCli(socketPath, ["session.list", "--json"]);
+      expect(JSON.parse(listed.stdout).sessions).toHaveLength(1);
+    } finally {
+      await host.dispose();
+    }
+  });
+
+  it("removes an idle adopted binding without closing its target", async () => {
+    const socketPath = createSocketPath();
+    const host = startHost(socketPath, { targetActive: false });
+
+    try {
+      await host.waitForMessage((message) => message.type === "HOST_READY");
+      seedOldSession(host.stateDir, "adopted");
+
+      const cleanup = await runCli(socketPath, ["session.cleanup", "--idle-after", "1s", "--json"]);
+      expect(cleanup).toMatchObject({ code: 0, stderr: "" });
+      expect(JSON.parse(cleanup.stdout)).toMatchObject({
+        removed: [{ name: "old", ownership: "adopted", targetAction: "keep", targetClosed: false }],
+      });
+      expect(host.messages.some((message) => message.type === "SESSION_CLOSE_TARGET")).toBe(false);
+
+      const listed = await runCli(socketPath, ["session.list", "--json"]);
+      expect(JSON.parse(listed.stdout).sessions).toEqual([]);
+    } finally {
+      await host.dispose();
+    }
+  });
+
+  it("does not refresh idle activity during list/info validation", async () => {
+    const socketPath = createSocketPath();
+    const host = startHost(socketPath, { targetActive: false });
+
+    try {
+      await host.waitForMessage((message) => message.type === "HOST_READY");
+      seedOldSession(host.stateDir);
+      const originalAccessTime = sessionAccessTime(host.stateDir);
+
+      const listed = await runCli(socketPath, ["session.list", "--refresh", "--json"]);
+      expect(listed.code).toBe(0);
+      expect(sessionAccessTime(host.stateDir)).toBe(originalAccessTime);
+
+      const info = await runCli(socketPath, ["session.info", "old", "--refresh", "--json"]);
+      expect(info.code).toBe(0);
+      expect(sessionAccessTime(host.stateDir)).toBe(originalAccessTime);
+
+      const cleanup = await runCli(socketPath, ["session.cleanup", "--idle-after", "1s", "--json"]);
+      expect(cleanup.code).toBe(0);
+      expect(JSON.parse(cleanup.stdout).removed).toMatchObject([
+        { name: "old", reason: "idle", targetAction: "close" },
+      ]);
     } finally {
       await host.dispose();
     }

--- a/test/unit/browser-session-store.test.ts
+++ b/test/unit/browser-session-store.test.ts
@@ -4,13 +4,14 @@ const { mkdtempSync, rmSync, writeFileSync } = require("node:fs");
 const { tmpdir } = require("node:os");
 const { join } = require("node:path");
 
-const { BrowserSessionStore, validateSessionName } =
+const { BrowserSessionStore, parseDurationMs, validateSessionName } =
   require("../../native/browser-session-store.cjs") as {
     BrowserSessionStore: new (options: {
       filePath: string;
       root: string;
       now?: () => string;
     }) => any;
+    parseDurationMs(value: string | number): number;
     validateSessionName(name: string): string;
   };
 
@@ -38,6 +39,17 @@ function store() {
 const identity = { browserInstanceId: "browser-a", browserEpoch: "epoch-a" };
 
 describe("BrowserSessionStore", () => {
+  it("parses explicit cleanup durations and plain seconds", () => {
+    expect(parseDurationMs("30s")).toBe(30_000);
+    expect(parseDurationMs("5m")).toBe(300_000);
+    expect(parseDurationMs("1h")).toBe(3_600_000);
+    expect(parseDurationMs("2d")).toBe(172_800_000);
+    expect(parseDurationMs(45)).toBe(45_000);
+    expect(() => parseDurationMs("1w")).toThrow(/duration/i);
+    expect(() => parseDurationMs(0)).toThrow(/positive/i);
+    expect(() => parseDurationMs(undefined as never)).toThrow(/requires/i);
+  });
+
   it("persists case-insensitive named bindings without changing their display name", () => {
     const { store: sessions } = store();
     const created = sessions.create(identity, "Research", {
@@ -49,6 +61,7 @@ describe("BrowserSessionStore", () => {
     });
 
     expect(created.name).toBe("Research");
+    expect(created.lastAccessedAt).toBe("2026-08-18T00:00:00.000Z");
     expect(sessions.get(identity, "research")).toMatchObject({ tabId: 11, windowId: 22 });
     expect(() => sessions.create(identity, "RESEARCH", { tabId: 99 })).toThrow(/already exists/i);
   });

--- a/test/unit/cli-args.test.ts
+++ b/test/unit/cli-args.test.ts
@@ -894,6 +894,20 @@ describe("CLI argument parsing", () => {
     });
   });
 
+  it("parses opt-in session.cleanup durations in dotted and spaced forms", async () => {
+    const dotted = await runCli(["session.cleanup", "--idle-after", "5m", "--dry-run"]);
+    expect(dotted.request.params).toEqual({
+      tool: "session.cleanup",
+      args: { "idle-after": "5m", "dry-run": true },
+    });
+
+    const spaced = await runCli(["session", "cleanup", "--idle-after", "120"]);
+    expect(spaced.request.params).toEqual({
+      tool: "session.cleanup",
+      args: { "idle-after": 120 },
+    });
+  });
+
   it("sends explicit session selection and no-wait admission outside tool args", async () => {
     const { request } = await runCli(["--session", "research", "page.read", "--no-wait"]);
 

--- a/test/unit/tool-scope.test.ts
+++ b/test/unit/tool-scope.test.ts
@@ -10,6 +10,10 @@ describe("tool scope classification", () => {
       scope: "browser-write",
       targetUse: "browser",
     });
+    expect(classifyTool("session.cleanup")).toMatchObject({
+      scope: "browser-write",
+      targetUse: "browser",
+    });
     expect(classifyTool("session.info")).toMatchObject({ scope: "host", targetUse: "host" });
     expect(classifyTool("session.info", { refresh: true })).toMatchObject({
       scope: "browser-read",


### PR DESCRIPTION
## Summary

- Add explicit `surf session.cleanup --idle-after <duration> [--dry-run]` for one-shot idle session cleanup.
- Remove stale/gone bindings, close only idle Surf-created targets, and keep adopted browser targets open.
- Track `lastAccessedAt` separately from refresh validation so `session.list --refresh` and `session.info --refresh` do not make forgotten sessions look active.

Reported by @marcoatpaladin in #233.

Fixes #233.

## Validation

- `npm ci --ignore-scripts`
- `npm run check`
- `npm test` — 57 files, 758 tests passed
- `npm run build`
- `npm run lint`
- `npm audit --audit-level=critical`
- `git diff --check`
- Fresh reviewer gate: No issues found (`/Users/nicobailon/Documents/docs/pr-issue233-gate-review.md`)
