### PR TITLE
fix: surface CDP error messages instead of the JSON envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Readable CDP errors** - `chrome.debugger` failures surfaced as a JSON blob (`{"code":-32000,"message":"Inspected target navigated or closed"}`); the message is now unwrapped and the CDP code and method are kept on the error as `cdpCode`/`cdpMethod`.
+
 ## [2.18.0] - 2026-09-04
 
 ### Highlights

--- a/src/cdp/controller.ts
+++ b/src/cdp/controller.ts
@@ -13,6 +13,39 @@ class CDPControllerError extends Error {
   }
 }
 
+export interface DebuggerCommandError extends Error {
+  /** CDP error code (for example -32000) when the browser reported one. */
+  cdpCode?: number;
+  /** The CDP method that failed. */
+  cdpMethod?: string;
+}
+
+/**
+ * `chrome.debugger.sendCommand` rejects with the CDP error serialised as
+ * JSON in the message (`{"code":-32000,"message":"Inspected target navigated
+ * or closed"}`). Surface the message itself and keep the code as a property,
+ * so callers and users see "Inspected target navigated or closed" instead
+ * of a JSON blob. Anything that is not such a JSON object passes through.
+ */
+export function describeDebuggerError(err: unknown, method?: string): Error {
+  const raw = err instanceof Error ? err.message : String(err);
+  const trimmed = raw.trim();
+  if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
+    try {
+      const parsed = JSON.parse(trimmed) as { code?: unknown; message?: unknown };
+      if (parsed && typeof parsed.message === "string" && parsed.message.length > 0) {
+        const error = new Error(parsed.message) as DebuggerCommandError;
+        if (typeof parsed.code === "number") error.cdpCode = parsed.code;
+        if (method) error.cdpMethod = method;
+        return error;
+      }
+    } catch {
+      // not JSON after all; fall through
+    }
+  }
+  return err instanceof Error ? err : new Error(raw);
+}
+
 interface ConsoleMessage {
   type: string;
   text: string;
@@ -1307,7 +1340,11 @@ export class CDPController {
   ): Promise<any> {
     await this.ensureAttached(tabId);
     const target = this.targets.get(tabId)!;
-    return chrome.debugger.sendCommand(target, method, params);
+    try {
+      return await chrome.debugger.sendCommand(target, method, params);
+    } catch (err) {
+      throw describeDebuggerError(err, method);
+    }
   }
 
   async sendCommand(

--- a/test/unit/cdp/controller.test.ts
+++ b/test/unit/cdp/controller.test.ts
@@ -1,5 +1,5 @@
 import { vi } from "vitest";
-import { CDPController } from "../../../src/cdp/controller";
+import { CDPController, describeDebuggerError } from "../../../src/cdp/controller";
 
 // Mock chrome.debugger API
 const mockChrome = {
@@ -15,7 +15,42 @@ const mockChrome = {
 // Set global chrome before tests
 vi.stubGlobal("chrome", mockChrome);
 
+describe("describeDebuggerError", () => {
+  it("unwraps the JSON-encoded CDP error chrome.debugger rejects with", () => {
+    const error = describeDebuggerError(
+      new Error('{"code":-32000,"message":"Inspected target navigated or closed"}'),
+      "Runtime.evaluate",
+    );
+    expect(error.message).toBe("Inspected target navigated or closed");
+    expect(error).toMatchObject({ cdpCode: -32000, cdpMethod: "Runtime.evaluate" });
+  });
+
+  it("passes plain errors and non-JSON messages through unchanged", () => {
+    const plain = new Error("Detached while handling command.");
+    expect(describeDebuggerError(plain, "Page.enable")).toBe(plain);
+    expect(describeDebuggerError("{not json", "Page.enable").message).toBe("{not json");
+    expect(describeDebuggerError('{"code":1}', "Page.enable").message).toBe('{"code":1}');
+  });
+});
+
 describe("CDPController", () => {
+  describe("send", () => {
+    it("rethrows CDP failures with the browser's message instead of a JSON blob", async () => {
+      const controller = new CDPController();
+      mockChrome.debugger.attach.mockResolvedValue(undefined);
+      mockChrome.debugger.sendCommand.mockRejectedValue(
+        new Error('{"code":-32000,"message":"Inspected target navigated or closed"}'),
+      );
+      await expect(
+        controller.sendCommand(7, "Runtime.evaluate", { expression: "1" }),
+      ).rejects.toMatchObject({
+        message: "Inspected target navigated or closed",
+        cdpCode: -32000,
+        cdpMethod: "Runtime.evaluate",
+      });
+    });
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
   });


### PR DESCRIPTION
## Summary

`chrome.debugger.sendCommand` rejects with the CDP error serialised as the `Error` message, so users saw the JSON envelope verbatim:

```
Error: {"code":-32000,"message":"Inspected target navigated or closed"}
```

`CDPController.send` now unwraps it: the error message becomes the human-readable text (`Inspected target navigated or closed`) and the CDP `code` and the method that failed are kept on the error as `cdpCode` / `cdpMethod`. Existing substring checks elsewhere (`Cannot access`, `navigated or closed`, `Detached while handling command`) keep working because they match the inner message. Non-JSON messages pass through unchanged.

## Validation

- `npm ci --ignore-scripts`
- `npm run lint` (existing `FakeNode` warning only)
- `npm run check`
- `npm test` — 60 files, 776 tests passed, 2 skipped (+3 vs `main`: JSON envelope unwrapped with code/method kept, non-JSON message untouched, envelope without a message)
- `npm run build`
- `npm run test:e2e:chrome` with the pinned Chrome for Testing 152.0.7977.54 — pass
- Manual: a `js` script that reloads its own page now fails with `Inspected target navigated or closed` instead of the JSON blob (Brave 151, throwaway profile).

Co-authored with Claude Code.
