### PR TITLE
feat: frame.diagnose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **`surf frame.diagnose`** - DOM `<iframe>` elements (including those inside open shadow roots, reported with their `shadowHost`), extension frames with a content-script reachability check, and the CDP frame tree side by side, correlated by URL and by `name`/`id` for `srcdoc`/`about:blank` frames, with warnings for blank frames, sandboxes without `allow-scripts`, cross-origin frames, out-of-process frames that `frame.js` cannot reach (and which commands still work there), still-loading frames and count mismatches. The text report abbreviates long frame URLs; `--json` keeps them whole.
+
 ## [2.18.0] - 2026-09-04
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -280,6 +280,13 @@ surf locate.role button --action click
 surf frame.main                     # Return to main page
 ```
 
+When a selector never matches, `frame.diagnose` shows the three frame views side by side (DOM `<iframe>` elements, the extension's frames with content-script reachability, and the CDP frame tree) and explains the mismatches: `srcdoc`/`about:blank` frames (matched to their CDP frame by `name`/`id`), sandboxes without `allow-scripts`, cross-origin frames, out-of-process frames that the CDP tree does not list (`frame.js` cannot reach them; `frame.switch` and `page.read` can when the content script answers), and frames still loading. The DOM inventory walks open shadow roots, so frames rendered by custom elements are listed with their `shadowHost` path. The text report abbreviates long frame URLs; `--json` keeps them whole.
+
+```bash
+surf frame.diagnose                 # Human-readable report with warnings
+surf frame.diagnose --json          # Full inventories
+```
+
 ### Interaction
 
 ```bash
@@ -941,7 +948,7 @@ echo '{"type":"tool_request","method":"execute_tool","params":{"tool":"tab.list"
 | `page.*` | `read`, `text`, `state` |
 | `locate.*` | `role`, `text`, `label` |
 | `element.*` | `styles` |
-| `frame.*` | `list`, `switch`, `main`, `js` |
+| `frame.*` | `list`, `diagnose`, `switch`, `main`, `js` |
 | `wait.*` | `element`, `network`, `url`, `dom`, `load` |
 | `cookie` / `cookie.*` | `list`, `get`, `set`, `clear`, `delete` |
 | `bookmark.*` | `add`, `remove`, `list` |

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -3832,6 +3832,18 @@ async function handleResponse(response) {
     console.log("\nUsage: surf emulate.device \"<device name>\"");
     console.log('Reset:  surf emulate.device "reset"');
   } else if (tool === "frame.diagnose" && data?.counts) {
+    // Keep frame URLs readable: embed runners carry kilobyte-long state
+    // parameters that bury the report (use --json for the full URLs).
+    const abbreviateUrl = (url, max = 100) => {
+      if (typeof url !== "string" || url.length <= max) return url;
+      try {
+        const parsed = new URL(url);
+        const base = `${parsed.origin}${parsed.pathname}`;
+        const trailing = url.length - base.length;
+        if (trailing > 0 && base.length <= max - 12) return `${base}?...(+${trailing} chars)`;
+      } catch {}
+      return `${url.slice(0, max - 3)}...`;
+    };
     const lines = [];
     lines.push(`Frame diagnosis for ${data.mainPage?.href ?? "?"}${data.mainPage?.title ? ` (${data.mainPage.title})` : ""}`);
     lines.push(`DOM iframes: ${data.counts.domIframes}, extension frames: ${data.counts.extensionFrames} (incl. main), CDP frames: ${data.counts.cdpFrames}`);
@@ -3848,20 +3860,20 @@ async function handleResponse(response) {
           f.extensionFrameIds?.length ? `ext ${f.extensionFrameIds.join("/")}` : "ext -",
           f.cdpFrameIds?.length ? `cdp ${f.cdpFrameIds.join("/")}` : "cdp -",
         ].join(", ");
-        lines.push(`  [${f.domIndex}] ${f.srcdoc ? "srcdoc" : (f.src || "about:blank")} ${Math.round(f.rect?.width ?? 0)}x${Math.round(f.rect?.height ?? 0)}${f.name ? ` name=${f.name}` : ""}${f.sandbox !== null && f.sandbox !== undefined ? ` sandbox="${f.sandbox}"` : ""}${flags ? ` [${flags}]` : ""} -> ${links}`);
+        lines.push(`  [${f.domIndex}] ${f.srcdoc ? "srcdoc" : abbreviateUrl(f.src || "about:blank")} ${Math.round(f.rect?.width ?? 0)}x${Math.round(f.rect?.height ?? 0)}${f.name ? ` name=${f.name}` : f.id ? ` id=${f.id}` : ""}${f.sandbox !== null && f.sandbox !== undefined ? ` sandbox="${f.sandbox}"` : ""}${f.shadowHost ? ` in shadow root of ${f.shadowHost}` : ""}${flags ? ` [${flags}]` : ""} -> ${links}`);
       }
     }
     if (Array.isArray(data.extensionFrames) && data.extensionFrames.length > 0) {
       lines.push("", "Extension frames (frame.switch ids):");
       for (const f of data.extensionFrames) {
         const reach = f.contentScriptReachable ? "content-script ok" : `content-script unreachable${f.contentScriptError ? ` (${f.contentScriptError})` : ""}`;
-        lines.push(`  #${f.frameId}${f.isMain ? " main" : ` parent ${f.parentFrameId}`} ${f.url}${f.crossOrigin ? " [cross-origin]" : ""} - ${reach}`);
+        lines.push(`  #${f.frameId}${f.isMain ? " main" : ` parent ${f.parentFrameId}`} ${abbreviateUrl(f.url)}${f.crossOrigin ? " [cross-origin]" : ""} - ${reach}`);
       }
     }
     if (Array.isArray(data.cdpFrames) && data.cdpFrames.length > 0) {
       lines.push("", "CDP frames (frame.js ids):");
       for (const f of data.cdpFrames) {
-        lines.push(`  ${f.frameId}${f.isMain ? " main" : ` parent ${f.parentId}`} ${f.url}${f.name ? ` name=${f.name}` : ""}${f.extensionFrameIds?.length ? ` -> ext ${f.extensionFrameIds.join("/")}` : ""}`);
+        lines.push(`  ${f.frameId}${f.isMain ? " main" : ` parent ${f.parentId}`} ${abbreviateUrl(f.url)}${f.name ? ` name=${f.name}` : ""}${f.extensionFrameIds?.length ? ` -> ext ${f.extensionFrameIds.join("/")}` : ""}`);
       }
     }
     lines.push("", Array.isArray(data.warnings) && data.warnings.length > 0 ? "Warnings:" : "No warnings.");

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -1760,6 +1760,7 @@ Video recording: surf video start ./demo.webm --fps 30; surf video stop
 Animation audit: surf animate-audit --selector ".thing" --duration 2000 --fps 10
 Performance audit: surf perf-audit --duration 3000 --trigger "click:.cta" --output /tmp/perf.json
 JavaScript: surf js "return document.title"
+Frames: surf frame.list | surf frame.diagnose      # diagnose explains why a selector misses inside iframes (shadow roots, srcdoc, out-of-process)
 Scroll: surf scroll down 800 | surf scroll up 400 | surf scroll bottom | surf scroll top
 Find by semantics: surf locate.role button --name "Submit" --action click
 Device/viewport: surf emulate.device "iPhone 14" | surf resize 375 812

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -1134,6 +1134,14 @@ const TOOLS = {
         args: [],
         examples: [{ cmd: "frame.list", desc: "Show frame tree" }]
       },
+      "frame.diagnose": {
+        desc: "Explain frame mismatches: DOM iframes, extension frames with content-script reachability, CDP frame tree",
+        args: [],
+        examples: [
+          { cmd: "frame.diagnose", desc: "Why does my selector not reach the widget?" },
+          { cmd: "frame.diagnose --json", desc: "Full inventories as JSON" },
+        ]
+      },
       "frame.switch": {
         desc: "Switch to iframe context",
         args: [],
@@ -1624,7 +1632,7 @@ const ALL_SOCKET_TOOLS = [
   "form.fill",
   "perf.start", "perf.stop", "perf.metrics",
   "upload",
-  "frame.list", "frame.switch", "frame.main", "frame.js",
+  "frame.list", "frame.diagnose", "frame.switch", "frame.main", "frame.js",
   "cookie.list", "cookie.get", "cookie.set", "cookie.clear",
   "search", "batch",
   "zoom", "resize",
@@ -1646,7 +1654,8 @@ const SEE_ALSO = {
   "tab.new": ["window.new for isolation"],
   "window.new": ["window.list"],
   "window.list": ["tab.list"],
-  "frame.list": ["frame.switch", "frame.main"],
+  "frame.list": ["frame.switch", "frame.main", "frame.diagnose"],
+  "frame.diagnose": ["frame.list", "frame.switch", "frame.js"],
   "frame.switch": ["frame.list", "frame.main", "frame.js"],
   "frame.main": ["frame.list", "frame.switch"],
   "frame.js": ["frame.switch", "js"],
@@ -3822,6 +3831,42 @@ async function handleResponse(response) {
     }
     console.log("\nUsage: surf emulate.device \"<device name>\"");
     console.log('Reset:  surf emulate.device "reset"');
+  } else if (tool === "frame.diagnose" && data?.counts) {
+    const lines = [];
+    lines.push(`Frame diagnosis for ${data.mainPage?.href ?? "?"}${data.mainPage?.title ? ` (${data.mainPage.title})` : ""}`);
+    lines.push(`DOM iframes: ${data.counts.domIframes}, extension frames: ${data.counts.extensionFrames} (incl. main), CDP frames: ${data.counts.cdpFrames}`);
+    if (Array.isArray(data.domIframes) && data.domIframes.length > 0) {
+      lines.push("", "DOM iframes:");
+      for (const f of data.domIframes) {
+        const flags = [
+          f.blank ? "blank" : null,
+          f.crossOrigin ? "cross-origin" : null,
+          f.scriptsBlocked ? "scripts-blocked" : null,
+          f.zeroSize ? "0-size" : null,
+        ].filter(Boolean).join(",");
+        const links = [
+          f.extensionFrameIds?.length ? `ext ${f.extensionFrameIds.join("/")}` : "ext -",
+          f.cdpFrameIds?.length ? `cdp ${f.cdpFrameIds.join("/")}` : "cdp -",
+        ].join(", ");
+        lines.push(`  [${f.domIndex}] ${f.srcdoc ? "srcdoc" : (f.src || "about:blank")} ${Math.round(f.rect?.width ?? 0)}x${Math.round(f.rect?.height ?? 0)}${f.name ? ` name=${f.name}` : ""}${f.sandbox !== null && f.sandbox !== undefined ? ` sandbox="${f.sandbox}"` : ""}${flags ? ` [${flags}]` : ""} -> ${links}`);
+      }
+    }
+    if (Array.isArray(data.extensionFrames) && data.extensionFrames.length > 0) {
+      lines.push("", "Extension frames (frame.switch ids):");
+      for (const f of data.extensionFrames) {
+        const reach = f.contentScriptReachable ? "content-script ok" : `content-script unreachable${f.contentScriptError ? ` (${f.contentScriptError})` : ""}`;
+        lines.push(`  #${f.frameId}${f.isMain ? " main" : ` parent ${f.parentFrameId}`} ${f.url}${f.crossOrigin ? " [cross-origin]" : ""} - ${reach}`);
+      }
+    }
+    if (Array.isArray(data.cdpFrames) && data.cdpFrames.length > 0) {
+      lines.push("", "CDP frames (frame.js ids):");
+      for (const f of data.cdpFrames) {
+        lines.push(`  ${f.frameId}${f.isMain ? " main" : ` parent ${f.parentId}`} ${f.url}${f.name ? ` name=${f.name}` : ""}${f.extensionFrameIds?.length ? ` -> ext ${f.extensionFrameIds.join("/")}` : ""}`);
+      }
+    }
+    lines.push("", Array.isArray(data.warnings) && data.warnings.length > 0 ? "Warnings:" : "No warnings.");
+    for (const w of Array.isArray(data.warnings) ? data.warnings : []) lines.push(`  - ${w}`);
+    console.log(lines.join("\n"));
   } else if (tool === "js") {
     if (data?.result !== undefined) {
       const val = data.result.value ?? data.result;

--- a/native/host-helpers.cjs
+++ b/native/host-helpers.cjs
@@ -875,6 +875,8 @@ function mapToolToMessage(tool, args, tabId) {
       return { type: "WAIT_FOR_LOAD", timeout: a.timeout || 30000, ...baseMsg };
     case "frame.list":
       return { type: "GET_FRAMES", ...baseMsg };
+    case "frame.diagnose":
+      return { type: "FRAME_DIAGNOSE", ...baseMsg };
     case "frame.switch":
       return { 
         type: "FRAME_SWITCH", 

--- a/native/mcp-server.cjs
+++ b/native/mcp-server.cjs
@@ -242,6 +242,10 @@ const TOOL_SCHEMAS = {
     desc: "List all frames in page",
     schema: {}
   },
+  "frame.diagnose": {
+    desc: "Compare DOM iframes, extension frames (with content-script reachability) and the CDP frame tree, with warnings",
+    schema: {}
+  },
   "frame.js": {
     desc: "Execute JS in specific frame",
     schema: {

--- a/native/tool-scope.cjs
+++ b/native/tool-scope.cjs
@@ -46,7 +46,7 @@ const TAB_TOOLS = new Set([
   "search", "locate.role", "locate.text", "locate.label", "element.styles",
   "js", "javascript_tool", "eval",
   "wait.element", "wait.url", "wait.network", "wait.dom", "wait.load", "health",
-  "frame.list", "frame.switch", "frame.main", "frame.js",
+  "frame.list", "frame.diagnose", "frame.switch", "frame.main", "frame.js",
   "dialog.accept", "dialog.dismiss", "dialog.info",
   "console", "network", "network.get", "network.body", "network.curl", "network.path",
   "network.origins", "network.clear", "network.stats", "network.export",

--- a/skills/surf/SKILL.md
+++ b/skills/surf/SKILL.md
@@ -321,6 +321,7 @@ surf page.text                 # Plain text content only
 surf page.html --strip-scripts # Rendered HTML without scripts
 surf page.save --selector "#artifact" --strip-scripts --output page.html # Save one static element
 surf page.state                # Modals, loading state, scroll info
+surf frame.diagnose            # Why a selector misses: DOM iframes (incl. open shadow roots) vs extension frames vs CDP tree, with warnings; out-of-process frames need frame.switch, not frame.js
 ```
 
 ### Export Rendered HTML

--- a/src/content/accessibility-tree.ts
+++ b/src/content/accessibility-tree.ts
@@ -1572,6 +1572,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       sendResponse(result);
       break;
     }
+    case "PING": {
+      sendResponse({ success: true, href: location.href, readyState: document.readyState });
+      break;
+    }
     case "EVAL_IN_PAGE": {
       try {
         const script = document.createElement('script');

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -1,5 +1,11 @@
 import { CDPController } from "../cdp/controller";
 import { debugLog } from "../utils/debug";
+import {
+  DOM_IFRAME_INVENTORY_EXPRESSION,
+  type DomIframeEntry,
+  type ExtensionFrameEntry,
+  buildFrameDiagnosis,
+} from "../utils/frame-diagnose";
 import { initNativeMessaging, postToNativeHost } from "../native/port-manager";
 
 debugLog("Service worker loaded");
@@ -151,6 +157,52 @@ async function labelSessionTab(tabId: number, name: string): Promise<number | un
   } catch {
     return undefined;
   }
+}
+
+async function collectDomIframeInventory(
+  tabId: number,
+): Promise<{ href: string; title: string; iframes: DomIframeEntry[] }> {
+  const result = await cdp.evaluateScript(tabId, DOM_IFRAME_INVENTORY_EXPRESSION);
+  if (result.exceptionDetails) {
+    throw new Error(
+      result.exceptionDetails.exception?.description ||
+        result.exceptionDetails.text ||
+        "Failed to collect the DOM iframe inventory",
+    );
+  }
+  const value = result.result?.value;
+  if (!value || typeof value !== "object" || !Array.isArray(value.iframes)) {
+    throw new Error("Unexpected DOM iframe inventory result shape");
+  }
+  return value as { href: string; title: string; iframes: DomIframeEntry[] };
+}
+
+/** webNavigation frames plus a content-script PING per frame. */
+async function collectExtensionFrames(tabId: number): Promise<ExtensionFrameEntry[]> {
+  const frames = (await chrome.webNavigation.getAllFrames({ tabId })) ?? [];
+  const entries: ExtensionFrameEntry[] = [];
+  for (const frame of frames) {
+    const entry: ExtensionFrameEntry = {
+      frameId: frame.frameId,
+      parentFrameId: frame.parentFrameId,
+      url: frame.url,
+      errorOccurred: frame.errorOccurred === true,
+      contentScriptReachable: false,
+    };
+    try {
+      const ping = await chrome.tabs.sendMessage(tabId, { type: "PING" }, { frameId: frame.frameId });
+      if (ping?.success) {
+        entry.contentScriptReachable = true;
+        entry.contentScript = { href: ping.href, readyState: ping.readyState };
+      } else {
+        entry.contentScriptError = ping?.error ? String(ping.error) : "no response";
+      }
+    } catch (err) {
+      entry.contentScriptError = err instanceof Error ? err.message : String(err);
+    }
+    entries.push(entry);
+  }
+  return entries;
 }
 
 const screenshotCache = new Map<string, { base64: string; width: number; height: number }>();
@@ -2121,6 +2173,25 @@ export async function handleMessage(
       const result = await cdp.getFrames(tabId);
       if (!result.success) throw new Error(result.error);
       return { success: true, frames: result.frames };
+    }
+
+    case "FRAME_DIAGNOSE": {
+      if (!tabId) throw new Error("No tabId provided");
+      const dom = await collectDomIframeInventory(tabId);
+      const extensionFrames = await collectExtensionFrames(tabId);
+      const cdpResult = await cdp.getFrames(tabId);
+      const diagnosis = buildFrameDiagnosis({
+        mainPage: { href: dom.href, title: dom.title },
+        domIframes: dom.iframes,
+        extensionFrames,
+        cdpFrames: cdpResult.success ? (cdpResult.frames ?? []) : [],
+      });
+      if (!cdpResult.success) {
+        diagnosis.warnings.unshift(`CDP frame tree unavailable: ${cdpResult.error}`);
+      }
+      // No `success` key on purpose: formatToolContent renders {success, frames}
+      // as the bare frame list.
+      return diagnosis;
     }
 
     case "FRAME_SWITCH": {

--- a/src/utils/frame-diagnose.ts
+++ b/src/utils/frame-diagnose.ts
@@ -1,0 +1,252 @@
+/**
+ * Frame diagnosis: three inventories of the same page side by side.
+ *
+ * A page can carry frames that each inventory sees differently:
+ *
+ * - The DOM lists `<iframe>` elements with their attributes and layout,
+ *   but a `srcdoc` or script-created frame shows up as `about:blank`.
+ * - `chrome.webNavigation.getAllFrames` lists the frames the extension can
+ *   message, with the numeric ids `frame.switch` uses; a frame the content
+ *   script did not load in (sandboxed, restricted, still loading) is
+ *   listed but unreachable.
+ * - The CDP frame tree (`Page.getFrameTree`) lists what the renderer knows,
+ *   with the string ids `frame.js` uses, including out-of-process frames.
+ *
+ * `buildFrameDiagnosis` correlates the three by URL and explains the
+ * mismatches, so an agent can pick the right frame command instead of
+ * guessing why a selector never matches.
+ */
+
+export interface FrameRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface DomIframeEntry {
+  domIndex: number;
+  /** Resolved absolute URL (`iframe.src`), empty for srcdoc/blank frames. */
+  src: string;
+  /** The literal `src` attribute, useful when it is relative. */
+  srcAttribute?: string;
+  srcdoc: boolean;
+  title: string;
+  name: string;
+  id: string;
+  sandbox: string | null;
+  allow: string;
+  rect: FrameRect;
+}
+
+export interface ExtensionFrameEntry {
+  frameId: number;
+  parentFrameId: number;
+  url: string;
+  errorOccurred: boolean;
+  contentScriptReachable: boolean;
+  contentScript?: { href?: string; readyState?: string };
+  contentScriptError?: string;
+}
+
+export interface CdpFrameEntry {
+  frameId: string;
+  parentId?: string;
+  url: string;
+  name: string;
+}
+
+export interface FrameDiagnosisInput {
+  mainPage: { href: string; title: string };
+  domIframes: DomIframeEntry[];
+  extensionFrames: ExtensionFrameEntry[];
+  cdpFrames: CdpFrameEntry[];
+}
+
+export interface DiagnosedDomIframe extends DomIframeEntry {
+  origin: string | null;
+  crossOrigin: boolean;
+  blank: boolean;
+  zeroSize: boolean;
+  scriptsBlocked: boolean;
+  extensionFrameIds: number[];
+  cdpFrameIds: string[];
+}
+
+export interface DiagnosedExtensionFrame extends ExtensionFrameEntry {
+  isMain: boolean;
+  origin: string | null;
+  crossOrigin: boolean;
+}
+
+export interface DiagnosedCdpFrame extends CdpFrameEntry {
+  isMain: boolean;
+  origin: string | null;
+  crossOrigin: boolean;
+  extensionFrameIds: number[];
+}
+
+export interface FrameDiagnosis {
+  mainPage: { href: string; title: string; origin: string | null };
+  counts: { domIframes: number; extensionFrames: number; cdpFrames: number };
+  domIframes: DiagnosedDomIframe[];
+  extensionFrames: DiagnosedExtensionFrame[];
+  cdpFrames: DiagnosedCdpFrame[];
+  warnings: string[];
+}
+
+export function originOf(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    return parsed.origin === "null" ? null : parsed.origin;
+  } catch {
+    return null;
+  }
+}
+
+export function isBlankFrameUrl(url: string): boolean {
+  return url === "" || url === "about:blank" || url.startsWith("about:blank?") || url === "about:srcdoc";
+}
+
+/** Sandboxed frames run no scripts unless `allow-scripts` is present. */
+export function sandboxBlocksScripts(sandbox: string | null): boolean {
+  if (sandbox === null) return false;
+  return !sandbox.split(/\s+/).includes("allow-scripts");
+}
+
+function sameUrl(a: string, b: string): boolean {
+  if (isBlankFrameUrl(a) && isBlankFrameUrl(b)) return true;
+  return a === b;
+}
+
+function short(url: string, max = 80): string {
+  if (url.length <= max) return url;
+  return `${url.slice(0, max - 3)}...`;
+}
+
+export function buildFrameDiagnosis(input: FrameDiagnosisInput): FrameDiagnosis {
+  const mainOrigin = originOf(input.mainPage.href);
+  const childExtensionFrames = input.extensionFrames.filter((frame) => frame.parentFrameId !== -1);
+  const warnings: string[] = [];
+
+  const extensionFrames: DiagnosedExtensionFrame[] = input.extensionFrames.map((frame) => {
+    const origin = originOf(frame.url);
+    return {
+      ...frame,
+      isMain: frame.parentFrameId === -1,
+      origin,
+      crossOrigin: origin !== null && mainOrigin !== null && origin !== mainOrigin,
+    };
+  });
+
+  const cdpFrames: DiagnosedCdpFrame[] = input.cdpFrames.map((frame) => {
+    const origin = originOf(frame.url);
+    return {
+      ...frame,
+      isMain: frame.parentId === undefined,
+      origin,
+      crossOrigin: origin !== null && mainOrigin !== null && origin !== mainOrigin,
+      extensionFrameIds: childExtensionFrames
+        .filter((candidate) => !isBlankFrameUrl(frame.url) && sameUrl(candidate.url, frame.url))
+        .map((candidate) => candidate.frameId),
+    };
+  });
+
+  const domIframes: DiagnosedDomIframe[] = input.domIframes.map((iframe) => {
+    const blank = iframe.srcdoc || isBlankFrameUrl(iframe.src);
+    const origin = blank ? null : originOf(iframe.src);
+    const matchesUrl = (url: string): boolean => !blank && sameUrl(url, iframe.src);
+    return {
+      ...iframe,
+      origin,
+      crossOrigin: origin !== null && mainOrigin !== null && origin !== mainOrigin,
+      blank,
+      zeroSize: iframe.rect.width <= 0 || iframe.rect.height <= 0,
+      scriptsBlocked: sandboxBlocksScripts(iframe.sandbox),
+      extensionFrameIds: childExtensionFrames.filter((frame) => matchesUrl(frame.url)).map((frame) => frame.frameId),
+      cdpFrameIds: input.cdpFrames.filter((frame) => frame.parentId !== undefined && matchesUrl(frame.url)).map((frame) => frame.frameId),
+    };
+  });
+
+  const blankIframes = domIframes.filter((iframe) => iframe.blank);
+  if (blankIframes.length > 0) {
+    warnings.push(
+      `${blankIframes.length} iframe(s) have no URL (about:blank or srcdoc): DOM indexes ${blankIframes.map((iframe) => iframe.domIndex).join(", ")}. Their content cannot be matched by URL; reach it through frame.list / frame.js with the CDP frame id, or frame.switch --index.`,
+    );
+  }
+
+  for (const iframe of domIframes) {
+    if (iframe.scriptsBlocked) {
+      warnings.push(`iframe ${iframe.domIndex} (${short(iframe.src) || "no src"}) is sandboxed without allow-scripts: no content script or page script runs inside it.`);
+    }
+    if (iframe.zeroSize) {
+      warnings.push(`iframe ${iframe.domIndex} (${short(iframe.src) || "no src"}) is rendered at ${iframe.rect.width}x${iframe.rect.height}: hidden, collapsed, or not yet laid out.`);
+    }
+    if (!iframe.blank && iframe.extensionFrameIds.length === 0) {
+      warnings.push(`iframe ${iframe.domIndex} (${short(iframe.src)}) has no matching extension frame: it may still be loading, be blocked, or have navigated elsewhere.`);
+    }
+    if (iframe.extensionFrameIds.length > 1) {
+      warnings.push(`iframe ${iframe.domIndex} (${short(iframe.src)}) matches ${iframe.extensionFrameIds.length} extension frames by URL (${iframe.extensionFrameIds.join(", ")}); use frame.switch --index to pick one.`);
+    }
+  }
+
+  for (const frame of extensionFrames) {
+    if (frame.isMain) continue;
+    if (!frame.contentScriptReachable) {
+      const reason = frame.contentScriptError ? ` (${frame.contentScriptError})` : "";
+      warnings.push(`extension frame ${frame.frameId} (${short(frame.url)}) has no reachable content script${reason}: page.read, click by ref and frame.switch will not work inside it; frame.js with its CDP frame id may.`);
+    }
+    if (frame.errorOccurred) {
+      warnings.push(`extension frame ${frame.frameId} (${short(frame.url)}) reported a navigation error.`);
+    }
+  }
+
+  const unseenByExtension = cdpFrames.filter(
+    (frame) => !frame.isMain && !isBlankFrameUrl(frame.url) && frame.extensionFrameIds.length === 0,
+  );
+  for (const frame of unseenByExtension) {
+    warnings.push(`CDP frame ${frame.frameId} (${short(frame.url)}) is not reported by chrome.webNavigation: likely out-of-process or detached; only frame.js can reach it.`);
+  }
+
+  const crossOriginCount = domIframes.filter((iframe) => iframe.crossOrigin).length;
+  if (crossOriginCount > 0) {
+    warnings.push(`${crossOriginCount} cross-origin iframe(s): selectors from the main page do not reach them; switch with frame.switch first.`);
+  }
+
+  if (domIframes.length !== childExtensionFrames.length) {
+    warnings.push(`DOM lists ${domIframes.length} iframe(s) but the extension sees ${childExtensionFrames.length} child frame(s); nested or detached frames account for the difference.`);
+  }
+
+  return {
+    mainPage: { ...input.mainPage, origin: mainOrigin },
+    counts: {
+      domIframes: domIframes.length,
+      extensionFrames: extensionFrames.length,
+      cdpFrames: cdpFrames.length,
+    },
+    domIframes,
+    extensionFrames,
+    cdpFrames,
+    warnings,
+  };
+}
+
+/** Page-side expression that returns the DOM iframe inventory as a plain object. */
+export const DOM_IFRAME_INVENTORY_EXPRESSION = `(() => {
+  const iframes = Array.from(document.querySelectorAll("iframe")).map((el, domIndex) => {
+    const rect = el.getBoundingClientRect();
+    return {
+      domIndex,
+      src: el.hasAttribute("srcdoc") ? "" : el.src || "",
+      srcAttribute: el.getAttribute("src") || "",
+      srcdoc: el.hasAttribute("srcdoc"),
+      title: el.title || "",
+      name: el.getAttribute("name") || "",
+      id: el.id || "",
+      sandbox: el.hasAttribute("sandbox") ? el.getAttribute("sandbox") : null,
+      allow: el.getAttribute("allow") || "",
+      rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+    };
+  });
+  return { href: location.href, title: document.title, iframes };
+})()`;

--- a/src/utils/frame-diagnose.ts
+++ b/src/utils/frame-diagnose.ts
@@ -37,6 +37,12 @@ export interface DomIframeEntry {
   sandbox: string | null;
   allow: string;
   rect: FrameRect;
+  /**
+   * Path of shadow hosts the iframe sits under (`div#host > x-widget`), or
+   * null when it is in the light DOM. `document.querySelectorAll("iframe")`
+   * never sees the former.
+   */
+  shadowHost?: string | null;
 }
 
 export interface ExtensionFrameEntry {
@@ -124,6 +130,11 @@ function short(url: string, max = 80): string {
   return `${url.slice(0, max - 3)}...`;
 }
 
+/** The name CDP reports for a frame is the iframe's `name`, else its `id`. */
+function frameName(iframe: DomIframeEntry): string {
+  return iframe.name || iframe.id || "";
+}
+
 export function buildFrameDiagnosis(input: FrameDiagnosisInput): FrameDiagnosis {
   const mainOrigin = originOf(input.mainPage.href);
   const childExtensionFrames = input.extensionFrames.filter((frame) => frame.parentFrameId !== -1);
@@ -156,22 +167,28 @@ export function buildFrameDiagnosis(input: FrameDiagnosisInput): FrameDiagnosis 
     const blank = iframe.srcdoc || isBlankFrameUrl(iframe.src);
     const origin = blank ? null : originOf(iframe.src);
     const matchesUrl = (url: string): boolean => !blank && sameUrl(url, iframe.src);
+    const name = frameName(iframe);
+    // CDP names frames after the iframe's name/id, which is the only handle a
+    // srcdoc or about:blank frame has.
+    const matchesCdp = (frame: CdpFrameEntry): boolean =>
+      frame.parentId !== undefined && (matchesUrl(frame.url) || (name !== "" && frame.name === name));
     return {
       ...iframe,
+      shadowHost: iframe.shadowHost ?? null,
       origin,
       crossOrigin: origin !== null && mainOrigin !== null && origin !== mainOrigin,
       blank,
       zeroSize: iframe.rect.width <= 0 || iframe.rect.height <= 0,
       scriptsBlocked: sandboxBlocksScripts(iframe.sandbox),
       extensionFrameIds: childExtensionFrames.filter((frame) => matchesUrl(frame.url)).map((frame) => frame.frameId),
-      cdpFrameIds: input.cdpFrames.filter((frame) => frame.parentId !== undefined && matchesUrl(frame.url)).map((frame) => frame.frameId),
+      cdpFrameIds: input.cdpFrames.filter(matchesCdp).map((frame) => frame.frameId),
     };
   });
 
-  const blankIframes = domIframes.filter((iframe) => iframe.blank);
-  if (blankIframes.length > 0) {
+  const unmatchedBlank = domIframes.filter((iframe) => iframe.blank && iframe.cdpFrameIds.length === 0);
+  if (unmatchedBlank.length > 0) {
     warnings.push(
-      `${blankIframes.length} iframe(s) have no URL (about:blank or srcdoc): DOM indexes ${blankIframes.map((iframe) => iframe.domIndex).join(", ")}. Their content cannot be matched by URL; reach it through frame.list / frame.js with the CDP frame id, or frame.switch --index.`,
+      `${unmatchedBlank.length} iframe(s) have no URL (about:blank or srcdoc): DOM indexes ${unmatchedBlank.map((iframe) => iframe.domIndex).join(", ")}. No CDP frame carries their name or id, so their content cannot be matched; give them a name or id attribute, or use frame.switch --index.`,
     );
   }
 
@@ -187,6 +204,24 @@ export function buildFrameDiagnosis(input: FrameDiagnosisInput): FrameDiagnosis 
     }
     if (iframe.extensionFrameIds.length > 1) {
       warnings.push(`iframe ${iframe.domIndex} (${short(iframe.src)}) matches ${iframe.extensionFrameIds.length} extension frames by URL (${iframe.extensionFrameIds.join(", ")}); use frame.switch --index to pick one.`);
+    }
+    if (!iframe.blank && iframe.extensionFrameIds.length > 0 && iframe.cdpFrameIds.length === 0) {
+      const reachable = iframe.extensionFrameIds.every(
+        (id) => input.extensionFrames.find((frame) => frame.frameId === id)?.contentScriptReachable === true,
+      );
+      if (iframe.crossOrigin) {
+        warnings.push(
+          `iframe ${iframe.domIndex} (${short(iframe.src)}) is out-of-process: it is missing from this tab's CDP frame tree, so frame.js cannot reach it; ${
+            reachable
+              ? "its content script answers, so frame.switch, page.read and click by ref work there."
+              : "its content script is unreachable too, so nothing in this tab can drive it."
+          }`,
+        );
+      } else {
+        warnings.push(
+          `iframe ${iframe.domIndex} (${short(iframe.src)}) has an extension frame but no CDP frame: it is still loading, navigated, or runs out of process; retry, or use frame.switch.`,
+        );
+      }
     }
   }
 
@@ -214,7 +249,16 @@ export function buildFrameDiagnosis(input: FrameDiagnosisInput): FrameDiagnosis 
   }
 
   if (domIframes.length !== childExtensionFrames.length) {
-    warnings.push(`DOM lists ${domIframes.length} iframe(s) but the extension sees ${childExtensionFrames.length} child frame(s); nested or detached frames account for the difference.`);
+    const nested = childExtensionFrames.filter((frame) => frame.parentFrameId !== 0).length;
+    const shadowed = domIframes.filter((iframe) => iframe.shadowHost).length;
+    const explained = domIframes.length === childExtensionFrames.length - nested;
+    warnings.push(
+      `DOM lists ${domIframes.length} iframe(s)${shadowed > 0 ? ` (${shadowed} inside open shadow roots)` : ""} but the extension sees ${childExtensionFrames.length} child frame(s)${nested > 0 ? `, ${nested} of them nested below another frame` : ""}; ${
+        explained
+          ? "the nested frames account for the difference."
+          : "the rest live in closed shadow roots, were created after the snapshot, or are detached."
+      }`,
+    );
   }
 
   return {
@@ -233,10 +277,22 @@ export function buildFrameDiagnosis(input: FrameDiagnosisInput): FrameDiagnosis 
 
 /** Page-side expression that returns the DOM iframe inventory as a plain object. */
 export const DOM_IFRAME_INVENTORY_EXPRESSION = `(() => {
-  const iframes = Array.from(document.querySelectorAll("iframe")).map((el, domIndex) => {
+  const describe = (el) => el.tagName.toLowerCase() + (el.id ? "#" + el.id : "") + (el.classList.length ? "." + Array.from(el.classList).slice(0, 2).join(".") : "");
+  const found = [];
+  // Walk open shadow roots too: querySelectorAll("iframe") on the document
+  // misses every frame a custom element renders inside its shadow tree.
+  const walk = (root, hostPath) => {
+    for (const el of root.querySelectorAll("iframe")) found.push({ el, hostPath });
+    for (const host of root.querySelectorAll("*")) {
+      if (host.shadowRoot) walk(host.shadowRoot, hostPath ? hostPath + " > " + describe(host) : describe(host));
+    }
+  };
+  walk(document, "");
+  const iframes = found.map(({ el, hostPath }, domIndex) => {
     const rect = el.getBoundingClientRect();
     return {
       domIndex,
+      shadowHost: hostPath || null,
       src: el.hasAttribute("srcdoc") ? "" : el.src || "",
       srcAttribute: el.getAttribute("src") || "",
       srcdoc: el.hasAttribute("srcdoc"),

--- a/test/e2e/real-chrome.mjs
+++ b/test/e2e/real-chrome.mjs
@@ -34,6 +34,7 @@ const screenshotPath = join(scratch, "shot.png");
 const hostPidPath = join(scratch, "native-host.pid");
 let browser;
 let browserPid;
+let crossOriginServer;
 let chromeExecutablePath;
 let puppeteer;
 let server;
@@ -106,6 +107,35 @@ async function runSurf(...args) {
     maxBuffer: 10 * 1024 * 1024,
   });
   return result.stdout;
+}
+
+/** `--json` with an explicit target wraps the payload as {result, target, notice}. */
+function unwrapJson(stdout) {
+  const parsed = JSON.parse(stdout);
+  return parsed && typeof parsed === "object" && "result" in parsed && "target" in parsed ? parsed.result : parsed;
+}
+
+/** tab.new prints "Created tab <id>: <url>" even with --json. */
+function tabIdFromOutput(stdout) {
+  const match = stdout.match(/\btab\s+(\d+)\b/i);
+  if (!match) throw new Error(`tab.new did not report a tab id: ${stdout}`);
+  return Number(match[1]);
+}
+
+function fixturePages(request, { crossOriginBase }) {
+  const url = new URL(request.url, "http://127.0.0.1");
+  if (url.pathname === "/frames") {
+    return `<!doctype html><html><head><title>Surf frames fixture</title></head>
+<body><h1>Frames</h1>
+<iframe id="same-origin" src="/fixture" width="300" height="120"></iframe>
+<iframe id="inline" srcdoc="<p>inline</p>" width="200" height="60"></iframe>
+<iframe id="cross-origin" src="${crossOriginBase}/fixture" width="300" height="120"></iframe>
+<iframe id="sandboxed" src="/fixture?sandboxed" sandbox="allow-forms" width="200" height="60"></iframe>
+<div id="host"></div>
+<script>document.getElementById("host").attachShadow({ mode: "open" }).innerHTML = '<iframe id="shadowed" src="/fixture?shadowed" width="200" height="60"></iframe>';</script>
+</body></html>`;
+  }
+  return null;
 }
 
 try {
@@ -190,7 +220,23 @@ try {
   mkdirSync(join(profileDir, "NativeMessagingHosts"), { recursive: true });
   cpSync(standardManifest, testingManifest);
 
+  crossOriginServer = createServer((request, response) => {
+    response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+    response.end(`<!doctype html><html><head><title>Cross-origin fixture</title></head><body><p>cross-origin ${request.url}</p></body></html>`);
+  });
+  await new Promise((resolve, reject) => {
+    crossOriginServer.once("error", reject);
+    crossOriginServer.listen(0, "127.0.0.1", resolve);
+  });
+  const crossOriginBase = `http://127.0.0.1:${crossOriginServer.address().port}`;
+
   server = createServer((request, response) => {
+    const extraPage = fixturePages(request, { crossOriginBase });
+    if (extraPage !== null) {
+      response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+      response.end(extraPage);
+      return;
+    }
     const hasSessionCookie = request.headers.cookie?.includes("surf_session=present") === true;
     response.writeHead(200, {
       "content-type": "text/html; charset=utf-8",
@@ -221,6 +267,7 @@ try {
   const address = server.address();
   const fixtureUrl = `http://127.0.0.1:${address.port}/fixture`;
   const navigationUrl = `${fixtureUrl}?navigated`;
+  const baseUrl = `http://127.0.0.1:${address.port}`;
 
   browser = await puppeteer.launch({
     headless: true,
@@ -337,6 +384,36 @@ try {
     "visual indicator",
   );
 
+  // --- frame.diagnose ----------------------------------------------------
+  const framesTab = { tabId: tabIdFromOutput(await runSurf("tab.new", `${baseUrl}/frames`)) };
+  await runSurf("wait.element", "#sandboxed", "--tab-id", String(framesTab.tabId), "--json");
+  await runSurf("wait.dom", "--tab-id", String(framesTab.tabId), "--json");
+  const diagnosis = unwrapJson(await runSurf("frame.diagnose", "--json", "--tab-id", String(framesTab.tabId)));
+  const byId = Object.fromEntries(diagnosis.domIframes.map((frame) => [frame.id, frame]));
+  if (diagnosis.counts.domIframes !== 5 || !byId["same-origin"] || !byId["inline"] || !byId["cross-origin"] || !byId["sandboxed"] || !byId["shadowed"]) {
+    throw new Error(`frame.diagnose did not list the five fixture iframes: ${JSON.stringify(diagnosis)}`);
+  }
+  if (byId["same-origin"].extensionFrameIds.length !== 1 || byId["same-origin"].cdpFrameIds.length !== 1) {
+    throw new Error(`same-origin iframe was not correlated: ${JSON.stringify(byId["same-origin"])}`);
+  }
+  if (byId["shadowed"].shadowHost !== "div#host" || byId["shadowed"].extensionFrameIds.length !== 1) {
+    throw new Error(`shadow-hosted iframe was not inventoried: ${JSON.stringify(byId["shadowed"])}`);
+  }
+  if (byId["inline"].cdpFrameIds.length !== 1) {
+    throw new Error(`srcdoc iframe was not matched to its CDP frame by id: ${JSON.stringify(byId["inline"])}`);
+  }
+  if (!byId["inline"].blank || byId["cross-origin"].crossOrigin !== true || byId["sandboxed"].scriptsBlocked !== true) {
+    throw new Error(`frame flags are wrong: ${JSON.stringify(byId)}`);
+  }
+  const sameOriginFrame = diagnosis.extensionFrames.find((frame) => frame.frameId === byId["same-origin"].extensionFrameIds[0]);
+  if (!sameOriginFrame?.contentScriptReachable) {
+    throw new Error(`content script PING did not reach the same-origin iframe: ${JSON.stringify(diagnosis.extensionFrames)}`);
+  }
+  if (!diagnosis.warnings.some((line) => line.includes("srcdoc")) || !diagnosis.warnings.some((line) => line.includes("allow-scripts"))) {
+    throw new Error(`frame.diagnose warnings missing: ${JSON.stringify(diagnosis.warnings)}`);
+  }
+  await runSurf("tab.close", "--id", String(framesTab.tabId), "--json");
+
   await runSurf("screenshot", "--output", screenshotPath);
   const png = readFileSync(screenshotPath);
   if (png.length < 100 || png.subarray(0, 8).toString("hex") !== "89504e470d0a1a0a") {
@@ -379,6 +456,7 @@ try {
         extensionId,
         platform: process.platform,
         result: "pass",
+        frameDiagnoseWarnings: diagnosis.warnings.length,
         screenshotBytes: png.length,
         serviceWorker: workerTarget.url(),
       },
@@ -410,6 +488,15 @@ try {
   if (server) {
     await new Promise((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+} catch (error) {
+  cleanupErrors.push(error);
+}
+try {
+  if (crossOriginServer) {
+    await new Promise((resolve, reject) => {
+      crossOriginServer.close((error) => (error ? reject(error) : resolve()));
     });
   }
 } catch (error) {

--- a/test/unit/frame-diagnose.test.ts
+++ b/test/unit/frame-diagnose.test.ts
@@ -200,7 +200,84 @@ describe("buildFrameDiagnosis", () => {
     expect(result.warnings).toEqual([
       "iframe 0 (https://late.example.com/) has no matching extension frame: it may still be loading, be blocked, or have navigated elsewhere.",
       "1 cross-origin iframe(s): selectors from the main page do not reach them; switch with frame.switch first.",
-      "DOM lists 1 iframe(s) but the extension sees 0 child frame(s); nested or detached frames account for the difference.",
+      "DOM lists 1 iframe(s) but the extension sees 0 child frame(s); the rest live in closed shadow roots, were created after the snapshot, or are detached.",
+    ]);
+  });
+
+  it("matches srcdoc and about:blank iframes to CDP frames by name or id", () => {
+    const result = buildFrameDiagnosis({
+      mainPage: { href: MAIN, title: "Page" },
+      domIframes: [
+        iframe({ src: "", srcdoc: true, id: "inline" }),
+        iframe({ domIndex: 1, src: "about:blank", name: "hidden" }),
+        iframe({ domIndex: 2, src: "about:blank" }),
+      ],
+      extensionFrames: [
+        mainExt,
+        extFrame({ frameId: 3, url: "about:srcdoc" }),
+        extFrame({ frameId: 4, url: "about:blank" }),
+      ],
+      cdpFrames: [
+        mainCdp,
+        cdpFrame({ frameId: "F3", url: "about:srcdoc", name: "inline" }),
+        cdpFrame({ frameId: "F4", url: "about:blank", name: "hidden" }),
+      ],
+    });
+    expect(result.domIframes.map((entry) => entry.cdpFrameIds)).toEqual([["F3"], ["F4"], []]);
+    expect(result.warnings[0]).toBe(
+      "1 iframe(s) have no URL (about:blank or srcdoc): DOM indexes 2. No CDP frame carries their name or id, so their content cannot be matched; give them a name or id attribute, or use frame.switch --index.",
+    );
+  });
+
+  it("explains out-of-process iframes that the CDP frame tree does not list", () => {
+    const result = buildFrameDiagnosis({
+      mainPage: { href: MAIN, title: "Page" },
+      domIframes: [
+        iframe({ src: "https://www.youtube.com/embed/x" }),
+        iframe({ domIndex: 1, src: "https://example.org/", sandbox: "" }),
+      ],
+      extensionFrames: [
+        mainExt,
+        extFrame({ frameId: 54, url: "https://www.youtube.com/embed/x" }),
+        extFrame({
+          frameId: 57,
+          url: "https://example.org/",
+          contentScriptReachable: false,
+          contentScriptError: "Receiving end does not exist.",
+        }),
+      ],
+      cdpFrames: [mainCdp],
+    });
+    expect(result.domIframes.map((entry) => entry.cdpFrameIds)).toEqual([[], []]);
+    expect(result.warnings).toContain(
+      "iframe 0 (https://www.youtube.com/embed/x) is out-of-process: it is missing from this tab's CDP frame tree, so frame.js cannot reach it; its content script answers, so frame.switch, page.read and click by ref work there.",
+    );
+    expect(result.warnings).toContain(
+      "iframe 1 (https://example.org/) is out-of-process: it is missing from this tab's CDP frame tree, so frame.js cannot reach it; its content script is unreachable too, so nothing in this tab can drive it.",
+    );
+    expect(result.warnings.some((line) => line.includes("DOM lists"))).toBe(false);
+  });
+
+  it("reports shadow-hosted iframes and nested frames in the count mismatch", () => {
+    const result = buildFrameDiagnosis({
+      mainPage: { href: MAIN, title: "Page" },
+      domIframes: [
+        iframe({ src: "https://app.example.com/inner", shadowHost: "div#host > x-widget" }),
+      ],
+      extensionFrames: [
+        mainExt,
+        extFrame({ frameId: 5, url: "https://app.example.com/inner" }),
+        extFrame({ frameId: 6, parentFrameId: 5, url: "https://app.example.com/inner/nested" }),
+      ],
+      cdpFrames: [
+        mainCdp,
+        cdpFrame({ frameId: "F5", url: "https://app.example.com/inner" }),
+        cdpFrame({ frameId: "F6", parentId: "F5", url: "https://app.example.com/inner/nested" }),
+      ],
+    });
+    expect(result.domIframes[0].shadowHost).toBe("div#host > x-widget");
+    expect(result.warnings).toEqual([
+      "DOM lists 1 iframe(s) (1 inside open shadow roots) but the extension sees 2 child frame(s), 1 of them nested below another frame; the nested frames account for the difference.",
     ]);
   });
 });

--- a/test/unit/frame-diagnose.test.ts
+++ b/test/unit/frame-diagnose.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFrameDiagnosis,
+  type CdpFrameEntry,
+  type DomIframeEntry,
+  type ExtensionFrameEntry,
+  isBlankFrameUrl,
+  originOf,
+  sandboxBlocksScripts,
+} from "../../src/utils/frame-diagnose";
+
+const MAIN = "https://app.example.com/page";
+
+function iframe(overrides: Partial<DomIframeEntry> = {}): DomIframeEntry {
+  return {
+    domIndex: 0,
+    src: "https://widgets.example.net/embed",
+    srcdoc: false,
+    title: "",
+    name: "",
+    id: "",
+    sandbox: null,
+    allow: "",
+    rect: { x: 0, y: 0, width: 300, height: 200 },
+    ...overrides,
+  };
+}
+
+function extFrame(overrides: Partial<ExtensionFrameEntry> = {}): ExtensionFrameEntry {
+  return {
+    frameId: 7,
+    parentFrameId: 0,
+    url: "https://widgets.example.net/embed",
+    errorOccurred: false,
+    contentScriptReachable: true,
+    contentScript: { href: "https://widgets.example.net/embed", readyState: "complete" },
+    ...overrides,
+  };
+}
+
+const mainExt: ExtensionFrameEntry = {
+  frameId: 0,
+  parentFrameId: -1,
+  url: MAIN,
+  errorOccurred: false,
+  contentScriptReachable: true,
+};
+
+function cdpFrame(overrides: Partial<CdpFrameEntry> = {}): CdpFrameEntry {
+  return {
+    frameId: "F2",
+    parentId: "F1",
+    url: "https://widgets.example.net/embed",
+    name: "",
+    ...overrides,
+  };
+}
+
+const mainCdp: CdpFrameEntry = { frameId: "F1", url: MAIN, name: "" };
+
+describe("helpers", () => {
+  it("computes origins and blank URLs", () => {
+    expect(originOf("https://a.example.com/x?y")).toBe("https://a.example.com");
+    expect(originOf("about:blank")).toBeNull();
+    expect(originOf("not a url")).toBeNull();
+    expect(isBlankFrameUrl("")).toBe(true);
+    expect(isBlankFrameUrl("about:blank?x")).toBe(true);
+    expect(isBlankFrameUrl("about:srcdoc")).toBe(true);
+    expect(isBlankFrameUrl("https://a/")).toBe(false);
+  });
+
+  it("knows when a sandbox blocks scripts", () => {
+    expect(sandboxBlocksScripts(null)).toBe(false);
+    expect(sandboxBlocksScripts("")).toBe(true);
+    expect(sandboxBlocksScripts("allow-forms")).toBe(true);
+    expect(sandboxBlocksScripts("allow-forms allow-scripts")).toBe(false);
+  });
+});
+
+describe("buildFrameDiagnosis", () => {
+  it("correlates a healthy cross-origin iframe across all three inventories", () => {
+    const result = buildFrameDiagnosis({
+      mainPage: { href: MAIN, title: "Page" },
+      domIframes: [iframe()],
+      extensionFrames: [mainExt, extFrame()],
+      cdpFrames: [mainCdp, cdpFrame()],
+    });
+
+    expect(result.mainPage.origin).toBe("https://app.example.com");
+    expect(result.counts).toEqual({ domIframes: 1, extensionFrames: 2, cdpFrames: 2 });
+    expect(result.domIframes[0]).toMatchObject({
+      crossOrigin: true,
+      blank: false,
+      zeroSize: false,
+      scriptsBlocked: false,
+      extensionFrameIds: [7],
+      cdpFrameIds: ["F2"],
+    });
+    expect(result.extensionFrames[0].isMain).toBe(true);
+    expect(result.extensionFrames[1].crossOrigin).toBe(true);
+    expect(result.cdpFrames[1].extensionFrameIds).toEqual([7]);
+    expect(result.warnings).toEqual([
+      "1 cross-origin iframe(s): selectors from the main page do not reach them; switch with frame.switch first.",
+    ]);
+  });
+
+  it("returns no warnings for a page without frames", () => {
+    const result = buildFrameDiagnosis({
+      mainPage: { href: MAIN, title: "Page" },
+      domIframes: [],
+      extensionFrames: [mainExt],
+      cdpFrames: [mainCdp],
+    });
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("explains blank and srcdoc iframes and points at the CDP ids", () => {
+    const result = buildFrameDiagnosis({
+      mainPage: { href: MAIN, title: "Page" },
+      domIframes: [iframe({ src: "", srcdoc: true }), iframe({ domIndex: 1, src: "about:blank" })],
+      extensionFrames: [
+        mainExt,
+        extFrame({ frameId: 3, url: "about:blank" }),
+        extFrame({ frameId: 4, url: "about:srcdoc" }),
+      ],
+      cdpFrames: [mainCdp, cdpFrame({ frameId: "F3", url: "about:blank" })],
+    });
+
+    expect(result.domIframes.map((entry) => entry.blank)).toEqual([true, true]);
+    expect(result.domIframes[0].extensionFrameIds).toEqual([]);
+    expect(result.warnings[0]).toContain(
+      "2 iframe(s) have no URL (about:blank or srcdoc): DOM indexes 0, 1",
+    );
+    expect(result.warnings.some((line) => line.includes("has no matching extension frame"))).toBe(
+      false,
+    );
+  });
+
+  it("flags unreachable content scripts, navigation errors and CDP-only frames", () => {
+    const result = buildFrameDiagnosis({
+      mainPage: { href: MAIN, title: "Page" },
+      domIframes: [iframe({ src: "https://app.example.com/inner" })],
+      extensionFrames: [
+        mainExt,
+        extFrame({
+          frameId: 5,
+          url: "https://app.example.com/inner",
+          contentScriptReachable: false,
+          contentScriptError: "Could not establish connection",
+          errorOccurred: true,
+        }),
+      ],
+      cdpFrames: [
+        mainCdp,
+        cdpFrame({ frameId: "F5", url: "https://app.example.com/inner" }),
+        cdpFrame({ frameId: "F9", url: "https://oop.example.org/" }),
+      ],
+    });
+
+    expect(result.domIframes[0].crossOrigin).toBe(false);
+    expect(result.warnings).toEqual([
+      "extension frame 5 (https://app.example.com/inner) has no reachable content script (Could not establish connection): page.read, click by ref and frame.switch will not work inside it; frame.js with its CDP frame id may.",
+      "extension frame 5 (https://app.example.com/inner) reported a navigation error.",
+      "CDP frame F9 (https://oop.example.org/) is not reported by chrome.webNavigation: likely out-of-process or detached; only frame.js can reach it.",
+    ]);
+  });
+
+  it("flags sandboxes without allow-scripts, zero-size frames and ambiguous URL matches", () => {
+    const result = buildFrameDiagnosis({
+      mainPage: { href: MAIN, title: "Page" },
+      domIframes: [
+        iframe({ sandbox: "allow-forms", rect: { x: 0, y: 0, width: 0, height: 0 } }),
+        iframe({ domIndex: 1 }),
+      ],
+      extensionFrames: [mainExt, extFrame({ frameId: 7 }), extFrame({ frameId: 8 })],
+      cdpFrames: [mainCdp],
+    });
+
+    expect(result.domIframes[0]).toMatchObject({
+      scriptsBlocked: true,
+      zeroSize: true,
+      extensionFrameIds: [7, 8],
+    });
+    expect(result.warnings.some((line) => line.includes("sandboxed without allow-scripts"))).toBe(
+      true,
+    );
+    expect(result.warnings.some((line) => line.includes("rendered at 0x0"))).toBe(true);
+    expect(
+      result.warnings.filter((line) => line.includes("matches 2 extension frames by URL (7, 8)")),
+    ).toHaveLength(2);
+  });
+
+  it("reports DOM iframes the extension does not list and count mismatches", () => {
+    const result = buildFrameDiagnosis({
+      mainPage: { href: MAIN, title: "Page" },
+      domIframes: [iframe({ src: "https://late.example.com/" })],
+      extensionFrames: [mainExt],
+      cdpFrames: [mainCdp],
+    });
+    expect(result.warnings).toEqual([
+      "iframe 0 (https://late.example.com/) has no matching extension frame: it may still be loading, be blocked, or have navigated elsewhere.",
+      "1 cross-origin iframe(s): selectors from the main page do not reach them; switch with frame.switch first.",
+      "DOM lists 1 iframe(s) but the extension sees 0 child frame(s); nested or detached frames account for the difference.",
+    ]);
+  });
+});

--- a/test/unit/host-helpers.test.ts
+++ b/test/unit/host-helpers.test.ts
@@ -543,3 +543,12 @@ describe("formatToolContent", () => {
     });
   });
 });
+
+describe("frame.diagnose", () => {
+  it("maps to FRAME_DIAGNOSE with the tab id", () => {
+    expect(helpers.mapToolToMessage("frame.diagnose", {}, 9)).toEqual({
+      type: "FRAME_DIAGNOSE",
+      tabId: 9,
+    });
+  });
+});

--- a/test/unit/service-worker/frame-diagnose-handlers.test.ts
+++ b/test/unit/service-worker/frame-diagnose-handlers.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createChromeMock, resetChromeMock } from "../../mocks/chrome";
+
+vi.mock("../../../src/native/port-manager", () => ({
+  initNativeMessaging: vi.fn(),
+  postToNativeHost: vi.fn(),
+}));
+
+async function loadHandleMessage() {
+  vi.resetModules();
+  (globalThis as any).chrome = createChromeMock();
+  const mod = await import("../../../src/service-worker/index");
+  return mod.handleMessage;
+}
+
+const inventory = {
+  href: "https://app.example.com/page",
+  title: "Page",
+  iframes: [
+    {
+      domIndex: 0,
+      src: "https://widgets.example.net/embed",
+      srcdoc: false,
+      title: "",
+      name: "widget",
+      id: "",
+      sandbox: null,
+      allow: "",
+      rect: { x: 0, y: 0, width: 300, height: 200 },
+    },
+  ],
+};
+
+function mockCdp(
+  chrome: ReturnType<typeof createChromeMock>,
+  options: { frameTreeError?: string } = {},
+) {
+  chrome.debugger.sendCommand.mockImplementation(async (_target: any, method: string) => {
+    if (method === "Runtime.evaluate") {
+      return { result: { value: inventory, type: "object" } };
+    }
+    if (method === "Page.getFrameTree") {
+      if (options.frameTreeError) {
+        throw new Error(options.frameTreeError);
+      }
+      return {
+        frameTree: {
+          frame: { id: "F1", url: "https://app.example.com/page", name: "" },
+          childFrames: [
+            { frame: { id: "F2", url: "https://widgets.example.net/embed", name: "widget" } },
+          ],
+        },
+      };
+    }
+    return {};
+  });
+}
+
+describe("FRAME_DIAGNOSE", () => {
+  beforeEach(() => {
+    resetChromeMock();
+  });
+
+  it("combines the DOM inventory, webNavigation frames with PING results and the CDP tree", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    mockCdp(chrome);
+    chrome.webNavigation.getAllFrames.mockResolvedValue([
+      { frameId: 0, parentFrameId: -1, url: "https://app.example.com/page", errorOccurred: false },
+      {
+        frameId: 7,
+        parentFrameId: 0,
+        url: "https://widgets.example.net/embed",
+        errorOccurred: false,
+      },
+    ]);
+    chrome.tabs.sendMessage.mockImplementation(async (_tabId: number, _msg: any, opts: any) => {
+      if (opts.frameId === 0) {
+        return { success: true, href: "https://app.example.com/page", readyState: "complete" };
+      }
+      throw new Error("Could not establish connection");
+    });
+
+    const result = await handleMessage({ type: "FRAME_DIAGNOSE", tabId: 5 }, {});
+
+    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(5, { type: "PING" }, { frameId: 0 });
+    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(5, { type: "PING" }, { frameId: 7 });
+    expect(result.success).toBeUndefined();
+    expect(result.mainPage).toEqual({
+      href: "https://app.example.com/page",
+      title: "Page",
+      origin: "https://app.example.com",
+    });
+    expect(result.counts).toEqual({ domIframes: 1, extensionFrames: 2, cdpFrames: 2 });
+    expect(result.domIframes[0]).toMatchObject({
+      extensionFrameIds: [7],
+      cdpFrameIds: ["F2"],
+      crossOrigin: true,
+    });
+    expect(result.extensionFrames[1]).toMatchObject({
+      frameId: 7,
+      contentScriptReachable: false,
+      contentScriptError: "Could not establish connection",
+    });
+    expect(result.extensionFrames[0].contentScript).toEqual({
+      href: "https://app.example.com/page",
+      readyState: "complete",
+    });
+    expect(
+      result.warnings.some(
+        (line: string) =>
+          line.includes("extension frame 7") && line.includes("no reachable content script"),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps going when the CDP frame tree is unavailable", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    mockCdp(chrome, { frameTreeError: "Target closed" });
+    chrome.webNavigation.getAllFrames.mockResolvedValue([
+      { frameId: 0, parentFrameId: -1, url: "https://app.example.com/page", errorOccurred: false },
+    ]);
+    chrome.tabs.sendMessage.mockResolvedValue({
+      success: true,
+      href: "https://app.example.com/page",
+      readyState: "complete",
+    });
+
+    const result = await handleMessage({ type: "FRAME_DIAGNOSE", tabId: 5 }, {});
+    expect(result.counts.cdpFrames).toBe(0);
+    expect(result.warnings[0]).toBe("CDP frame tree unavailable: Target closed");
+  });
+
+  it("requires a tab id", async () => {
+    const handleMessage = await loadHandleMessage();
+    await expect(handleMessage({ type: "FRAME_DIAGNOSE" }, {})).rejects.toThrow(
+      "No tabId provided",
+    );
+  });
+});

--- a/test/unit/tool-scope.test.ts
+++ b/test/unit/tool-scope.test.ts
@@ -48,6 +48,13 @@ describe("tool scope classification", () => {
     expect(classified.resourceKeys).toEqual([`file:${require("node:path").resolve("same.har")}`]);
   });
 
+  it("keeps frame.diagnose on the tab lane", () => {
+    expect(classifyTool("frame.diagnose", {})).toMatchObject({
+      scope: "tab",
+      targetUse: "default-tab",
+    });
+  });
+
   it("fails conservative for unclassified browser commands", () => {
     expect(classifyTool("future.browser.command")).toMatchObject({
       scope: "browser-write",


### PR DESCRIPTION
## Summary

"Why does my selector never match?" is usually "which iframe is that widget in, and can Surf reach it?". `surf frame.diagnose [--json]` shows the three frame views side by side and explains the mismatches:

- DOM `<iframe>` elements (walking open shadow roots; each entry carries `shadowHost` when applicable) with `src`/`srcdoc`, size, `name`/`id`, `sandbox`, `blank`, `crossOrigin`, `scriptsBlocked`, `zeroSize`.
- Extension frames from `chrome.webNavigation.getAllFrames` with a content-script `PING` per frame (`contentScriptReachable`, `frame.switch` ids).
- The CDP frame tree (`frame.js` ids).
- Correlation by URL, and by `name`/`id` for `srcdoc`/`about:blank` frames (CDP names them after the iframe's `name`/`id`); per DOM entry `extensionFrameIds` / `cdpFrameIds`.
- Warnings that name the command that still works: srcdoc/blank frames (CDP id only), sandboxes without `allow-scripts`, cross-origin frames, out-of-process iframes that are absent from the tab's CDP tree (`frame.js` cannot reach them; `frame.switch`, `page.read` and click-by-ref work when the content script answers), unreachable content scripts, still-loading frames, and count mismatches explained by nested or shadow-hosted frames. Ambiguous matches (several frames with the same URL, frames that navigated after load) are reported as ambiguous rather than guessed.
- The text report abbreviates kilobyte-long embed URLs; `--json` keeps everything.

Two commits: the tool itself, and the follow-up from driving it on real pages (shadow roots, name/id matching, out-of-process warning, count explanation, URL abbreviation). The content-script `PING` handler is added here because this is the tool that uses it.

## Observed on real pages (Brave 151, throwaway profile)

- developer.mozilla.org `<iframe>` reference (live samples rendered by `mdn-play-runner` custom elements, each an out-of-process iframe): first version reported "DOM iframes: 0, extension frames: 7"; now 3 DOM iframes `in shadow root of mdn-live-sample-result > mdn-play-runner`, the mismatch explained, 60 ms, 3.6 KB text.
- Own fixture (YouTube embed, srcdoc, example.com, `sandbox=""` iana.org, hidden `about:blank`, iframe inside an open shadow root): every frame inventoried, srcdoc/blank matched to their CDP frames by name, four out-of-process warnings each saying which commands still work, no false mismatch warning. 45-66 ms per call.

## Questions for the maintainer

1. Correlation is by URL and `name`/`id`. Mapping `documentId` (webNavigation) to CDP `frameId` via `Target.getTargets` would resolve ambiguous cases and could offer the out-of-process frame's own target id to `frame.js`, at the cost of extra CDP round-trips. Worth a follow-up?

## Attribution

The three-view frame diagnosis was studied in the surf-cli Go fork by Manuel Odendahl (MIT) and re-implemented from scratch in TypeScript for this codebase; no code was copied.

## Validation

- `npm ci --ignore-scripts`
- `npm run lint` (existing `FakeNode` warning only)
- `npm run check`
- `npm test` — 62 files, 789 tests passed, 2 skipped (+16 vs `main`: correlation, warnings, shadow roots, name/id matching, out-of-process warning, service-worker handler, host mapping, tool scope)
- `npm run build`
- `npm run test:e2e:chrome` with the pinned Chrome for Testing 152.0.7977.54 — pass; new `/frames` fixture with same-origin, srcdoc, cross-origin (second local server), sandboxed (`allow-forms` only) and shadow-hosted iframes asserts the inventory, the extension/CDP correlation (srcdoc matched by id), the flags, the content-script PING and the warnings

Co-authored with Claude Code.
