### PR TITLE
Add opt-in socket group access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - **One-shot session cleanup** - Added opt-in `surf session.cleanup --idle-after <duration> [--dry-run]` to remove gone or idle session bindings, closing only inactive Surf-created targets. Reported by @marcoatpaladin in #233.
+- **Opt-in local socket groups** - `surf install` can persist POSIX socket mode `660` and a configured group while keeping the default at `0600`. Thanks to [@marcoatpaladin](https://github.com/marcoatpaladin) for #225.
 
 ## [2.17.0] - 2026-08-28
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ surf remote list
 
 `surf install --listen` persists the explicit Tailnet address in the native-host wrapper. Re-run `surf install` without `--listen` to remove it. The address must be a Tailscale IPv4 or IPv6 address with a port; Surf does not bind every interface. Remote listeners currently require a POSIX browser host and are not supported by Windows native-host wrappers.
 
+For advanced local-only sharing, `surf install <extension-id> --socket-mode 660 --socket-group <group>` persists an opt-in group-owned socket. The default remains mode `600`; mode `660` gives every account in that group full Surf authority, so use a dedicated narrow group. Re-run `surf install` without these flags to clear persisted socket settings. Remote Surf credentials remain the revocable per-client alternative.
+
 Keep Tailscale policy restrictions as defense in depth. For example:
 
 ```json
@@ -811,6 +813,8 @@ SURF_REMOTE               # Remote Surf endpoint as host:port (overrides SURF_SO
 SURF_REMOTE_CREDENTIAL    # Client Ed25519 credential for the selected remote endpoint
 SURF_REMOTE_STATE_DIR     # Host identity/authorization directory (default: ~/.surf/remote)
 SURF_LISTEN               # Native-host Tailnet bind address as <tailscale-ip>:<port>
+SURF_SOCKET_MODE          # Advanced POSIX local socket mode: 600 (default) or 660
+SURF_SOCKET_GROUP         # Group name or numeric gid required with mode 660
 SURF_NODE_PATH            # Path to node binary (for native host wrapper)
 SURF_HOST_PATH            # Path to native/host.cjs (for native host wrapper)
 SURF_EXTENSION_PATH       # Path to extension dist/ directory
@@ -824,6 +828,7 @@ SURF_EXTENSION_PATH       # Path to extension dist/ directory
 - `SURF_REMOTE_CREDENTIAL`: Credential used for mutual remote authentication. `--remote-credential <path>` overrides it.
 - `SURF_REMOTE_STATE_DIR`: Advanced host-side override for the mode-0700 identity and client registry directory.
 - `SURF_LISTEN`: Native-host listener address on the browser machine. Use `surf install ... --listen <tailscale-ip>:<port>` to persist it in that host's wrapper.
+- `SURF_SOCKET_MODE` / `SURF_SOCKET_GROUP`: Advanced POSIX native-host settings. Use `surf install ... --socket-mode 660 --socket-group <group>` to persist group access; mode `660` grants full Surf authority to every member of that group.
 - `SURF_NODE_PATH` / `SURF_HOST_PATH`: Package manager installs (e.g., Nix) that store binaries in non-standard locations
 - `SURF_EXTENSION_PATH`: Package managers that create stable symlinks instead of changing paths on reinstall
 

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -2024,12 +2024,17 @@ Options:
                   On WSL2, auto installs for Windows Chrome. Use linux for WSLg/Linux browsers.
   --listen <tailscale-ip>:<port>
                   Requires surf remote authorize <label> --output <path> first.
+  --socket-mode <600|660>
+                  Persist the local POSIX socket mode (default: 600); 660 requires --socket-group.
+  --socket-group <group-or-gid>
+                  Persist the local POSIX socket group for mode 660.
 
 Examples:
   surf install hnfbepgmaoklhekckbpjnleifhahkcpl
   surf install hnfbepgmaoklhekckbpjnleifhahkcpl --browser brave
   surf install hnfbepgmaoklhekckbpjnleifhahkcpl --browser all
   surf install hnfbepgmaoklhekckbpjnleifhahkcpl --target linux
+  surf install hnfbepgmaoklhekckbpjnleifhahkcpl --socket-mode 660 --socket-group surf
 `);
     process.exit(0);
   }

--- a/native/host.cjs
+++ b/native/host.cjs
@@ -50,6 +50,7 @@ const { resolveOp } = require("./playbooks.cjs");
 const { commandMetadata, redactCommandArgs } = require("./workflow-definition.cjs");
 const { BrowserScheduler } = require("./browser-scheduler.cjs");
 const { BrowserSessionStore, parseDurationMs, validateSessionName } = require("./browser-session-store.cjs");
+const { applySocketPermissions, resolveSocketPermissions } = require("./socket-permissions.cjs");
 const { classifyTool } = require("./tool-scope.cjs");
 const { fromExtensionError, surfError } = require("./surf-error.cjs");
 const MAX_CLIENT_FRAME_BYTES = MAX_FRAME_BYTES;
@@ -61,7 +62,15 @@ if (IS_WIN) { try { fs.mkdirSync(SURF_TMP, { recursive: true }); } catch {} }
 // The endpoint passed here is already validated by the caller. Keeping this
 // lifecycle separate lets tests use an ephemeral loopback port without adding
 // a localhost escape hatch to SURF_LISTEN parsing.
-function createListenerLifecycle({ localPath, tcpEndpoint, handler, onReady, onFatal }) {
+function createListenerLifecycle({
+  localPath,
+  tcpEndpoint,
+  handler,
+  onReady,
+  onFatal,
+  socketMode = process.env.SURF_SOCKET_MODE,
+  socketGroup = process.env.SURF_SOCKET_GROUP,
+}) {
   const localServer = net.createServer(handler);
   const tcpServer = tcpEndpoint ? net.createServer(handler) : null;
   let shuttingDown = false;
@@ -85,9 +94,10 @@ function createListenerLifecycle({ localPath, tcpEndpoint, handler, onReady, onF
     if (startPromise) return startPromise;
     startPromise = (async () => {
       try {
+        const socketPermissions = IS_WIN ? null : resolveSocketPermissions(socketMode, socketGroup);
         await listen(localServer, localPath);
         if (shuttingDown) return false;
-        if (!IS_WIN) { try { fs.chmodSync(localPath, 0o600); } catch {} }
+        if (!IS_WIN) applySocketPermissions(localPath, socketPermissions);
         if (tcpServer) {
           await listen(tcpServer, tcpEndpoint);
           if (shuttingDown) return false;

--- a/native/socket-permissions.cjs
+++ b/native/socket-permissions.cjs
@@ -1,0 +1,114 @@
+const fs = require("fs");
+const { execFileSync } = require("child_process");
+
+const DEFAULT_SOCKET_MODE = 0o600;
+const ALLOWED_SOCKET_MODES = new Set([0o600, 0o660]);
+const MAX_GID = 0xfffffffe;
+const SOCKET_GROUP_PATTERN = /^(?:\d+|[A-Za-z_][A-Za-z0-9_.-]*)$/;
+
+function parseSocketMode(value) {
+  if (value === undefined) return DEFAULT_SOCKET_MODE;
+  if (typeof value === "number" && ALLOWED_SOCKET_MODES.has(value)) return value;
+  if (value === 600) return DEFAULT_SOCKET_MODE;
+  if (value === 660) return 0o660;
+  const text = String(value).trim();
+  if (!/^0?(?:600|660)$/.test(text)) {
+    throw new Error("SURF_SOCKET_MODE must be 600 or 660");
+  }
+  return Number.parseInt(text, 8);
+}
+
+function validateSocketGroup(value) {
+  if (value === undefined) return undefined;
+  if (value === null || typeof value === "boolean") {
+    throw new Error("SURF_SOCKET_GROUP must be a numeric gid or a simple group name");
+  }
+  const group = String(value).trim();
+  if (!SOCKET_GROUP_PATTERN.test(group)) {
+    throw new Error("SURF_SOCKET_GROUP must be a numeric gid or a simple group name");
+  }
+  if (/^\d+$/.test(group)) {
+    const gid = Number(group);
+    if (!Number.isSafeInteger(gid) || gid < 0 || gid > MAX_GID) {
+      throw new Error("SURF_SOCKET_GROUP gid is out of range");
+    }
+  }
+  return group;
+}
+
+function normalizeSocketConfig(socketMode, socketGroup) {
+  const mode = socketMode === undefined ? undefined : parseSocketMode(socketMode);
+  const group = socketGroup === undefined ? undefined : validateSocketGroup(socketGroup);
+  if (mode === 0o660 && !group) {
+    throw new Error("SURF_SOCKET_MODE=660 requires SURF_SOCKET_GROUP");
+  }
+  return { mode, group };
+}
+
+function resolveSocketGroup(value) {
+  const group = validateSocketGroup(value);
+  if (group === undefined) return undefined;
+  if (/^\d+$/.test(group)) return Number(group);
+
+  const command = process.platform === "darwin" ? "dscl" : "getent";
+  const args = process.platform === "darwin"
+    ? [".", "-read", `/Groups/${group}`, "PrimaryGroupID"]
+    : ["group", group];
+  let output;
+  try {
+    output = execFileSync(command, args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+  } catch (error) {
+    throw new Error(`could not resolve socket group ${group}: ${error.message}`);
+  }
+  const match = process.platform === "darwin"
+    ? output.match(/\bPrimaryGroupID:\s*(\d+)\b/)
+    : output.trim().split(/\r?\n/, 1)[0]?.split(":")[2]?.match(/^\d+$/);
+  const gid = Number(match?.[1] || match?.[0]);
+  if (!Number.isSafeInteger(gid) || gid < 0 || gid > MAX_GID) {
+    throw new Error(`could not resolve socket group ${group}`);
+  }
+  return gid;
+}
+
+function resolveSocketPermissions(socketMode, socketGroup) {
+  const config = normalizeSocketConfig(socketMode, socketGroup);
+  const mode = config.mode ?? DEFAULT_SOCKET_MODE;
+  const gid = resolveSocketGroup(config.group);
+  return { mode, group: config.group, gid };
+}
+
+function assertSocketPath(socketPath) {
+  let stat;
+  try {
+    stat = fs.lstatSync(socketPath);
+  } catch (error) {
+    throw new Error(`could not inspect local socket: ${error.message}`);
+  }
+  if (stat.isSymbolicLink()) throw new Error("refusing symbolic-link local socket");
+  if (!stat.isSocket()) throw new Error("local socket path is not a Unix socket");
+  return stat;
+}
+
+function applySocketPermissions(socketPath, permissions) {
+  const before = assertSocketPath(socketPath);
+  if (permissions.gid !== undefined) {
+    fs.chownSync(socketPath, before.uid, permissions.gid);
+  }
+  fs.chmodSync(socketPath, permissions.mode);
+  const after = assertSocketPath(socketPath);
+  if ((after.mode & 0o7777) !== permissions.mode) {
+    throw new Error(`local socket mode is not ${permissions.mode.toString(8)}`);
+  }
+  if (permissions.gid !== undefined && after.gid !== permissions.gid) {
+    throw new Error(`local socket group is not ${permissions.group}`);
+  }
+  return after;
+}
+
+module.exports = {
+  applySocketPermissions,
+  normalizeSocketConfig,
+  parseSocketMode,
+  resolveSocketPermissions,
+  validateSocketGroup,
+};

--- a/scripts/install-native-host.cjs
+++ b/scripts/install-native-host.cjs
@@ -4,6 +4,7 @@ const path = require("path");
 const os = require("os");
 const { execFileSync, execSync } = require("child_process");
 const { parseListenEndpoint } = require("../native/listener.cjs");
+const { normalizeSocketConfig } = require("../native/socket-permissions.cjs");
 const { getStateDir, loadHostIdentity, loadRegistry } = require("../native/remote-auth.cjs");
 
 const HOST_NAME = "surf.browser.host";
@@ -166,7 +167,9 @@ function wslPathToWindowsPath(wslPath) {
   }
 }
 
-function createWrapper(wrapperDir, nodePath, hostPath, target = process.platform, listen) {
+function createWrapper(wrapperDir, nodePath, hostPath, target = process.platform, listen, socketMode, socketGroup) {
+  const socketConfig = normalizeSocketConfig(socketMode, socketGroup);
+  assertSocketAccessTargetSupported(socketConfig.mode, socketConfig.group, target);
   fs.mkdirSync(wrapperDir, { recursive: true });
 
   if (target === "wsl-windows") {
@@ -186,9 +189,13 @@ function createWrapper(wrapperDir, nodePath, hostPath, target = process.platform
 
   const shPath = path.join(wrapperDir, "host-wrapper.sh");
   const hostDir = path.dirname(hostPath);
+  const socketEnvironment = [
+    socketConfig.mode === undefined ? "" : `: "\${SURF_SOCKET_MODE:=${socketConfig.mode.toString(8)}}"\nexport SURF_SOCKET_MODE\n`,
+    socketConfig.group === undefined ? "" : `: "\${SURF_SOCKET_GROUP:=${socketConfig.group}}"\nexport SURF_SOCKET_GROUP\n`,
+  ].join("");
   const content = `#!/usr/bin/env bash
 cd "${hostDir}"
-${listen ? `: "\${SURF_LISTEN:=${listen}}"\nexport SURF_LISTEN\n` : ""}exec "${nodePath}" "${hostPath}" "$@"
+${listen ? `: "\${SURF_LISTEN:=${listen}}"\nexport SURF_LISTEN\n` : ""}${socketEnvironment}exec "${nodePath}" "${hostPath}" "$@"
 `;
   fs.writeFileSync(shPath, content);
   fs.chmodSync(shPath, "755");
@@ -198,6 +205,12 @@ ${listen ? `: "\${SURF_LISTEN:=${listen}}"\nexport SURF_LISTEN\n` : ""}exec "${n
 function assertListenTargetSupported(listen, target) {
   if (listen && (target === "win32" || target === "wsl-windows")) {
     throw new Error("--listen is not supported for Windows native-host wrappers");
+  }
+}
+
+function assertSocketAccessTargetSupported(socketMode, socketGroup, target) {
+  if ((socketMode !== undefined || socketGroup !== undefined) && (target === "win32" || target === "wsl-windows")) {
+    throw new Error("--socket-mode and --socket-group are only supported for POSIX native-host wrappers");
   }
 }
 
@@ -276,7 +289,14 @@ function installWindowsRegistry(browser, extensionId, wrapperPath) {
 
 function parseArgs() {
   const args = process.argv.slice(2);
-  const result = { extensionId: null, browsers: ["chrome"], target: "auto", listen: undefined };
+  const result = {
+    extensionId: null,
+    browsers: ["chrome"],
+    target: "auto",
+    listen: undefined,
+    socketMode: undefined,
+    socketGroup: undefined,
+  };
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -292,6 +312,12 @@ function parseArgs() {
     } else if (arg === "--listen") {
       result.listen = args[++i];
       if (!result.listen || result.listen.startsWith("--")) throw new Error("--listen requires a Tailnet IP and port");
+    } else if (arg === "--socket-mode") {
+      result.socketMode = args[++i];
+      if (!result.socketMode || result.socketMode.startsWith("--")) throw new Error("--socket-mode requires 600 or 660");
+    } else if (arg === "--socket-group") {
+      result.socketGroup = args[++i];
+      if (!result.socketGroup || result.socketGroup.startsWith("--")) throw new Error("--socket-group requires a group name or gid");
     } else if (arg === "--help" || arg === "-h") {
       printHelp();
       process.exit(0);
@@ -322,6 +348,12 @@ Options:
                   Persist an authenticated Tailnet-only listener endpoint.
                   Requires at least one surf remote authorize client first.
                   Supports Tailscale IPv4 or IPv6 addresses; POSIX wrappers only.
+  --socket-mode <600|660>
+                  Persist the local Unix socket mode (default: 600).
+                  Mode 660 requires --socket-group; POSIX wrappers only.
+  --socket-group <group-or-gid>
+                  Persist the local Unix socket group for mode 660.
+                  Use a dedicated group; this grants full Surf authority.
 
 Examples:
   node install-native-host.cjs abcdefghijklmnopabcdefghijklmnop
@@ -329,13 +361,14 @@ Examples:
   node install-native-host.cjs abcdefghijklmnop --browser all
   node install-native-host.cjs abcdefghijklmnop --target linux
   node install-native-host.cjs abcdefghijklmnop --listen 100.64.1.2:4321
+  node install-native-host.cjs abcdefghijklmnop --socket-mode 660 --socket-group surf
 `);
 }
 
 function main() {
   let parsed;
   try { parsed = parseArgs(); } catch (error) { console.error(`Error: ${error.message}`); process.exit(1); }
-  const { extensionId, browsers, target, listen } = parsed;
+  const { extensionId, browsers, target, listen, socketMode, socketGroup } = parsed;
 
   if (!extensionId) {
     console.error("Error: Extension ID required");
@@ -378,7 +411,12 @@ function main() {
   }
 
   const effectiveTarget = runningInWsl && target !== "linux" ? "wsl-windows" : process.platform;
-  try { assertListenTargetSupported(listen, effectiveTarget); } catch (error) { console.error(`Error: ${error.message}`); process.exit(1); }
+  let socketConfig;
+  try {
+    socketConfig = normalizeSocketConfig(socketMode, socketGroup);
+    assertListenTargetSupported(listen, effectiveTarget);
+    assertSocketAccessTargetSupported(socketMode, socketGroup, effectiveTarget);
+  } catch (error) { console.error(`Error: ${error.message}`); process.exit(1); }
 
   const nodePath = findNode();
   if (!nodePath) {
@@ -407,7 +445,15 @@ function main() {
   console.log(`Wrapper dir: ${wrapperDir}`);
   console.log("");
 
-  const wrapperPath = createWrapper(wrapperDir, nodePath, hostPath, effectiveTarget, listener);
+  const wrapperPath = createWrapper(
+    wrapperDir,
+    nodePath,
+    hostPath,
+    effectiveTarget,
+    listener,
+    socketConfig.mode,
+    socketConfig.group,
+  );
   console.log(`Created wrapper: ${wrapperPath}`);
   console.log("");
 
@@ -450,4 +496,5 @@ module.exports = {
   createWrapper,
   writeManifest,
   assertListenTargetSupported,
+  assertSocketAccessTargetSupported,
 };

--- a/skills/surf/SKILL.md
+++ b/skills/surf/SKILL.md
@@ -15,6 +15,8 @@ On macOS, Chrome reads the native messaging manifest at `~/Library/Application S
 
 If a command reports `Socket connect failed`, run `surf doctor` first, then check the `Attempted socket:` line. Default sockets are `/tmp/surf.sock` on macOS/Linux/WSL2 and `//./pipe/surf` on Windows. If `SURF_SOCKET` is set, the browser-launched host and the shell running `surf` must use the same value.
 
+For opt-in POSIX group sharing, install with `surf install <extension-id> --socket-mode 660 --socket-group <group>`. The default remains `0600`; mode `660` grants every member of that group full Surf authority, so use a dedicated narrow group. Re-run `surf install` without those flags to clear the wrapper settings. Remote Surf credentials remain the revocable per-client alternative.
+
 ## Remote Surf
 
 Remote clients require a per-client credential; Tailnet reachability alone is not authorization. On the POSIX browser host, authorize the client before installing the listener:

--- a/test/integration/native-host-protocol.test.ts
+++ b/test/integration/native-host-protocol.test.ts
@@ -13,6 +13,7 @@ declare const process: {
   cwd(): string;
   env: Record<string, string | undefined>;
   execPath: string;
+  getgid(): number;
   pid: number;
   platform: string;
 };
@@ -66,6 +67,7 @@ const { spawn } = require("node:child_process") as {
 const fs = require("node:fs") as {
   existsSync(targetPath: string): boolean;
   mkdtempSync(prefix: string): string;
+  statSync(targetPath: string): { gid: number; mode: number };
   rmSync(targetPath: string, options: { recursive: boolean; force: boolean }): void;
   readdirSync(targetPath: string): string[];
   writeFileSync(targetPath: string, content: string): void;
@@ -406,6 +408,9 @@ describe("native host protocol integration", () => {
     });
     expect(await lifecycle.start()).toBe(true);
     expect(ready).toBe(true);
+    if (process.platform !== "win32") {
+      expect(fs.statSync(localPath).mode & 0o7777).toBe(0o600);
+    }
     const tcpAddress = lifecycle.tcpServer.address();
     expect(tcpAddress.port).toBeGreaterThan(0);
 
@@ -463,6 +468,61 @@ describe("native host protocol integration", () => {
     expect(fatal).toBeInstanceOf(Error);
     expect(fs.existsSync(localPath)).toBe(false);
     await new Promise<void>((resolve) => blocker.close(resolve));
+  });
+
+  it("applies opt-in group socket permissions before reporting ready", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const localPath = createSocketPath();
+    let ready = false;
+    const lifecycle = createListenerLifecycle({
+      localPath,
+      socketMode: "660",
+      socketGroup: String(process.getgid()),
+      handler() {
+        return undefined;
+      },
+      onReady() {
+        ready = true;
+      },
+      onFatal(error: Error) {
+        throw error;
+      },
+    });
+    expect(await lifecycle.start()).toBe(true);
+    expect(ready).toBe(true);
+    const stat = fs.statSync(localPath);
+    expect(stat.mode & 0o7777).toBe(0o660);
+    expect(stat.gid).toBe(process.getgid());
+    await lifecycle.shutdown();
+  });
+
+  it("fails closed for invalid explicit socket permissions", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const localPath = createSocketPath();
+    let ready = false;
+    let fatal: Error | undefined;
+    const lifecycle = createListenerLifecycle({
+      localPath,
+      socketMode: "666",
+      handler() {
+        return undefined;
+      },
+      onReady() {
+        ready = true;
+      },
+      onFatal(error: Error) {
+        fatal = error;
+      },
+    });
+    expect(await lifecycle.start()).toBe(false);
+    expect(ready).toBe(false);
+    expect(fatal).toBeInstanceOf(Error);
+    expect(fatal?.message).toContain("SURF_SOCKET_MODE");
+    expect(fs.existsSync(localPath)).toBe(false);
   });
 
   it("closes both listeners and unlinks local socket during shutdown", async () => {

--- a/test/unit/native-host-installer.test.ts
+++ b/test/unit/native-host-installer.test.ts
@@ -15,8 +15,14 @@ const {
   createWrapper,
   writeManifest,
   assertListenTargetSupported,
+  assertSocketAccessTargetSupported,
 } = require("../../scripts/install-native-host.cjs");
 const { parseListenEndpoint } = require("../../native/listener.cjs");
+const {
+  normalizeSocketConfig,
+  parseSocketMode,
+  validateSocketGroup,
+} = require("../../native/socket-permissions.cjs");
 
 const extensionA = "abcdefghijklmnopabcdefghijklmnop";
 const extensionB = "bcdefghijklmnopabcdefghijklmnopa";
@@ -25,9 +31,11 @@ function makeTempDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), "surf-native-host-test-"));
 }
 
-function envWithoutListen() {
+function envWithoutPersistedSettings() {
   const env = { ...process.env };
   env.SURF_LISTEN = undefined;
+  env.SURF_SOCKET_MODE = undefined;
+  env.SURF_SOCKET_GROUP = undefined;
   return env;
 }
 
@@ -40,6 +48,25 @@ describe("native host installer", () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("--listen <tailscale-ip>:<port>");
     expect(result.stdout).toContain("Tailnet-only listener endpoint");
+    expect(result.stdout).toContain("--socket-mode <600|660>");
+    expect(result.stdout).toContain("--socket-group <group-or-gid>");
+  });
+
+  it("accepts only the private socket modes and safe group values", () => {
+    expect(parseSocketMode(undefined)).toBe(0o600);
+    expect(parseSocketMode(600)).toBe(0o600);
+    expect(parseSocketMode(660)).toBe(0o660);
+    expect(parseSocketMode("600")).toBe(0o600);
+    expect(parseSocketMode("0660")).toBe(0o660);
+    expect(() => parseSocketMode("664")).toThrow(/600 or 660/);
+    expect(() => parseSocketMode("777")).toThrow(/600 or 660/);
+    expect(() => parseSocketMode("6000")).toThrow(/600 or 660/);
+    expect(validateSocketGroup("surf")).toBe("surf");
+    expect(validateSocketGroup("1000")).toBe("1000");
+    expect(() => validateSocketGroup("surf;id")).toThrow(/group/i);
+    expect(() => validateSocketGroup(null)).toThrow(/group/i);
+    expect(() => normalizeSocketConfig("660", undefined)).toThrow(/requires/i);
+    expect(() => assertSocketAccessTargetSupported("660", "surf", "win32")).toThrow(/POSIX/i);
   });
 
   it("merges manifest allowed_origins without dropping existing fields", () => {
@@ -81,7 +108,7 @@ describe("native host installer", () => {
     const hostPath = path.join(tempDir, "host.cjs");
     fs.writeFileSync(
       hostPath,
-      "process.stdout.write(JSON.stringify({ listen: process.env.SURF_LISTEN, args: process.argv.slice(2) }));",
+      "process.stdout.write(JSON.stringify({ listen: process.env.SURF_LISTEN, mode: process.env.SURF_SOCKET_MODE, group: process.env.SURF_SOCKET_GROUP, args: process.argv.slice(2) }));",
     );
 
     const nativeWrapperPath = createWrapper(tempDir, nodePath, hostPath, "linux");
@@ -92,9 +119,14 @@ describe("native host installer", () => {
       expect(nativeWrapperContent).toContain(`"${hostPath}" "$@"`);
       const persisted = spawnSync(nativeWrapperPath, ["one"], {
         encoding: "utf8",
-        env: envWithoutListen(),
+        env: envWithoutPersistedSettings(),
       });
-      expect(JSON.parse(persisted.stdout)).toEqual({ listen: undefined, args: ["one"] });
+      expect(JSON.parse(persisted.stdout)).toEqual({
+        listen: undefined,
+        mode: undefined,
+        group: undefined,
+        args: ["one"],
+      });
 
       const configuredWrapper = createWrapper(
         tempDir,
@@ -105,22 +137,78 @@ describe("native host installer", () => {
       );
       const defaulted = spawnSync(configuredWrapper, ["two"], {
         encoding: "utf8",
-        env: envWithoutListen(),
+        env: envWithoutPersistedSettings(),
       });
-      expect(JSON.parse(defaulted.stdout)).toEqual({ listen: "100.64.1.2:4321", args: ["two"] });
+      expect(JSON.parse(defaulted.stdout)).toEqual({
+        listen: "100.64.1.2:4321",
+        mode: undefined,
+        group: undefined,
+        args: ["two"],
+      });
       const overridden = spawnSync(configuredWrapper, ["three"], {
         encoding: "utf8",
-        env: { ...envWithoutListen(), SURF_LISTEN: "100.64.1.3:4321" },
+        env: { ...envWithoutPersistedSettings(), SURF_LISTEN: "100.64.1.3:4321" },
       });
-      expect(JSON.parse(overridden.stdout)).toEqual({ listen: "100.64.1.3:4321", args: ["three"] });
+      expect(JSON.parse(overridden.stdout)).toEqual({
+        listen: "100.64.1.3:4321",
+        mode: undefined,
+        group: undefined,
+        args: ["three"],
+      });
+
+      const socketConfiguredWrapper = createWrapper(
+        tempDir,
+        nodePath,
+        hostPath,
+        "linux",
+        undefined,
+        "660",
+        "surf",
+      );
+      const socketDefaulted = spawnSync(socketConfiguredWrapper, ["four"], {
+        encoding: "utf8",
+        env: envWithoutPersistedSettings(),
+      });
+      expect(JSON.parse(socketDefaulted.stdout)).toEqual({
+        listen: undefined,
+        mode: "660",
+        group: "surf",
+        args: ["four"],
+      });
+      const socketOverridden = spawnSync(socketConfiguredWrapper, ["five"], {
+        encoding: "utf8",
+        env: {
+          ...envWithoutPersistedSettings(),
+          SURF_SOCKET_MODE: "600",
+          SURF_SOCKET_GROUP: "other",
+        },
+      });
+      expect(JSON.parse(socketOverridden.stdout)).toEqual({
+        listen: undefined,
+        mode: "600",
+        group: "other",
+        args: ["five"],
+      });
 
       const reinstalled = createWrapper(tempDir, nodePath, hostPath, "linux");
       expect(fs.readFileSync(reinstalled, "utf8")).not.toContain("SURF_LISTEN");
-      const inherited = spawnSync(reinstalled, ["four"], {
+      expect(fs.readFileSync(reinstalled, "utf8")).not.toContain("SURF_SOCKET_MODE");
+      expect(fs.readFileSync(reinstalled, "utf8")).not.toContain("SURF_SOCKET_GROUP");
+      const inherited = spawnSync(reinstalled, ["six"], {
         encoding: "utf8",
-        env: { ...envWithoutListen(), SURF_LISTEN: "100.64.1.4:4321" },
+        env: {
+          ...envWithoutPersistedSettings(),
+          SURF_LISTEN: "100.64.1.4:4321",
+          SURF_SOCKET_MODE: "660",
+          SURF_SOCKET_GROUP: "inherited",
+        },
       });
-      expect(JSON.parse(inherited.stdout)).toEqual({ listen: "100.64.1.4:4321", args: ["four"] });
+      expect(JSON.parse(inherited.stdout)).toEqual({
+        listen: "100.64.1.4:4321",
+        mode: "660",
+        group: "inherited",
+        args: ["six"],
+      });
     }
 
     const cmdPath = createWrapper(tempDir, nodePath, hostPath, "wsl-windows");


### PR DESCRIPTION
## Summary

- Add explicit POSIX local socket mode/group configuration for native-host wrappers.
- Keep the default local socket mode at `0600`; allow opt-in `660` only with a validated group.
- Apply and verify socket group/mode before host readiness, failing closed on invalid explicit configuration.
- Persist `--socket-mode` / `--socket-group` through `surf install` for Chrome-launched native hosts.

Thanks to [@marcoatpaladin](https://github.com/marcoatpaladin) for #225.

Fixes #225.

## Validation

- `npm run check`
- `npm test` — 57 files, 761 tests passed
- `npm run build`
- `npm run lint`
- `npm audit --audit-level=critical`
- `node --check native/socket-permissions.cjs`
- `node --check native/host.cjs`
- `node --check scripts/install-native-host.cjs`
- `node --check native/cli.cjs`
- `git diff --check`
- Fresh reviewer gate: No issues found (`/Users/nicobailon/Documents/docs/pr-issue225-gate-review.md`)
