### PR TITLE
feat: surf extract + js --options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 - **Typed page readiness** - `surf wait.ready` polls with a bounded budget and reports `ready`, `empty`, `login`, `challenge`, `not-found` or `error` instead of timing out silently; negative states exit with `page_login`, `page_challenge`, `page_not_found`, `page_error` or `page_timeout`, and `--accept` returns them to the caller. `surf page.readiness` classifies the page once. Detection uses visible UI state and the caller's expectations (`--selector`, `--text`, `--url-prefix`, `--empty-text`), not site-specific selectors.
+- **`surf extract`** - Runs a read-only page-side script in an owned tab (`tab.new` -> `wait.ready` -> `js` -> `tab.close`) with bounded fresh-tab retry on transient failures, a zero-rows-is-failure invariant (`--allow-empty`, `--empty-text`), a `SURF_OPTIONS` prelude (`--options`) and Markdown or `--json` output. `--tab-id`/`--session` read an existing tab in place without retry.
+- **`surf js --options`** - Exposes a JSON object to `js`/`frame.js` scripts as a frozen `SURF_OPTIONS` constant.
 
 ## [2.18.0] - 2026-09-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **Typed page readiness** - `surf wait.ready` polls with a bounded budget and reports `ready`, `empty`, `login`, `challenge`, `not-found` or `error` instead of timing out silently; negative states exit with `page_login`, `page_challenge`, `page_not_found`, `page_error` or `page_timeout`, and `--accept` returns them to the caller. `surf page.readiness` classifies the page once. Detection uses visible UI state and the caller's expectations (`--selector`, `--text`, `--url-prefix`, `--empty-text`), not site-specific selectors.
+
 ## [2.18.0] - 2026-09-04
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -580,10 +580,26 @@ surf wait.ready --url-prefix "https://app.example.com/" --empty-text "No results
 surf wait.ready --accept login --json   # {"state":"login","evidence":[...]} instead of an error
 ```
 
+Note that `js` on a tab that is not the active tab of its window can take many seconds in Brave (background-tab throttling of the DevTools session); `page.read` and `page.readiness` are unaffected because they run in the content script. Switch to the tab first (`surf tab.switch <id>`) or let `extract` open its own tab.
+
+### Extraction
+
+`surf extract` runs a read-only page-side script in a tab it owns: `tab.new -> wait.ready -> js -> tab.close`. Transient target failures, readiness timeouts and zero-row results are retried in a fresh tab (`--retry`, default 1); login bounces, challenges and not-found pages are not, because the next tab would land on the same page. Zero rows is a failure unless `--allow-empty` is set or the page showed its own empty state (`--empty-text`), which separates "no results" from "logged out, blocked, or the selectors missed". The script must `return` JSON (an array, or an object with a `rows`/`items`/`results` array) and reads its parameters from a frozen `SURF_OPTIONS` constant.
+
+```bash
+surf extract "https://example.com/list" --file rows.js --ready-selector ".item"          # Markdown table
+surf extract "https://example.com/search?q=x" --file rows.js --options '{"limit": 20}' \
+  --empty-text "No results" --json                                                         # {data, rows, rowCount, attempts, readiness}
+surf extract --tab-id 42 --code 'return [...document.querySelectorAll("h2")].map(h => ({ title: h.textContent }))'
+```
+
+With `--tab-id` or `--session` the script runs in that tab in place (navigating only when a URL is given), with no retry and no close. The command replays its whole sequence on retry, so scripts that mutate state belong in `surf js` on an explicit target, not in `extract`.
+
 ### Other
 
 ```bash
 surf js "return document.title"     # Execute JavaScript
+surf js --file script.js --options '{"limit": 20}'   # Script reads SURF_OPTIONS.limit
 surf record --duration 2000 --fps 10 --output /tmp/anim.gif      # Animated GIF capture
 surf animate-audit --selector ".thing" --duration 2000 --fps 10  # JSON animation timeline
 surf perf-audit --duration 3000 --output /tmp/perf.json           # PerformanceObserver snapshot
@@ -947,6 +963,7 @@ echo '{"type":"tool_request","method":"execute_tool","params":{"tool":"tab.list"
 | `window.*` | `new`, `list`, `focus`, `close`, `resize` |
 | `tab.*` | `list`, `new`, `switch`, `close`, `name`, `unname`, `named`, `group`, `ungroup`, `groups`, `reload` |
 | `scroll.*` | `top`, `bottom`, `to`, `info` |
+| `extract` | `extract` |
 | `page.*` | `read`, `text`, `state`, `readiness` |
 | `locate.*` | `role`, `text`, `label` |
 | `element.*` | `styles` |

--- a/README.md
+++ b/README.md
@@ -569,6 +569,15 @@ surf wait 2                         # Wait 2 seconds
 surf wait.element ".loaded"         # Wait for element
 surf wait.network                   # Wait for network idle
 surf wait.url "/dashboard"          # Wait for URL pattern
+surf wait.ready --selector ".results"   # Wait for content, fail fast on a bounce
+surf page.readiness --json          # Classify the page once
+```
+
+`wait.ready` polls with a bounded budget and reports a typed state instead of timing out silently: `ready`, `empty` (the page showed its own no-results message, `--empty-text`), or one of the negative states `login`, `challenge` (anti-bot interstitial), `not-found`, `error`. A negative state exits non-zero with codes `page_login`, `page_challenge`, `page_not_found`, `page_error`; `page_timeout` reports the last observed state. Pass `--accept login` to return a state to the caller instead. Detection uses visible UI state (a rendered password field, a login-looking route, the page's own wording, `--url-prefix` bounces), never site-specific selectors.
+
+```bash
+surf wait.ready --url-prefix "https://app.example.com/" --empty-text "No results"
+surf wait.ready --accept login --json   # {"state":"login","evidence":[...]} instead of an error
 ```
 
 ### Other
@@ -938,11 +947,11 @@ echo '{"type":"tool_request","method":"execute_tool","params":{"tool":"tab.list"
 | `window.*` | `new`, `list`, `focus`, `close`, `resize` |
 | `tab.*` | `list`, `new`, `switch`, `close`, `name`, `unname`, `named`, `group`, `ungroup`, `groups`, `reload` |
 | `scroll.*` | `top`, `bottom`, `to`, `info` |
-| `page.*` | `read`, `text`, `state` |
+| `page.*` | `read`, `text`, `state`, `readiness` |
 | `locate.*` | `role`, `text`, `label` |
 | `element.*` | `styles` |
 | `frame.*` | `list`, `switch`, `main`, `js` |
-| `wait.*` | `element`, `network`, `url`, `dom`, `load` |
+| `wait.*` | `element`, `network`, `url`, `dom`, `load`, `ready` |
 | `cookie` / `cookie.*` | `list`, `get`, `set`, `clear`, `delete` |
 | `bookmark.*` | `add`, `remove`, `list` |
 | `history.*` | `list`, `search` |

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -1771,6 +1771,7 @@ Purpose: control Chrome from shell. Commands are \`surf <command> [args] [option
 Core loop: navigate -> wait/read -> act -> screenshot/read.
 Navigate: surf navigate "https://example.com"    # alias: surf go "..."
 Wait after navigation: surf wait 2                # or wait.load for load complete
+Wait for real content: surf wait.ready --selector ".results"   # fails fast with page_login / page_challenge / page_not_found; --accept login returns the state
 Read DOM/refs: surf page.read --depth 3 --compact # alias: surf read
 Refs: use e1/e2 refs from page.read; prefer refs over CSS when available.
 Click ref: surf click e5

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -16,7 +16,9 @@ const {
   validateWorkflowArgs,
   validateWorkflowFile,
 } = require("./workflow-definition.cjs");
-const { executeDoSteps } = require("./do-executor.cjs");
+const { executeDoSteps, sendDoRequest } = require("./do-executor.cjs");
+const { runExtraction, renderExtractionMarkdown } = require("./extract.cjs");
+const { parseScriptOptions } = require("./script-options.cjs");
 const { openClientTransport } = require("./client-transport.cjs");
 const { version: VERSION } = require("../package.json");
 const {
@@ -905,6 +907,39 @@ const TOOLS = {
       },
       "hover": { desc: "Hover over element", args: [], opts: { ref: "Element ref", x: "X coordinate", y: "Y coordinate" } },
       "drag": { desc: "Drag between points", args: [], opts: { from: "Start x,y", to: "End x,y" } },
+    }
+  },
+  extract: {
+    desc: "Read-only extraction in an owned tab",
+    commands: {
+      "extract": {
+        desc: "Open a URL in a fresh tab, wait until it is ready, run a page-side script that returns JSON, print rows",
+        args: ["url"],
+        opts: {
+          file: "Script file; must `return` JSON (an array, or an object with a rows/items/results array)",
+          code: "Inline script instead of --file",
+          options: "JSON object exposed to the script as SURF_OPTIONS",
+          "options-file": "Read the options object from a JSON file",
+          "ready-selector": "wait.ready --selector before extracting",
+          "ready-text": "wait.ready --text before extracting",
+          "ready-url-prefix": "wait.ready --url-prefix; a different URL is a bounce",
+          "empty-text": "wait.ready --empty-text; lets an explicit no-results page pass the zero-rows check",
+          "ready-timeout": "Readiness timeout in ms (default: 20000)",
+          rows: "Key of the row array in the script result (default: auto)",
+          retry: "Fresh-tab retries on transient failures (default: 1, max: 5)",
+          "retry-delay-ms": "Delay between attempts (default: 500)",
+          "allow-empty": "Accept zero rows",
+          "keep-tab": "Leave the owned tab open on success and report its id",
+          "tab-id": "Extract from an existing tab instead (no fresh tab, no retry; navigates only if a URL is given)",
+          session: "Extract from a session's tab instead (same rules as --tab-id)",
+          json: "Print {data, rows, rowCount, attempts, readiness} as JSON",
+        },
+        examples: [
+          { cmd: 'extract "https://example.com/list" --file rows.js --ready-selector ".item"', desc: "Fresh tab, wait for items, print a Markdown table" },
+          { cmd: 'extract "https://example.com/search?q=x" --file rows.js --options \'{"limit": 20}\' --empty-text "No results" --json', desc: "Options prelude, explicit empty state, JSON output" },
+          { cmd: "extract --tab-id 42 --code 'return [...document.querySelectorAll(\"h2\")].map(h => ({ title: h.textContent }))'", desc: "Read an existing tab in place" },
+        ]
+      },
     }
   },
   js: {
@@ -2600,6 +2635,139 @@ if (args[0] === "do") {
       console.error(`Error: ${error.message}`);
       process.exit(1);
     });
+  return;
+}
+
+// Handle `surf extract`: a read-only page-side script in an owned tab with a
+// readiness gate, bounded fresh-tab retry and the zero-rows invariant.
+if (args[0] === "extract") {
+  const extractArgs = args.slice(1);
+  const valueFlags = new Set([
+    "file", "code", "options", "options-file", "ready-selector", "ready-text", "ready-url-prefix",
+    "ready-timeout", "ready-interval", "empty-text", "rows", "retry", "retry-delay-ms",
+    "tab-id", "window-id", "session",
+  ]);
+  const boolFlags = new Set(["allow-empty", "keep-tab", "json", "markdown", "no-wait", "no-lock", "help"]);
+  const opts = {};
+  let url = null;
+  for (let i = 0; i < extractArgs.length; i++) {
+    const arg = extractArgs[i];
+    if (arg === "-f") {
+      opts.file = extractArgs[++i];
+    } else if (arg.startsWith("--")) {
+      const key = arg.slice(2);
+      if (boolFlags.has(key)) opts[key] = true;
+      else if (valueFlags.has(key)) opts[key] = extractArgs[++i];
+      else {
+        console.error(`Error: unknown extract option --${key}`);
+        process.exit(1);
+      }
+    } else if (url === null) {
+      url = arg;
+    } else {
+      console.error(`Error: unexpected argument ${arg}`);
+      process.exit(1);
+    }
+  }
+  if (opts.help) {
+    showToolHelp("extract");
+    process.exit(0);
+  }
+  const wantJson = opts.json === true;
+  const fail = (code, message, details) => {
+    if (wantJson) {
+      console.log(JSON.stringify({ error: { code, message, ...(details ? { details } : {}) } }, null, 2));
+    } else {
+      console.error(`Error: ${message}${code ? ` [${code}]` : ""}`);
+    }
+    process.exit(1);
+  };
+
+  let code = null;
+  try {
+    if (opts.file && opts.code) fail("usage", "use either --file or --code, not both");
+    if (opts.file) code = fs.readFileSync(opts.file, "utf8");
+    else if (typeof opts.code === "string") code = opts.code;
+    else fail("usage", "an extraction script is required: --file script.js or --code 'return {...}'");
+  } catch (error) {
+    fail("usage", `Failed to read script: ${error.message}`);
+  }
+
+  let scriptOptions = {};
+  try {
+    if (opts.options && opts["options-file"]) fail("usage", "use either --options or --options-file, not both");
+    if (opts["options-file"]) scriptOptions = parseScriptOptions(fs.readFileSync(opts["options-file"], "utf8"));
+    else scriptOptions = parseScriptOptions(opts.options);
+  } catch (error) {
+    fail("usage", error.message);
+  }
+
+  const toInt = (key, fallback) => {
+    if (opts[key] === undefined) return fallback;
+    const parsed = parseInt(opts[key], 10);
+    if (Number.isNaN(parsed) || parsed < 0) fail("usage", `--${key} must be a non-negative integer`);
+    return parsed;
+  };
+
+  const targetOptions = resolveEarlyTargetOptions(extractArgs);
+  const hasTarget = Boolean(targetOptions.tabId || targetOptions.windowId || targetOptions.session);
+  if (!hasTarget && !url) fail("usage", "a URL is required unless --tab-id, --window-id or --session names the page to read");
+
+  const settings = {
+    code,
+    url: url ?? undefined,
+    options: scriptOptions,
+    ready: {
+      selector: opts["ready-selector"],
+      text: opts["ready-text"],
+      urlPrefix: opts["ready-url-prefix"],
+      emptyText: opts["empty-text"],
+      timeout: toInt("ready-timeout", undefined),
+      interval: toInt("ready-interval", undefined),
+    },
+    retry: { count: toInt("retry", undefined), delayMs: toInt("retry-delay-ms", undefined) },
+    keepTab: opts["keep-tab"] === true,
+    allowEmpty: opts["allow-empty"] === true,
+    rowsKey: opts.rows,
+    target: hasTarget,
+  };
+
+  const runExtract = async () => {
+    let transport;
+    try {
+      transport = await openClientTransport(endpoint);
+      const baseContext = { ...targetOptions, endpoint, transport };
+      const executeTool = (toolName, toolArgs, ownedTabId) => {
+        const context = ownedTabId
+          ? { tabId: ownedTabId, admission: targetOptions.admission, endpoint, transport }
+          : baseContext;
+        return sendDoRequest(toolName, toolArgs, context);
+      };
+      const result = await runExtraction({
+        ...settings,
+        executeTool,
+        onEvent: (event) => {
+          if (wantJson) return;
+          if (event.type === "attempt" && event.of > 1) console.error(`[surf] extract attempt ${event.attempt}/${event.of}`);
+          if (event.type === "attempt-failed" && event.retryable) console.error(`[surf] attempt ${event.attempt} failed (${event.error}); retrying with a fresh tab`);
+        },
+      });
+      if (wantJson) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        console.log(renderExtractionMarkdown(result.data, result.rows, { title: url ? `Extraction from ${url}` : "Extraction" }));
+        if (result.tabId) console.error(`[surf] tab ${result.tabId} left open (--keep-tab)`);
+      }
+      return 0;
+    } catch (error) {
+      fail(error.code || "extraction_failed", error.message, error.details);
+      return 1;
+    } finally {
+      await transport?.close();
+    }
+  };
+
+  runExtract().then((exitCode) => process.exit(exitCode));
   return;
 }
 

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -18,7 +18,7 @@ const {
 } = require("./workflow-definition.cjs");
 const { executeDoSteps, sendDoRequest } = require("./do-executor.cjs");
 const { runExtraction, renderExtractionMarkdown } = require("./extract.cjs");
-const { parseScriptOptions } = require("./script-options.cjs");
+const { applyOptionsPrelude, parseScriptOptions } = require("./script-options.cjs");
 const { openClientTransport } = require("./client-transport.cjs");
 const { version: VERSION } = require("../package.json");
 const {
@@ -948,11 +948,13 @@ const TOOLS = {
       "js": {
         desc: "Execute JavaScript (use 'return' for values)",
         args: ["code"],
-        opts: { file: "Run JS from file" },
+        opts: { file: "Run JS from file", options: "JSON object exposed to the script as a frozen SURF_OPTIONS constant" },
         examples: [
           { cmd: 'js "return document.title"', desc: "Get title" },
           { cmd: 'js "document.body.style.background = \'red\'"', desc: "Run code" },
           { cmd: "js --file script.js", desc: "Run file" },
+          { cmd: 'js --file script.js --options \'{"limit": 20}\'', desc: "Run file with SURF_OPTIONS.limit" },
+          { cmd: 'js "piHelpers.setValue(document.querySelector(\'#q\'), \'hello\')"', desc: "Set a framework-controlled input" },
         ]
       },
     }
@@ -1220,7 +1222,7 @@ const TOOLS = {
       "frame.js": {
         desc: "Execute JS in specific frame",
         args: ["code"],
-        opts: { id: "Frame ID from frame.list", file: "Run JS from file" },
+        opts: { id: "Frame ID from frame.list", file: "Run JS from file", options: "JSON object exposed as SURF_OPTIONS" },
         examples: [
           { cmd: 'frame.js "return document.title" --id frame1', desc: "JS in specific frame" },
         ]
@@ -3178,6 +3180,17 @@ if ((tool === "js" || tool === "frame.js") && toolArgs.file) {
     delete toolArgs.file;
   } catch (e) {
     console.error(`Error: Failed to read file: ${e.message}`);
+    process.exit(1);
+  }
+}
+
+if ((tool === "js" || tool === "frame.js") && toolArgs.options !== undefined) {
+  try {
+    if (typeof toolArgs.code !== "string") throw new Error("--options needs code (inline or --file)");
+    toolArgs.code = applyOptionsPrelude(toolArgs.code, toolArgs.options);
+    delete toolArgs.options;
+  } catch (e) {
+    console.error(`Error: ${e.message}`);
     process.exit(1);
   }
 }

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -1820,7 +1820,8 @@ Record animation: surf record --duration 2000 --fps 10 --output /tmp/anim.gif
 Video recording: surf video start ./demo.webm --fps 30; surf video stop
 Animation audit: surf animate-audit --selector ".thing" --duration 2000 --fps 10
 Performance audit: surf perf-audit --duration 3000 --trigger "click:.cta" --output /tmp/perf.json
-JavaScript: surf js "return document.title"
+JavaScript: surf js "return document.title"       # --file script.js --options '{"limit":20}' exposes SURF_OPTIONS
+Extract rows (read-only, owned tab): surf extract "https://example.com/list" --file rows.js --ready-selector ".item" --json
 Scroll: surf scroll down 800 | surf scroll up 400 | surf scroll bottom | surf scroll top
 Find by semantics: surf locate.role button --name "Submit" --action click
 Device/viewport: surf emulate.device "iPhone 14" | surf resize 375 812

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -721,6 +721,17 @@ const TOOLS = {
         examples: [{ cmd: "page.save --output page.html", desc: "Save current document HTML" }],
       },
       "page.state": { desc: "Get page state (modals, loading, etc.)", args: [] },
+      "page.readiness": {
+        desc: "Classify the page once: ready, empty, loading, login, challenge, not-found, error",
+        args: [],
+        opts: {
+          selector: "Visible CSS selector that marks a ready page",
+          text: "Page text that marks a ready page",
+          "url-prefix": "Expected URL prefix",
+          "empty-text": "Text of an explicit no-results render",
+        },
+        examples: [{ cmd: "page.readiness --json", desc: "State plus evidence as JSON" }]
+      },
     }
   },
   locate: {
@@ -824,6 +835,24 @@ const TOOLS = {
       },
       "wait.dom": { desc: "Wait for DOM to stabilize", args: [], opts: { stable: "Stability window in ms (default: 100)", timeout: "Max wait time in ms" } },
       "wait.load": { desc: "Wait for page to fully load", args: [], opts: { timeout: "Max wait time in ms (default: 30000)" } },
+      "wait.ready": {
+        desc: "Wait until the page is ready, or fail fast with a typed state (challenge, login, not-found, error)",
+        args: [],
+        opts: {
+          selector: "Visible CSS selector that marks a ready page",
+          text: "Page text that marks a ready page",
+          "url-prefix": "Expected URL prefix; anything else is a bounce",
+          "empty-text": "Text of an explicit no-results render (reports state 'empty')",
+          accept: "Negative states to return instead of fail (comma list)",
+          timeout: "Max wait time in ms (default: 20000, max: 120000)",
+          interval: "Poll interval in ms (default: 400)",
+        },
+        examples: [
+          { cmd: 'wait.ready --selector ".results"', desc: "Wait for content; fail fast on a login bounce" },
+          { cmd: 'wait.ready --url-prefix "https://app.example.com/" --empty-text "No results"', desc: "Distinguish empty from blocked" },
+          { cmd: "wait.ready --accept login --json", desc: "Return the login state to the caller" },
+        ]
+      },
     }
   },
   input: {
@@ -1614,7 +1643,8 @@ const ALL_SOCKET_TOOLS = [
   "tab.list", "tab.new", "tab.switch", "tab.close", "tab.move", "tab.name", "tab.unname", "tab.named",
   "tab.group", "tab.ungroup", "tab.groups", "tab.reload",
   "scroll.top", "scroll.bottom", "scroll.to", "scroll.info",
-  "wait.element", "wait.network", "wait.url", "wait.dom", "wait.load",
+  "wait.element", "wait.network", "wait.url", "wait.dom", "wait.load", "wait.ready",
+  "page.readiness",
   "click", "hover", "drag",
   "js", "console", "network",
   "network.get", "network.body", "network.curl", "network.origins",
@@ -1668,7 +1698,9 @@ const SEE_ALSO = {
   "animate-audit": ["screenshot", "record", "perf-audit", "js"],
   "perf-audit": ["record", "animate-audit", "perf.metrics", "console"],
   "search": ["locate.text", "page.read"],
-  "wait.element": ["wait.load", "wait.network"],
+  "wait.element": ["wait.load", "wait.network", "wait.ready"],
+  "wait.ready": ["page.readiness", "wait.element", "wait.url"],
+  "page.readiness": ["wait.ready", "page.state"],
   "wait.load": ["wait.element", "wait.network"],
   "wait.network": ["wait.load", "wait.element"],
   "scroll.to": ["click", "page.read"],
@@ -3822,6 +3854,14 @@ async function handleResponse(response) {
     }
     console.log("\nUsage: surf emulate.device \"<device name>\"");
     console.log('Reset:  surf emulate.device "reset"');
+  } else if (tool === "wait.ready" || tool === "page.readiness") {
+    const lines = [`state: ${data?.state ?? "unknown"}`];
+    if (data?.href) lines.push(`url: ${data.href}`);
+    if (data?.title) lines.push(`title: ${data.title}`);
+    if (typeof data?.waited === "number") lines.push(`waited: ${data.waited}ms (${data.polls} poll${data.polls === 1 ? "" : "s"})`);
+    if (data?.accepted) lines.push("accepted: negative state returned because of --accept");
+    for (const item of Array.isArray(data?.evidence) ? data.evidence : []) lines.push(`- ${item}`);
+    console.log(lines.join("\n"));
   } else if (tool === "js") {
     if (data?.result !== undefined) {
       const val = data.result.value ?? data.result;

--- a/native/extract.cjs
+++ b/native/extract.cjs
@@ -1,0 +1,374 @@
+/**
+ * Read-only page extraction in an owned tab.
+ *
+ * Lifecycle per attempt: tab.new -> wait.ready -> js -> parse -> rows
+ * invariant -> tab.close. A retry always closes the failed tab and opens
+ * a fresh one, so a target whose execution context was invalidated by a
+ * navigation is never reused.
+ *
+ * This runner is for extraction only. It replays the whole sequence on
+ * transient failures, so a script that mutates state (submits a form,
+ * sends a message, changes a setting) could apply its side effect more
+ * than once. Run such scripts through `surf js` on an explicit target.
+ */
+
+const { applyOptionsPrelude } = require("./script-options.cjs");
+
+const DEFAULT_RETRY_COUNT = 1;
+const DEFAULT_RETRY_DELAY_MS = 500;
+const MAX_RETRY_COUNT = 5;
+const ROW_KEY_CANDIDATES = ["rows", "items", "results", "entries", "records", "data"];
+
+/** Error substrings that mean the tab or its execution context went away. */
+const TRANSIENT_TAB_ERROR_MARKERS = [
+  "navigated or closed",
+  "Detached while handling command",
+  "Cannot find default execution context",
+  "Execution context was destroyed",
+  "Receiving end does not exist",
+  "Content script not loaded",
+  "no longer exists",
+  "Target closed",
+];
+
+/** Error codes for which a fresh tab is meaningful. */
+const RETRYABLE_ERROR_CODES = new Set(["empty_result", "page_timeout", "tab_gone", "target_gone"]);
+
+/** Readiness codes where a retry cannot help. */
+const FATAL_READINESS_CODES = new Set(["page_login", "page_challenge", "page_not_found", "page_error"]);
+
+class ExtractError extends Error {
+  constructor(code, message, details = {}) {
+    super(message);
+    this.name = "ExtractError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+function errorMessageOf(error) {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  if (error && typeof error === "object") {
+    const text = error.content?.[0]?.text;
+    if (typeof text === "string") return text;
+    if (typeof error.message === "string") return error.message;
+    return JSON.stringify(error);
+  }
+  return String(error);
+}
+
+function errorCodeOf(error) {
+  if (error && typeof error === "object" && typeof error.code === "string") return error.code;
+  return null;
+}
+
+function isTransientTabError(error) {
+  const message = errorMessageOf(error);
+  return TRANSIENT_TAB_ERROR_MARKERS.some((marker) => message.includes(marker));
+}
+
+/**
+ * Whether a failed attempt is worth a fresh tab. Login bounces, challenges
+ * and not-found pages are not: the next tab lands on the same page.
+ */
+function isRetryableExtractionError(error) {
+  const code = errorCodeOf(error);
+  if (code && FATAL_READINESS_CODES.has(code)) return false;
+  if (code && RETRYABLE_ERROR_CODES.has(code)) return true;
+  return isTransientTabError(error);
+}
+
+/** Text of a successful tool response, or null. */
+function responseText(response) {
+  const text = response?.result?.content?.[0]?.text;
+  return typeof text === "string" ? text : null;
+}
+
+/** Turn a `{error}` tool response into an ExtractError, or return null. */
+function responseError(response, stage) {
+  if (!response || !response.error) return null;
+  const err = response.error;
+  const code = errorCodeOf(err) || "tool_error";
+  return new ExtractError(code, errorMessageOf(err), { stage, ...(err.details || {}) });
+}
+
+/** Parse what `surf js` printed for the script's return value. */
+function parseExtractionOutput(text) {
+  if (text === null || text === undefined || text.trim() === "" || text.trim() === "undefined") {
+    throw new ExtractError(
+      "no_output",
+      "The extraction script returned nothing. End it with `return { rows: [...] }` or `return [...]`.",
+    );
+  }
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new ExtractError("invalid_output", `The extraction script did not return JSON: ${error.message}`, {
+      preview: text.slice(0, 200),
+    });
+  }
+}
+
+/**
+ * Pick the row array out of the script result: the result itself when it
+ * is an array, `--rows <key>` when given, else the first conventional key
+ * holding an array. Returns null when the result has no row concept.
+ */
+function selectRows(data, rowsKey) {
+  if (rowsKey) {
+    const rows = data && typeof data === "object" && !Array.isArray(data) ? data[rowsKey] : undefined;
+    if (!Array.isArray(rows)) {
+      throw new ExtractError("rows_key_missing", `The script result has no array at "${rowsKey}"`, {
+        keys: data && typeof data === "object" ? Object.keys(data) : [],
+      });
+    }
+    return rows;
+  }
+  if (Array.isArray(data)) return data;
+  if (data && typeof data === "object") {
+    for (const key of ROW_KEY_CANDIDATES) {
+      if (Array.isArray(data[key])) return data[key];
+    }
+  }
+  return null;
+}
+
+/**
+ * Zero rows is a failure unless the caller opts in. A logged-out render,
+ * a selector miss or a half-loaded page all look like "no results"; only
+ * the caller knows whether an empty result is plausible.
+ */
+function enforceRowsInvariant(rows, { allowEmpty = false, readiness } = {}) {
+  if (!Array.isArray(rows) || rows.length > 0 || allowEmpty) return;
+  if (readiness?.state === "empty") return;
+  throw new ExtractError(
+    "empty_result",
+    "The extraction returned zero rows (the page may be logged out, blocked, or the selectors missed). Pass --allow-empty to accept an empty result, or --empty-text to recognise the page's own no-results message.",
+    { rows: 0 },
+  );
+}
+
+function cellText(value) {
+  let text;
+  if (value === null || value === undefined) text = "";
+  else if (typeof value === "string") text = value;
+  else text = JSON.stringify(value);
+  return text.replace(/\s+/g, " ").replace(/\|/g, "\\|").trim();
+}
+
+function isPlainRow(row) {
+  return row !== null && typeof row === "object" && !Array.isArray(row);
+}
+
+/** Markdown for humans and LLMs: metadata bullets, then a table of rows. */
+function renderExtractionMarkdown(data, rows, { title = "Extraction" } = {}) {
+  const lines = [`# ${title}`, ""];
+  if (data && typeof data === "object" && !Array.isArray(data)) {
+    for (const [key, value] of Object.entries(data)) {
+      if (Array.isArray(value) || (value && typeof value === "object")) continue;
+      lines.push(`- ${key}: ${cellText(value)}`);
+    }
+    if (lines.length > 2) lines.push("");
+  }
+  if (!Array.isArray(rows)) {
+    lines.push("```json", JSON.stringify(data, null, 2), "```");
+    return lines.join("\n");
+  }
+  lines.push(`${rows.length} row${rows.length === 1 ? "" : "s"}`, "");
+  if (rows.length === 0) return lines.join("\n").trimEnd();
+  if (!rows.every(isPlainRow)) {
+    for (const row of rows) lines.push(`- ${cellText(row)}`);
+    return lines.join("\n");
+  }
+  const columns = [];
+  for (const row of rows) {
+    for (const key of Object.keys(row)) {
+      if (!columns.includes(key)) columns.push(key);
+    }
+  }
+  lines.push(`| ${columns.join(" | ")} |`);
+  lines.push(`| ${columns.map(() => "---").join(" | ")} |`);
+  for (const row of rows) {
+    lines.push(`| ${columns.map((column) => cellText(row[column])).join(" | ")} |`);
+  }
+  return lines.join("\n");
+}
+
+function normalizeRetry(retry) {
+  const count = Number.isInteger(retry?.count) ? Math.max(0, Math.min(retry.count, MAX_RETRY_COUNT)) : DEFAULT_RETRY_COUNT;
+  const delayMs = Number.isFinite(retry?.delayMs) && retry.delayMs >= 0 ? retry.delayMs : DEFAULT_RETRY_DELAY_MS;
+  return { count, delayMs };
+}
+
+function readinessArgs(ready = {}) {
+  const args = {};
+  if (ready.selector) args.selector = ready.selector;
+  if (ready.text) args.text = ready.text;
+  if (ready.urlPrefix) args.urlPrefix = ready.urlPrefix;
+  if (ready.emptyText) args.emptyText = ready.emptyText;
+  if (ready.timeout) args.timeout = ready.timeout;
+  if (ready.interval) args.interval = ready.interval;
+  return args;
+}
+
+/**
+ * Tab id from a tab.new response. The host prints "Created tab <id>: <url>"
+ * for a single tab; socket clients may also see {tabId} or {id}.
+ */
+function tabIdFromResponse(response) {
+  const failure = responseError(response, "tab.new");
+  if (failure) throw failure;
+  const text = responseText(response);
+  let parsed = null;
+  try {
+    parsed = text === null ? null : JSON.parse(text);
+  } catch {
+    parsed = null;
+  }
+  const fromJson = Number(parsed?.tabId ?? parsed?.id);
+  if (Number.isInteger(fromJson) && fromJson > 0) return fromJson;
+  const match = typeof text === "string" ? text.match(/\btab\s+(\d+)\b/i) : null;
+  if (match) return Number(match[1]);
+  throw new ExtractError("no_tab", "tab.new did not return a tab id", { response: text ?? response });
+}
+
+function parseToolJson(response, stage) {
+  const failure = responseError(response, stage);
+  if (failure) throw failure;
+  const text = responseText(response);
+  if (text === null) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+/**
+ * Run one extraction attempt on `tabId` (already navigated). Shared by the
+ * owned-tab and caller-supplied-target modes.
+ */
+async function runAttemptOnTab(executeTool, tabId, settings) {
+  const readiness = parseToolJson(await executeTool("wait.ready", readinessArgs(settings.ready), tabId), "wait.ready");
+  const code = applyOptionsPrelude(settings.code, settings.options);
+  const jsResponse = await executeTool("js", { code }, tabId);
+  const failure = responseError(jsResponse, "js");
+  if (failure) throw failure;
+  const data = parseExtractionOutput(responseText(jsResponse));
+  const rows = selectRows(data, settings.rowsKey);
+  enforceRowsInvariant(rows, { allowEmpty: settings.allowEmpty, readiness });
+  return { data, rows, readiness };
+}
+
+/**
+ * @param {object} settings
+ * @param {(tool: string, args: object, tabId?: number) => Promise<object>} settings.executeTool
+ *   Sends one tool request. `tabId` overrides the target for owned tabs; when
+ *   it is undefined the caller's default target (session/tab/window) applies.
+ * @param {string} settings.code Page-side script; must `return` JSON.
+ * @param {string} [settings.url] Page to open. Required unless `target` is set.
+ * @param {object} [settings.options] Exposed to the script as SURF_OPTIONS.
+ * @param {object} [settings.ready] wait.ready expectations (selector, text, urlPrefix, emptyText, timeout, interval).
+ * @param {{count?: number, delayMs?: number}} [settings.retry]
+ * @param {boolean} [settings.keepTab] Leave the owned tab open on success.
+ * @param {boolean} [settings.allowEmpty]
+ * @param {string} [settings.rowsKey]
+ * @param {boolean} [settings.target] Use the caller's target instead of an owned tab.
+ * @param {(error: unknown) => boolean} [settings.isRetryable]
+ * @param {(ms: number) => Promise<void>} [settings.sleep]
+ * @param {(event: object) => void} [settings.onEvent]
+ */
+async function runExtraction(settings) {
+  const {
+    executeTool,
+    code,
+    url,
+    target = false,
+    keepTab = false,
+    isRetryable = isRetryableExtractionError,
+    sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+    onEvent = () => {},
+  } = settings;
+  if (typeof executeTool !== "function") throw new Error("runExtraction requires executeTool");
+  if (typeof code !== "string" || code.trim() === "") throw new ExtractError("no_script", "An extraction script is required (--file or --code)");
+  if (!target && !url) throw new ExtractError("no_url", "A URL is required unless --tab-id or --session names the page to read");
+
+  if (target) {
+    // Caller-supplied target: navigate once if asked, never close, never retry.
+    if (url) {
+      const navigation = await executeTool("navigate", { url });
+      const failure = responseError(navigation, "navigate");
+      if (failure) throw failure;
+    }
+    onEvent({ type: "attempt", attempt: 1, of: 1, mode: "target" });
+    const attempt = await runAttemptOnTab(executeTool, undefined, settings);
+    return { ...attempt, rowCount: Array.isArray(attempt.rows) ? attempt.rows.length : null, attempts: 1, mode: "target", url: url ?? null };
+  }
+
+  const retry = normalizeRetry(settings.retry);
+  const attempts = retry.count + 1;
+  let lastError = null;
+  let attemptsMade = 0;
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    attemptsMade = attempt;
+    if (attempt > 1) await sleep(retry.delayMs);
+    onEvent({ type: "attempt", attempt, of: attempts, mode: "owned-tab" });
+    let tabId = null;
+    try {
+      tabId = tabIdFromResponse(await executeTool("tab.new", { url }));
+      const result = await runAttemptOnTab(executeTool, tabId, settings);
+      if (!keepTab) {
+        const closed = await executeTool("tab.close", { id: tabId }, tabId);
+        const closeFailure = responseError(closed, "tab.close");
+        if (closeFailure) throw closeFailure;
+      }
+      return {
+        ...result,
+        rowCount: Array.isArray(result.rows) ? result.rows.length : null,
+        attempts: attempt,
+        mode: "owned-tab",
+        url,
+        tabId: keepTab ? tabId : null,
+      };
+    } catch (error) {
+      lastError = error;
+      if (tabId) {
+        try {
+          await executeTool("tab.close", { id: tabId }, tabId);
+        } catch (closeError) {
+          onEvent({ type: "close-failed", attempt, tabId, error: errorMessageOf(closeError) });
+        }
+      }
+      const retryable = attempt < attempts && isRetryable(error);
+      onEvent({ type: "attempt-failed", attempt, of: attempts, error: errorMessageOf(error), code: errorCodeOf(error), retryable });
+      if (!retryable) break;
+    }
+  }
+  if (lastError instanceof ExtractError) {
+    lastError.details = { ...lastError.details, attempts: attemptsMade };
+    throw lastError;
+  }
+  throw new ExtractError(errorCodeOf(lastError) || "extraction_failed", errorMessageOf(lastError), { attempts: attemptsMade });
+}
+
+module.exports = {
+  DEFAULT_RETRY_COUNT,
+  DEFAULT_RETRY_DELAY_MS,
+  ExtractError,
+  FATAL_READINESS_CODES,
+  MAX_RETRY_COUNT,
+  RETRYABLE_ERROR_CODES,
+  ROW_KEY_CANDIDATES,
+  TRANSIENT_TAB_ERROR_MARKERS,
+  enforceRowsInvariant,
+  errorMessageOf,
+  isRetryableExtractionError,
+  isTransientTabError,
+  parseExtractionOutput,
+  renderExtractionMarkdown,
+  runExtraction,
+  selectRows,
+  tabIdFromResponse,
+};

--- a/native/host-helpers.cjs
+++ b/native/host-helpers.cjs
@@ -470,6 +470,30 @@ function formatToolContent(result, log = () => {}, options = {}) {
 }
 
 /**
+ * Readiness expectations accept both CLI flag spelling (--url-prefix) and
+ * socket API spelling (urlPrefix). Empty values are dropped.
+ */
+function readinessExpectations(a) {
+  const pick = (...keys) => {
+    for (const key of keys) {
+      const value = a[key];
+      if (typeof value === "string" && value.trim() !== "") return value;
+    }
+    return undefined;
+  };
+  const expect = {
+    selector: pick("selector"),
+    text: pick("text"),
+    urlPrefix: pick("urlPrefix", "url-prefix"),
+    emptyText: pick("emptyText", "empty-text"),
+  };
+  for (const key of Object.keys(expect)) {
+    if (expect[key] === undefined) delete expect[key];
+  }
+  return expect;
+}
+
+/**
  * Map computer action to extension message
  */
 function mapComputerAction(args, tabId) {
@@ -871,6 +895,17 @@ function mapToolToMessage(tool, args, tabId) {
       return { type: "WAIT_FOR_URL", pattern: a.pattern || a.url, timeout: a.timeout, ...baseMsg };
     case "wait.dom":
       return { type: "WAIT_FOR_DOM_STABLE", stable: a.stable || 100, timeout: a.timeout || 5000, ...baseMsg };
+    case "wait.ready":
+      return {
+        type: "WAIT_FOR_READY",
+        expect: readinessExpectations(a),
+        timeout: a.timeout,
+        interval: a.interval,
+        accept: a.accept,
+        ...baseMsg,
+      };
+    case "page.readiness":
+      return { type: "PAGE_READINESS", expect: readinessExpectations(a), ...baseMsg };
     case "wait.load":
       return { type: "WAIT_FOR_LOAD", timeout: a.timeout || 30000, ...baseMsg };
     case "frame.list":
@@ -1280,4 +1315,4 @@ function mapToolToMessage(tool, args, tabId) {
   }
 }
 
-module.exports = { mapToolToMessage, mapComputerAction, formatToolContent, formatToolError, buildProviderUploadMessage };
+module.exports = { mapToolToMessage, mapComputerAction, formatToolContent, formatToolError, buildProviderUploadMessage, readinessExpectations };

--- a/native/mcp-server.cjs
+++ b/native/mcp-server.cjs
@@ -159,6 +159,27 @@ const TOOL_SCHEMAS = {
       timeout: z.number().optional().describe("Max wait time in ms")
     }
   },
+  "wait.ready": {
+    desc: "Wait until the page is ready, or fail fast with a typed state (login, challenge, not-found, error)",
+    schema: {
+      selector: z.string().optional().describe("Visible CSS selector that marks a ready page"),
+      text: z.string().optional().describe("Page text that marks a ready page"),
+      urlPrefix: z.string().optional().describe("Expected URL prefix; anything else is a bounce"),
+      emptyText: z.string().optional().describe("Text of an explicit no-results render (state 'empty')"),
+      accept: z.string().optional().describe("Negative states to return instead of fail, comma-separated"),
+      timeout: z.number().optional().describe("Max wait time in ms (default 20000, max 120000)"),
+      interval: z.number().optional().describe("Poll interval in ms (default 400)")
+    }
+  },
+  "page.readiness": {
+    desc: "Classify the page once: ready, empty, loading, login, challenge, not-found, error",
+    schema: {
+      selector: z.string().optional().describe("Visible CSS selector that marks a ready page"),
+      text: z.string().optional().describe("Page text that marks a ready page"),
+      urlPrefix: z.string().optional().describe("Expected URL prefix"),
+      emptyText: z.string().optional().describe("Text of an explicit no-results render")
+    }
+  },
   "wait.load": {
     desc: "Wait for page to fully load",
     schema: { timeout: z.number().optional().describe("Max wait time in ms") }

--- a/native/script-options.cjs
+++ b/native/script-options.cjs
@@ -1,0 +1,52 @@
+/**
+ * Options prelude for page-side scripts.
+ *
+ * A script run through `surf js --file` or `surf extract` often needs a few
+ * parameters (a result limit, a query, a mode). Instead of templating them
+ * into the source, the caller passes JSON and the script reads a frozen
+ * `SURF_OPTIONS` constant. The script stays a plain file that runs unchanged
+ * in any other JavaScript-in-page tool when the constant is defined by hand.
+ */
+
+const PRELUDE_NAME = "SURF_OPTIONS";
+
+function isPlainObject(value) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Accept an object or a JSON string; reject anything that is not a JSON
+ * object. Returns `{}` for undefined, null or an empty string.
+ */
+function parseScriptOptions(input) {
+  if (input === undefined || input === null || input === "") return {};
+  if (input === true) throw new Error("--options needs a JSON object value");
+  let value = input;
+  if (typeof input === "string") {
+    try {
+      value = JSON.parse(input);
+    } catch (error) {
+      throw new Error(`--options is not valid JSON: ${error.message}`);
+    }
+  }
+  if (!isPlainObject(value)) {
+    throw new Error("--options must be a JSON object, e.g. '{\"limit\": 20}'");
+  }
+  // Round-trip so functions, undefined and prototypes cannot leak into the page.
+  return JSON.parse(JSON.stringify(value));
+}
+
+/** `const SURF_OPTIONS = Object.freeze({...});` followed by a newline. */
+function buildOptionsPrelude(options) {
+  const normalized = parseScriptOptions(options);
+  return `const ${PRELUDE_NAME} = Object.freeze(${JSON.stringify(normalized)});\n`;
+}
+
+/** Prefix `code` with the prelude; an empty options object still defines the constant. */
+function applyOptionsPrelude(code, options) {
+  return `${buildOptionsPrelude(options)}${code}`;
+}
+
+module.exports = { PRELUDE_NAME, applyOptionsPrelude, buildOptionsPrelude, parseScriptOptions };

--- a/native/tool-scope.cjs
+++ b/native/tool-scope.cjs
@@ -45,7 +45,7 @@ const TAB_TOOLS = new Set([
   "scroll", "scroll.top", "scroll.bottom", "scroll.to", "scroll.info", "scroll_to_position",
   "search", "locate.role", "locate.text", "locate.label", "element.styles",
   "js", "javascript_tool", "eval",
-  "wait.element", "wait.url", "wait.network", "wait.dom", "wait.load", "health",
+  "wait.element", "wait.url", "wait.network", "wait.dom", "wait.load", "wait.ready", "page.readiness", "health",
   "frame.list", "frame.switch", "frame.main", "frame.js",
   "dialog.accept", "dialog.dismiss", "dialog.info",
   "console", "network", "network.get", "network.body", "network.curl", "network.path",

--- a/skills/surf/SKILL.md
+++ b/skills/surf/SKILL.md
@@ -398,7 +398,13 @@ surf wait.network              # Wait for network idle
 surf wait.url "/success"       # Wait for URL pattern
 surf wait.dom --stable 100     # Wait for DOM stability
 surf wait.load                 # Wait for page load complete
+surf wait.ready --selector ".results"                 # Ready, or fail fast: login / challenge / not-found / error
+surf wait.ready --url-prefix "https://app.example.com/" --empty-text "No results"  # empty vs blocked
+surf wait.ready --accept login --json                 # Return the negative state instead of failing
+surf page.readiness --json     # Classify the current page once (state + evidence)
 ```
+
+Typed readiness states replace "the selector never appeared": exit codes carry `page_login`, `page_challenge`, `page_not_found`, `page_error` or `page_timeout`. Detection uses visible UI (a rendered password field, a login route, the page's wording, a URL outside `--url-prefix`), not site selectors.
 
 ## Dialog Handling
 

--- a/skills/surf/SKILL.md
+++ b/skills/surf/SKILL.md
@@ -401,10 +401,21 @@ surf wait.load                 # Wait for page load complete
 surf wait.ready --selector ".results"                 # Ready, or fail fast: login / challenge / not-found / error
 surf wait.ready --url-prefix "https://app.example.com/" --empty-text "No results"  # empty vs blocked
 surf wait.ready --accept login --json                 # Return the negative state instead of failing
+# js on a background tab can stall for seconds in Brave; run surf tab.switch <id> first, or use extract (owns an active tab).
 surf page.readiness --json     # Classify the current page once (state + evidence)
 ```
 
 Typed readiness states replace "the selector never appeared": exit codes carry `page_login`, `page_challenge`, `page_not_found`, `page_error` or `page_timeout`. Detection uses visible UI (a rendered password field, a login route, the page's wording, a URL outside `--url-prefix`), not site selectors.
+
+## Extraction (owned tab, read-only)
+
+```bash
+surf extract "https://example.com/list" --file rows.js --ready-selector ".item"   # tab.new -> wait.ready -> js -> tab.close
+surf extract "<url>" --file rows.js --options '{"limit": 20}' --empty-text "No results" --json
+surf extract --tab-id 42 --code 'return [...document.querySelectorAll("h2")].map(h => ({ title: h.textContent }))'
+```
+
+Rules: the script must `return` JSON and reads parameters from `SURF_OPTIONS`; zero rows fails unless `--allow-empty` or the page showed its own empty state; transient tab failures and timeouts retry in a fresh tab (`--retry`), login/challenge/not-found never do; only run read-only scripts here (the sequence may replay). Mutations go through `surf js` on an explicit target.
 
 ## Dialog Handling
 

--- a/src/cdp/controller.ts
+++ b/src/cdp/controller.ts
@@ -1283,6 +1283,29 @@ export class CDPController {
     return this.send(tabId, "Page.stopScreencast");
   }
 
+  /**
+   * Parse `expression` in the page without running it. Lets the service
+   * worker check syntax although its own CSP forbids `new Function`.
+   */
+  async compileScript(tabId: number, expression: string): Promise<{ parses: boolean; error?: string }> {
+    await this.ensureAttached(tabId);
+    try {
+      await this.send(tabId, "Runtime.enable");
+    } catch (e) {}
+    const result = await this.send(tabId, "Runtime.compileScript", {
+      expression,
+      sourceURL: "",
+      persistScript: false,
+    });
+    if (result?.exceptionDetails) {
+      return {
+        parses: false,
+        error: result.exceptionDetails.exception?.description || result.exceptionDetails.text || "SyntaxError",
+      };
+    }
+    return { parses: true };
+  }
+
   async evaluateScript(tabId: number, expression: string): Promise<{
     result?: { value?: any; type?: string; description?: string };
     exceptionDetails?: { text?: string; exception?: { description?: string } };

--- a/src/content/accessibility-tree.ts
+++ b/src/content/accessibility-tree.ts
@@ -1,3 +1,4 @@
+import { createDomProbe, probePageReadiness } from "./page-readiness-probe";
 import type { VisualIndicatorMessageType } from "./visual-indicator.ts";
 
 export {};
@@ -1570,6 +1571,14 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     case "FORM_INPUT": {
       const result = setFormValue(message.ref, message.value);
       sendResponse(result);
+      break;
+    }
+    case "PAGE_READINESS": {
+      try {
+        sendResponse(probePageReadiness(createDomProbe(document, window), message.expect || {}));
+      } catch (err) {
+        sendResponse({ error: err instanceof Error ? err.message : String(err) });
+      }
       break;
     }
     case "EVAL_IN_PAGE": {

--- a/src/content/page-readiness-probe.ts
+++ b/src/content/page-readiness-probe.ts
@@ -1,0 +1,129 @@
+import {
+  CAPTCHA_FRAME_SELECTORS,
+  CHALLENGE_MARKER_SELECTORS,
+  type ReadinessExpectations,
+  type ReadinessSnapshot,
+  type ReadinessVerdict,
+  classifyReadiness,
+  normalizeText,
+} from "../utils/page-readiness";
+
+/**
+ * The minimal view of a document the snapshot collector needs. Real pages
+ * go through `createDomProbe`; tests can hand in a plain object.
+ */
+export interface ReadinessProbeDom {
+  href: string;
+  title: string;
+  readyState: string;
+  /** Full normalized visible text of the body. */
+  bodyText(): string;
+  /** Number of elements matching `selector` that are rendered and visible. */
+  countVisible(selector: string): number;
+  /** Visible h1/h2 texts in document order. */
+  visibleHeadings(): string[];
+}
+
+export const BODY_TEXT_SAMPLE_LENGTH = 4000;
+
+const TEXT_INPUT_SELECTOR =
+  "input:not([type]), input[type='text'], input[type='email'], input[type='tel'], input[type='search'], input[type='url'], textarea";
+
+function safeCount(dom: ReadinessProbeDom, selector: string): number {
+  try {
+    return dom.countVisible(selector);
+  } catch {
+    return 0;
+  }
+}
+
+/** Gather the facts the classifier needs. Never throws on a bad selector. */
+export function collectReadinessSnapshot(
+  dom: ReadinessProbeDom,
+  expect: ReadinessExpectations = {},
+): ReadinessSnapshot {
+  const bodyText = dom.bodyText();
+  const lowerBody = bodyText.toLowerCase();
+  const snapshot: ReadinessSnapshot = {
+    href: dom.href,
+    title: normalizeText(dom.title),
+    readyState: dom.readyState,
+    bodyTextSample: bodyText.slice(0, BODY_TEXT_SAMPLE_LENGTH),
+    bodyTextLength: bodyText.length,
+    headings: dom.visibleHeadings().map(normalizeText).filter(Boolean).slice(0, 5),
+    visiblePasswordInputs: safeCount(dom, "input[type='password']"),
+    visibleTextInputs: safeCount(dom, TEXT_INPUT_SELECTOR),
+    challengeMarkers: CHALLENGE_MARKER_SELECTORS.filter((selector) => safeCount(dom, selector) > 0),
+    captchaFrames: CAPTCHA_FRAME_SELECTORS.reduce((sum, selector) => sum + safeCount(dom, selector), 0),
+  };
+
+  if (expect.selector) {
+    snapshot.selector = { expected: expect.selector, matched: safeCount(dom, expect.selector) > 0 };
+  }
+  if (expect.text) {
+    snapshot.text = {
+      expected: expect.text,
+      matched: lowerBody.includes(normalizeText(expect.text).toLowerCase()),
+    };
+  }
+  if (expect.urlPrefix) {
+    snapshot.urlPrefix = { expected: expect.urlPrefix, matched: dom.href.startsWith(expect.urlPrefix) };
+  }
+  if (expect.emptyText) {
+    snapshot.emptyText = {
+      expected: expect.emptyText,
+      matched: lowerBody.includes(normalizeText(expect.emptyText).toLowerCase()),
+    };
+  }
+  return snapshot;
+}
+
+export interface PageReadinessReport extends ReadinessVerdict {
+  href: string;
+  title: string;
+  readyState: string;
+  snapshot: Omit<ReadinessSnapshot, "bodyTextSample">;
+}
+
+/** Collect and classify in one step; this is what the content script returns. */
+export function probePageReadiness(
+  dom: ReadinessProbeDom,
+  expect: ReadinessExpectations = {},
+): PageReadinessReport {
+  const snapshot = collectReadinessSnapshot(dom, expect);
+  const verdict = classifyReadiness(snapshot);
+  const { bodyTextSample: _sample, ...rest } = snapshot;
+  return {
+    ...verdict,
+    href: snapshot.href,
+    title: snapshot.title,
+    readyState: snapshot.readyState,
+    snapshot: rest,
+  };
+}
+
+/** Adapter over a live document. Visibility follows the same rules as wait.element. */
+export function createDomProbe(doc: Document, win: Window): ReadinessProbeDom {
+  const isVisible = (element: Element): boolean => {
+    const style = win.getComputedStyle(element);
+    const box = element as HTMLElement;
+    return (
+      style.display !== "none" &&
+      style.visibility !== "hidden" &&
+      style.opacity !== "0" &&
+      box.offsetWidth > 0 &&
+      box.offsetHeight > 0
+    );
+  };
+  return {
+    href: win.location.href,
+    title: doc.title,
+    readyState: doc.readyState,
+    bodyText: () => normalizeText(doc.body?.innerText ?? doc.body?.textContent ?? ""),
+    countVisible: (selector) => Array.from(doc.querySelectorAll(selector)).filter(isVisible).length,
+    visibleHeadings: () =>
+      Array.from(doc.querySelectorAll("h1, h2"))
+        .filter(isVisible)
+        .map((element) => normalizeText(element.textContent)),
+  };
+}

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -531,12 +531,24 @@ function codeWithExpressionReturn(code: string): string {
   return `return (\n${code}\n);`;
 }
 
-function scriptParses(code: string): boolean {
+/**
+ * Whether the wrapped statement body parses. The MV3 extension CSP
+ * (`script-src 'self'`) makes `new Function` throw an EvalError inside the
+ * service worker; in that case ask the page's parser through CDP instead,
+ * which compiles without running anything.
+ */
+async function statementBodyParses(tabId: number, body: string): Promise<boolean> {
   try {
-    new Function(code);
+    new Function(body);
     return true;
   } catch (err) {
-    return !(err instanceof SyntaxError);
+    if (err instanceof SyntaxError) return false;
+  }
+  try {
+    const compiled = await cdp.compileScript(tabId, `(async () => { 'use strict'; ${body} })()`);
+    return compiled.parses;
+  } catch {
+    return true;
   }
 }
 
@@ -2338,7 +2350,10 @@ export async function handleMessage(
 
         let result = await cdp.evaluateScript(tabId, expression);
 
-        if (result.exceptionDetails && !scriptParses(body)) {
+        // Statement scripts (declarations, loops, explicit `return`) cannot be
+        // wrapped as an expression; retry them in statement mode when the
+        // expression form failed to parse.
+        if (result.exceptionDetails && !(await statementBodyParses(tabId, body))) {
           result = await cdp.evaluateScript(tabId, `(async () => { 'use strict'; ${message.code} })()`);
         }
 

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -1,5 +1,14 @@
 import { CDPController } from "../cdp/controller";
 import { debugLog } from "../utils/debug";
+import type { ReadinessExpectations } from "../utils/page-readiness";
+import {
+  type ReadinessProbeResult,
+  type ReadinessState,
+  clampReadinessBudget,
+  parseAcceptStates,
+  pollReadiness,
+  readinessErrorCode,
+} from "../utils/readiness-poll";
 import { initNativeMessaging, postToNativeHost } from "../native/port-manager";
 
 debugLog("Service worker loaded");
@@ -151,6 +160,55 @@ async function labelSessionTab(tabId: number, name: string): Promise<number | un
   } catch {
     return undefined;
   }
+}
+
+function readinessExpectationsFrom(input: unknown): ReadinessExpectations {
+  const raw = input && typeof input === "object" ? (input as Record<string, unknown>) : {};
+  const expect: ReadinessExpectations = {};
+  for (const key of ["selector", "text", "urlPrefix", "emptyText"] as const) {
+    const value = raw[key];
+    if (typeof value === "string" && value.trim() !== "") expect[key] = value;
+  }
+  return expect;
+}
+
+/**
+ * One readiness probe of a tab. A blank tab is `loading` (a navigation is
+ * usually pending), other restricted pages are `error`, and an unreachable
+ * content script (mid-navigation, or not injected yet) is `loading`, so the
+ * poll loop needs no special cases.
+ */
+async function probeTabReadiness(tabId: number, expect: ReadinessExpectations): Promise<ReadinessProbeResult> {
+  let tabStatus: string | undefined;
+  let tabUrl: string | undefined;
+  try {
+    const tab = await chrome.tabs.get(tabId);
+    tabStatus = tab.status;
+    tabUrl = tab.pendingUrl || tab.url;
+  } catch {}
+  if (!tabUrl || tabUrl === "about:blank") {
+    return { state: "loading", evidence: [`tab URL is ${tabUrl || "empty"}`], href: tabUrl, tabStatus };
+  }
+  if (isRestrictedTabUrl(tabUrl)) {
+    return { state: "error", evidence: [`restricted browser or extension page ${tabUrl}`], href: tabUrl, tabStatus };
+  }
+  try {
+    const report = await chrome.tabs.sendMessage(tabId, { type: "PAGE_READINESS", expect }, { frameId: 0 });
+    if (report?.state) {
+      return { ...report, tabStatus };
+    }
+    const reason = report?.error ? String(report.error) : "content script returned no verdict";
+    return { state: "loading", evidence: [reason], href: tabUrl, tabStatus };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    return { state: "loading", evidence: [`content script unreachable: ${reason}`], href: tabUrl, tabStatus };
+  }
+}
+
+function describeReadiness(result: ReadinessProbeResult): string {
+  const where = result.href ? ` at ${result.href}` : "";
+  const evidence = result.evidence.length > 0 ? ` (${result.evidence.join("; ")})` : "";
+  return `${result.state}${where}${evidence}`;
 }
 
 const screenshotCache = new Map<string, { base64: string; width: number; height: number }>();
@@ -1853,6 +1911,52 @@ export async function handleMessage(
           await chrome.tabs.sendMessage(tabId, { type: "SHOW_AFTER_TOOL_USE" }, { frameId: 0 });
         } catch (e) {}
       }
+    }
+
+    case "PAGE_READINESS": {
+      if (!tabId) throw new Error("No tabId provided");
+      return await probeTabReadiness(tabId, readinessExpectationsFrom(message.expect));
+    }
+
+    case "WAIT_FOR_READY": {
+      if (!tabId) throw new Error("No tabId provided");
+      const expect = readinessExpectationsFrom(message.expect);
+      const budget = clampReadinessBudget({ timeoutMs: message.timeout, intervalMs: message.interval });
+      const accept: ReadinessState[] = parseAcceptStates(message.accept);
+      const outcome = await pollReadiness({
+        ...budget,
+        accept,
+        probe: () => probeTabReadiness(tabId, expect),
+      });
+      const summary = {
+        state: outcome.result.state,
+        evidence: outcome.result.evidence,
+        href: outcome.result.href,
+        title: outcome.result.title,
+        readyState: outcome.result.readyState,
+        tabStatus: outcome.result.tabStatus,
+        polls: outcome.polls,
+        waited: outcome.waitedMs,
+        timeout: budget.timeoutMs,
+        interval: budget.intervalMs,
+      };
+      if (outcome.kind === "settled" || outcome.kind === "accepted") {
+        // No `success` key on purpose: formatToolContent renders any
+        // {success, readyState} result as a fixed "Page loaded" line.
+        return { accepted: outcome.kind === "accepted", ...summary };
+      }
+      if (outcome.kind === "timeout") {
+        throw new BrowserCommandError(
+          "page_timeout",
+          `Page did not become ready within ${budget.timeoutMs}ms; last state ${describeReadiness(outcome.result)}`,
+          { ...summary, tabId },
+        );
+      }
+      throw new BrowserCommandError(
+        readinessErrorCode(outcome.result.state) ?? "page_not_ready",
+        `Page is not ready: ${describeReadiness(outcome.result)}`,
+        { ...summary, tabId },
+      );
     }
 
     case "WAIT_FOR_DOM_STABLE": {

--- a/src/utils/page-readiness.ts
+++ b/src/utils/page-readiness.ts
@@ -1,0 +1,272 @@
+/**
+ * Page readiness classification.
+ *
+ * A navigation can settle in states other than "the page you wanted": an
+ * anti-bot interstitial, a bounce to a login form, a not-found page, a
+ * browser error page, or an explicit "no results" render. Waiting for a
+ * selector on such a page only times out and hides the cause. This module
+ * turns a DOM snapshot into a typed verdict so callers can branch on the
+ * state instead of on a timeout.
+ *
+ * The classifier is pure: it only looks at the `ReadinessSnapshot` it is
+ * given. The snapshot is collected in the content script (see
+ * `src/content/page-readiness-probe.ts`), and every rule below is
+ * site-independent: it relies on browser behaviour, vendor-neutral markup
+ * conventions and generic wording, never on a particular site's layout.
+ *
+ * This module is bundled into the content script only. The service worker
+ * side (state lists, error codes, the poll loop) lives in
+ * `./readiness-poll.ts`; the two share only types, so the extension build
+ * does not emit a chunk that a classic content script could not import.
+ */
+
+import type { ReadinessState } from "./readiness-poll";
+
+export interface ReadinessExpectations {
+  /** CSS selector that must be present and visible before the page counts as ready. */
+  selector?: string;
+  /** Text that must appear in the page before it counts as ready. */
+  text?: string;
+  /** The page URL must start with this prefix; a different URL is a bounce. */
+  urlPrefix?: string;
+  /** Text that marks an explicit "no results" render (state `empty`). */
+  emptyText?: string;
+}
+
+export interface ExpectationOutcome<T> {
+  expected: T;
+  matched: boolean;
+}
+
+export interface ReadinessSnapshot {
+  href: string;
+  title: string;
+  readyState: string;
+  /** `chrome.tabs.Tab.status` when the caller knows it. */
+  tabStatus?: string;
+  /** Normalized visible body text, truncated to a few thousand characters. */
+  bodyTextSample: string;
+  /** Length of the full normalized body text. */
+  bodyTextLength: number;
+  /** Visible h1/h2 texts, document order. */
+  headings: string[];
+  visiblePasswordInputs: number;
+  visibleTextInputs: number;
+  /** Selectors from CHALLENGE_MARKER_SELECTORS that matched. */
+  challengeMarkers: string[];
+  /** Visible captcha or challenge iframes. */
+  captchaFrames: number;
+  selector?: ExpectationOutcome<string>;
+  text?: ExpectationOutcome<string>;
+  urlPrefix?: ExpectationOutcome<string>;
+  emptyText?: ExpectationOutcome<string>;
+}
+
+export interface ReadinessVerdict {
+  state: ReadinessState;
+  /** Human-readable reasons, most decisive first. */
+  evidence: string[];
+}
+
+/**
+ * Vendor-neutral markup left by common anti-bot interstitials. These are
+ * markers of the challenge vendors themselves, not of any target site.
+ */
+export const CHALLENGE_MARKER_SELECTORS: readonly string[] = [
+  "#challenge-running",
+  "#challenge-form",
+  "#challenge-stage",
+  "#cf-challenge-running",
+  "form[action*='captcha' i]",
+  "[data-sitekey][data-callback]",
+];
+
+/** iframes that host captcha widgets. Only decisive on otherwise empty pages. */
+export const CAPTCHA_FRAME_SELECTORS: readonly string[] = [
+  "iframe[src*='captcha' i]",
+  "iframe[src*='challenge' i]",
+  "iframe[title*='captcha' i]",
+];
+
+export const CHALLENGE_TITLE_PATTERN =
+  /just a moment|attention required|access denied|verify(?:ing)? (?:that )?you are (?:a )?human|security check|checking your browser|are you a robot|bot (?:detection|check|protection)|captcha|one more step|please wait while we verify/i;
+
+export const CHALLENGE_TEXT_PATTERN =
+  /verify(?:ing)? (?:that )?you are (?:a )?human|checking (?:your|the) browser|enable javascript and cookies|unusual traffic|automated (?:access|requests|queries)|complete the security check|prove you are human/i;
+
+export const NOT_FOUND_PATTERN =
+  /\b404\b|\bnot found\b|page (?:doesn.t|does not|cannot be|could not be|can.t be) (?:exist|found)|no longer (?:available|exists)|(?:doesn.t|does not) exist\b/i;
+
+export const LOGIN_PATH_PATTERN =
+  /(?:^|\/)(?:log-?in|sign-?in|sign-?on|auth|authenticate|authorize|sso|oauth2?|session\/new|users\/sign_in|account\/login)(?:\/|$|\?|#)/i;
+
+export const LOGIN_TITLE_PATTERN = /\b(?:log ?in|sign ?in|sign ?on|authenticate|authentication)\b/i;
+
+export const BROWSER_ERROR_PATTERN =
+  /this site can.t be reached|took too long to respond|ERR_[A-Z_]{4,}|no internet|connection (?:was )?(?:reset|refused)/i;
+
+/** Body text shorter than this is treated as an interstitial or error page, not content. */
+export const SHORT_PAGE_TEXT_LENGTH = 800;
+
+export function normalizeText(value: string | null | undefined): string {
+  return (value ?? "").replace(/\s+/g, " ").trim();
+}
+
+export function pathnameOf(href: string): string {
+  try {
+    return new URL(href).pathname;
+  } catch {
+    return "";
+  }
+}
+
+function isBlankHref(href: string): boolean {
+  return href === "" || href === "about:blank" || href.startsWith("about:blank?");
+}
+
+function classifyError(snapshot: ReadinessSnapshot): ReadinessVerdict | null {
+  if (snapshot.href.startsWith("chrome-error://")) {
+    return { state: "error", evidence: [`browser error page ${snapshot.href}`] };
+  }
+  if (snapshot.bodyTextLength < SHORT_PAGE_TEXT_LENGTH) {
+    const match = snapshot.bodyTextSample.match(BROWSER_ERROR_PATTERN);
+    if (match) {
+      return { state: "error", evidence: [`page text reads like a browser error: "${match[0]}"`] };
+    }
+  }
+  return null;
+}
+
+function classifyChallenge(snapshot: ReadinessSnapshot): ReadinessVerdict | null {
+  const evidence: string[] = [];
+  if (snapshot.challengeMarkers.length > 0) {
+    evidence.push(`challenge markup present: ${snapshot.challengeMarkers.join(", ")}`);
+  }
+  const titleMatch = snapshot.title.match(CHALLENGE_TITLE_PATTERN);
+  if (titleMatch) {
+    evidence.push(`title "${snapshot.title}" matches challenge wording`);
+  }
+  const shortPage = snapshot.bodyTextLength < SHORT_PAGE_TEXT_LENGTH;
+  if (shortPage) {
+    const headingMatch = snapshot.headings.find((heading) => CHALLENGE_TITLE_PATTERN.test(heading));
+    if (headingMatch) {
+      evidence.push(`heading "${headingMatch}" matches challenge wording`);
+    }
+    const textMatch = snapshot.bodyTextSample.match(CHALLENGE_TEXT_PATTERN);
+    if (textMatch) {
+      evidence.push(`short page text contains "${textMatch[0]}"`);
+    }
+    if (snapshot.captchaFrames > 0) {
+      evidence.push(`${snapshot.captchaFrames} captcha frame(s) on a short page`);
+    }
+  }
+  if (evidence.length === 0) {
+    return null;
+  }
+  // A lone captcha frame on a short page is weak on its own (cookie banners,
+  // tiny login forms); require a second signal for it.
+  if (evidence.length === 1 && snapshot.captchaFrames > 0 && snapshot.challengeMarkers.length === 0 && !titleMatch) {
+    return null;
+  }
+  return { state: "challenge", evidence };
+}
+
+function classifyNotFound(snapshot: ReadinessSnapshot): ReadinessVerdict | null {
+  const titleMatch = snapshot.title.match(NOT_FOUND_PATTERN);
+  if (titleMatch) {
+    return { state: "not-found", evidence: [`title "${snapshot.title}" matches not-found wording`] };
+  }
+  const heading = snapshot.headings.find((text) => NOT_FOUND_PATTERN.test(text));
+  if (heading) {
+    return { state: "not-found", evidence: [`heading "${heading}" matches not-found wording`] };
+  }
+  return null;
+}
+
+function classifyLogin(snapshot: ReadinessSnapshot): ReadinessVerdict | null {
+  const evidence: string[] = [];
+  const passwordVisible = snapshot.visiblePasswordInputs > 0;
+  const urlLooksLogin = LOGIN_PATH_PATTERN.test(pathnameOf(snapshot.href));
+  const titleLooksLogin = LOGIN_TITLE_PATTERN.test(snapshot.title);
+  const bounced = snapshot.urlPrefix !== undefined && !snapshot.urlPrefix.matched;
+
+  if (passwordVisible) evidence.push(`${snapshot.visiblePasswordInputs} visible password field(s)`);
+  if (urlLooksLogin) evidence.push(`URL path ${pathnameOf(snapshot.href)} looks like a login route`);
+  if (titleLooksLogin) evidence.push(`title "${snapshot.title}" mentions signing in`);
+  if (bounced && snapshot.urlPrefix) {
+    evidence.push(`URL ${snapshot.href} left the expected prefix ${snapshot.urlPrefix.expected}`);
+  }
+
+  const isLogin =
+    (passwordVisible && (urlLooksLogin || titleLooksLogin || bounced)) ||
+    (urlLooksLogin && (titleLooksLogin || bounced));
+  return isLogin ? { state: "login", evidence } : null;
+}
+
+function describeExpectation(name: string, outcome: ExpectationOutcome<string> | undefined): string | null {
+  if (!outcome) return null;
+  return `${name} "${outcome.expected}" ${outcome.matched ? "found" : "not found"}`;
+}
+
+/**
+ * Classify a snapshot. Negative states win over loading so a bounce is
+ * reported as soon as it renders instead of after a timeout; an explicit
+ * empty render wins over a missing content selector; expectations gate
+ * `ready`.
+ */
+export function classifyReadiness(snapshot: ReadinessSnapshot): ReadinessVerdict {
+  const negative =
+    classifyError(snapshot) ??
+    classifyChallenge(snapshot) ??
+    classifyNotFound(snapshot) ??
+    classifyLogin(snapshot);
+  if (negative) {
+    return negative;
+  }
+
+  const evidence: string[] = [];
+  const blank = isBlankHref(snapshot.href);
+  const expectsBlank = snapshot.urlPrefix?.expected.startsWith("about:blank") === true;
+  if (blank && !expectsBlank) {
+    return { state: "loading", evidence: [`URL is ${snapshot.href || "empty"}`] };
+  }
+  if (snapshot.urlPrefix && !snapshot.urlPrefix.matched) {
+    return {
+      state: "loading",
+      evidence: [`URL ${snapshot.href} does not start with ${snapshot.urlPrefix.expected}`],
+    };
+  }
+
+  const contentPresent = snapshot.selector?.matched === true || snapshot.text?.matched === true;
+  if (snapshot.readyState !== "complete" && !contentPresent) {
+    evidence.push(`document.readyState is ${snapshot.readyState}`);
+    if (snapshot.tabStatus && snapshot.tabStatus !== "complete") {
+      evidence.push(`tab status is ${snapshot.tabStatus}`);
+    }
+    return { state: "loading", evidence };
+  }
+
+  if (snapshot.emptyText?.matched) {
+    return { state: "empty", evidence: [`empty-state text "${snapshot.emptyText.expected}" found`] };
+  }
+
+  const missing = [
+    snapshot.selector && !snapshot.selector.matched ? describeExpectation("selector", snapshot.selector) : null,
+    snapshot.text && !snapshot.text.matched ? describeExpectation("text", snapshot.text) : null,
+  ].filter((entry): entry is string => entry !== null);
+  if (missing.length > 0) {
+    return { state: "loading", evidence: missing };
+  }
+
+  const matched = [
+    describeExpectation("selector", snapshot.selector),
+    describeExpectation("text", snapshot.text),
+  ].filter((entry): entry is string => entry !== null);
+  if (matched.length === 0) {
+    matched.push(`document.readyState is ${snapshot.readyState}`);
+  }
+  if (snapshot.visiblePasswordInputs > 0) {
+    matched.push(`${snapshot.visiblePasswordInputs} visible password field(s), page otherwise looks ready`);
+  }
+  return { state: "ready", evidence: matched };
+}

--- a/src/utils/readiness-poll.ts
+++ b/src/utils/readiness-poll.ts
@@ -1,0 +1,157 @@
+/**
+ * Host-side half of page readiness: the state vocabulary, error codes,
+ * `--accept` parsing and the bounded poll loop. Bundled into the service
+ * worker only; the DOM classifier in `./page-readiness.ts` is content-script
+ * only and imports nothing but types from here.
+ */
+
+export type ReadinessState =
+  | "ready"
+  | "empty"
+  | "loading"
+  | "login"
+  | "challenge"
+  | "not-found"
+  | "error";
+
+/** States that mean "stop waiting, the page will not become ready". */
+export const NEGATIVE_READINESS_STATES: readonly ReadinessState[] = [
+  "challenge",
+  "login",
+  "not-found",
+  "error",
+];
+
+/** States that mean "the page has settled and can be read". */
+export const SETTLED_READINESS_STATES: readonly ReadinessState[] = ["ready", "empty"];
+
+/** Error code for a negative state, or null for states that are not errors. */
+export function readinessErrorCode(state: ReadinessState): string | null {
+  switch (state) {
+    case "challenge":
+      return "page_challenge";
+    case "login":
+      return "page_login";
+    case "not-found":
+      return "page_not_found";
+    case "error":
+      return "page_error";
+    default:
+      return null;
+  }
+}
+
+export function isReadinessState(value: unknown): value is ReadinessState {
+  return (
+    value === "ready" ||
+    value === "empty" ||
+    value === "loading" ||
+    NEGATIVE_READINESS_STATES.includes(value as ReadinessState)
+  );
+}
+
+/** Parse `--accept login,challenge` style input into a state list. */
+export function parseAcceptStates(input: unknown): ReadinessState[] {
+  const raw: unknown[] = Array.isArray(input)
+    ? input
+    : typeof input === "string"
+      ? input.split(",")
+      : [];
+  const states: ReadinessState[] = [];
+  for (const entry of raw) {
+    const trimmed = typeof entry === "string" ? entry.trim() : "";
+    if (!isReadinessState(trimmed)) {
+      throw new Error(
+        `Unknown readiness state "${String(entry)}". Expected one of: challenge, login, not-found, error`,
+      );
+    }
+    if (!states.includes(trimmed)) states.push(trimmed);
+  }
+  return states;
+}
+
+/** What one probe of the page reports. */
+export interface ReadinessProbeResult {
+  state: ReadinessState;
+  evidence: string[];
+  href?: string;
+  title?: string;
+  readyState?: string;
+  tabStatus?: string;
+}
+
+export interface ReadinessBudget {
+  timeoutMs: number;
+  intervalMs: number;
+}
+
+export const DEFAULT_READINESS_TIMEOUT_MS = 20_000;
+export const MAX_READINESS_TIMEOUT_MS = 120_000;
+export const DEFAULT_READINESS_INTERVAL_MS = 400;
+export const MIN_READINESS_INTERVAL_MS = 50;
+
+/** Clamp caller-supplied numbers into a bounded polling budget. */
+export function clampReadinessBudget(input: { timeoutMs?: unknown; intervalMs?: unknown }): ReadinessBudget {
+  const timeoutRaw = Number(input.timeoutMs);
+  const intervalRaw = Number(input.intervalMs);
+  const timeoutMs = Number.isFinite(timeoutRaw) && timeoutRaw > 0
+    ? Math.min(timeoutRaw, MAX_READINESS_TIMEOUT_MS)
+    : DEFAULT_READINESS_TIMEOUT_MS;
+  const intervalBase = Number.isFinite(intervalRaw) && intervalRaw > 0 ? intervalRaw : DEFAULT_READINESS_INTERVAL_MS;
+  const intervalMs = Math.min(Math.max(intervalBase, MIN_READINESS_INTERVAL_MS), timeoutMs);
+  return { timeoutMs, intervalMs };
+}
+
+export interface ReadinessPollOptions extends ReadinessBudget {
+  probe: () => Promise<ReadinessProbeResult>;
+  /** Negative states that end the wait successfully instead of failing it. */
+  accept?: readonly ReadinessState[];
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+  /** Called after every probe; useful for debug lines. */
+  onPoll?: (result: ReadinessProbeResult, poll: number, waitedMs: number) => void;
+}
+
+export type ReadinessPollKind = "settled" | "accepted" | "negative" | "timeout";
+
+export interface ReadinessPollOutcome {
+  kind: ReadinessPollKind;
+  result: ReadinessProbeResult;
+  polls: number;
+  waitedMs: number;
+}
+
+const defaultSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Probe until the page settles, a negative state appears, or the budget is
+ * spent. The loop never spins faster than `intervalMs` and always makes at
+ * least one probe.
+ */
+export async function pollReadiness(options: ReadinessPollOptions): Promise<ReadinessPollOutcome> {
+  const sleep = options.sleep ?? defaultSleep;
+  const now = options.now ?? Date.now;
+  const accept = options.accept ?? [];
+  const startedAt = now();
+  let polls = 0;
+  let last: ReadinessProbeResult = { state: "loading", evidence: ["no probe completed"] };
+
+  for (;;) {
+    last = await options.probe();
+    polls += 1;
+    const waitedMs = now() - startedAt;
+    options.onPoll?.(last, polls, waitedMs);
+
+    if (SETTLED_READINESS_STATES.includes(last.state)) {
+      return { kind: "settled", result: last, polls, waitedMs };
+    }
+    if (NEGATIVE_READINESS_STATES.includes(last.state)) {
+      return { kind: accept.includes(last.state) ? "accepted" : "negative", result: last, polls, waitedMs };
+    }
+    const remaining = options.timeoutMs - (now() - startedAt);
+    if (remaining <= 0) {
+      return { kind: "timeout", result: last, polls, waitedMs: now() - startedAt };
+    }
+    await sleep(Math.min(options.intervalMs, remaining));
+  }
+}

--- a/test/e2e/fixtures/list-items.js
+++ b/test/e2e/fixtures/list-items.js
@@ -1,0 +1,11 @@
+// Page-side extractor used by the real-Chrome E2E for `surf extract`.
+// Reads SURF_OPTIONS.limit (injected by --options) and returns rows.
+const limit = Number.isFinite(SURF_OPTIONS.limit) ? SURF_OPTIONS.limit : 50;
+const rows = Array.from(document.querySelectorAll(".item"))
+  .slice(0, limit)
+  .map((item) => ({
+    id: item.dataset.id,
+    title: item.querySelector("h2")?.textContent?.trim() ?? "",
+    href: item.querySelector("a")?.getAttribute("href") ?? "",
+  }));
+return { query: new URL(location.href).searchParams.get("q") ?? "", total: rows.length, rows };

--- a/test/e2e/real-chrome.mjs
+++ b/test/e2e/real-chrome.mjs
@@ -139,6 +139,37 @@ function fixturePages(request) {
 <body><main><h1>Sign in</h1><form><label>Email <input type="email" name="email"></label>
 <label>Password <input type="password" name="password"></label><button type="submit">Sign in</button></form></main></body></html>`;
   }
+  if (url.pathname === "/list") {
+    const empty = url.searchParams.get("empty") === "1";
+    const items = empty
+      ? '<p class="empty-state">No results for this search.</p>'
+      : [1, 2, 3]
+          .map((n) => `<article class="item" data-id="${n}"><h2>Item ${n}</h2><a href="/items/${n}">open</a></article>`)
+          .join("");
+    return `<!doctype html><html><head><title>Surf list fixture</title></head>
+<body><h1>List</h1><label>Tracked <input id="tracked" type="text"></label><output id="mirror"></output>
+<section id="results">${items}</section>
+<script>
+  // Emulates a framework value tracker: an own "value" property on the
+  // instance shadows the native accessor and records what it saw. On
+  // "input" the framework compares its tracked value with the DOM value
+  // and ignores the event when they match, exactly like a controlled input.
+  const tracked = document.querySelector("#tracked");
+  const native = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value");
+  let trackedValue = "";
+  Object.defineProperty(tracked, "value", {
+    configurable: true,
+    get() { return native.get.call(this); },
+    set(next) { trackedValue = String(next); native.set.call(this, next); },
+  });
+  tracked.addEventListener("input", () => {
+    const domValue = native.get.call(tracked);
+    if (domValue === trackedValue) return; // framework sees no change
+    trackedValue = domValue;
+    document.querySelector("#mirror").textContent = domValue;
+  });
+</script></body></html>`;
+  }
   return null;
 }
 
@@ -405,6 +436,50 @@ try {
   }
   await runSurf("tab.close", "--id", String(loginTab.tabId), "--json");
 
+  // --- js --file with statements and --options -------------------------------
+  const extractScript = join(repo, "test/e2e/fixtures/list-items.js");
+  const listTabForJs = { tabId: tabIdFromOutput(await runSurf("tab.new", `${baseUrl}/list?q=js`)) };
+  await runSurf("wait.ready", "--json", "--tab-id", String(listTabForJs.tabId), "--selector", ".item");
+  const jsOutput = unwrapJson(
+    await runSurf("js", "--file", extractScript, "--options", '{"limit": 1}', "--tab-id", String(listTabForJs.tabId), "--json"),
+  );
+  if (jsOutput?.query !== "js" || jsOutput?.total !== 1 || jsOutput?.rows?.[0]?.title !== "Item 1") {
+    throw new Error(`js --file with statements and --options did not return the script result: ${JSON.stringify(jsOutput)}`);
+  }
+  await runSurf("tab.close", "--id", String(listTabForJs.tabId), "--json");
+
+  // --- extract -------------------------------------------------------------
+  const extracted = JSON.parse(
+    await runSurf("extract", `${baseUrl}/list?q=surf`, "--file", extractScript, "--options", '{"limit": 2}', "--ready-selector", ".item", "--json"),
+  );
+  if (extracted.rowCount !== 2 || extracted.attempts !== 1 || extracted.data.query !== "surf" || extracted.rows[1].title !== "Item 2") {
+    throw new Error(`extract did not return the fixture rows: ${JSON.stringify(extracted)}`);
+  }
+  const markdown = await runSurf("extract", `${baseUrl}/list?q=surf`, "--file", extractScript, "--ready-selector", ".item");
+  // chrome.debugger returns dictionaries key-sorted, so only check content, not column order.
+  const headerLine = markdown.split("\n").find((line) => line.startsWith("| ") && line.includes("title"));
+  const rowLine = markdown.split("\n").find((line) => line.includes("Item 3"));
+  if (!markdown.includes("3 rows") || !headerLine?.includes("id") || !headerLine.includes("href") || !rowLine?.includes("/items/3")) {
+    throw new Error(`extract Markdown output unexpected: ${markdown}`);
+  }
+  const emptyAccepted = JSON.parse(
+    await runSurf("extract", `${baseUrl}/list?empty=1`, "--file", extractScript, "--empty-text", "No results", "--json"),
+  );
+  if (emptyAccepted.rowCount !== 0 || emptyAccepted.readiness.state !== "empty") {
+    throw new Error(`extract did not accept the explicit empty state: ${JSON.stringify(emptyAccepted)}`);
+  }
+  const emptyRejected = await runSurfExpectingFailure(
+    "extract", `${baseUrl}/list?empty=1`, "--file", extractScript, "--retry", "1", "--retry-delay-ms", "0", "--json",
+  );
+  const emptyError = JSON.parse(emptyRejected.stdout);
+  if (emptyError.error?.code !== "empty_result" || emptyError.error?.details?.attempts !== 2) {
+    throw new Error(`extract did not enforce the zero-rows invariant: ${JSON.stringify(emptyRejected)}`);
+  }
+  const tabsAfterExtract = JSON.parse(await runSurf("tab.list", "--json"));
+  if (tabsAfterExtract.some((tab) => tab.url.includes("/list"))) {
+    throw new Error(`extract leaked an owned tab: ${JSON.stringify(tabsAfterExtract)}`);
+  }
+
   await runSurf("screenshot", "--output", screenshotPath);
   const png = readFileSync(screenshotPath);
   if (png.length < 100 || png.subarray(0, 8).toString("hex") !== "89504e470d0a1a0a") {
@@ -448,6 +523,7 @@ try {
         platform: process.platform,
         result: "pass",
         readiness: { fixture: readiness.state, loginAccepted: acceptedLogin.state },
+        extractRows: extracted.rowCount,
         screenshotBytes: png.length,
         serviceWorker: workerTarget.url(),
       },

--- a/test/e2e/real-chrome.mjs
+++ b/test/e2e/real-chrome.mjs
@@ -108,6 +108,40 @@ async function runSurf(...args) {
   return result.stdout;
 }
 
+/** `--json` with an explicit target wraps the payload as {result, target, notice}. */
+function unwrapJson(stdout) {
+  const parsed = JSON.parse(stdout);
+  return parsed && typeof parsed === "object" && "result" in parsed && "target" in parsed ? parsed.result : parsed;
+}
+
+/** tab.new prints "Created tab <id>: <url>" even with --json. */
+function tabIdFromOutput(stdout) {
+  const match = stdout.match(/\btab\s+(\d+)\b/i);
+  if (!match) throw new Error(`tab.new did not report a tab id: ${stdout}`);
+  return Number(match[1]);
+}
+
+/** Run surf expecting a non-zero exit; returns stdout and stderr. */
+async function runSurfExpectingFailure(...args) {
+  try {
+    const stdout = await runSurf(...args);
+    throw new Error(`Expected \`surf ${args.join(" ")}\` to fail, but it printed: ${stdout}`);
+  } catch (error) {
+    if (typeof error.code !== "number" || error.code === 0) throw error;
+    return { code: error.code, stdout: error.stdout ?? "", stderr: error.stderr ?? "" };
+  }
+}
+
+function fixturePages(request) {
+  const url = new URL(request.url, "http://127.0.0.1");
+  if (url.pathname === "/login") {
+    return `<!doctype html><html><head><title>Sign in - Surf fixture</title></head>
+<body><main><h1>Sign in</h1><form><label>Email <input type="email" name="email"></label>
+<label>Password <input type="password" name="password"></label><button type="submit">Sign in</button></form></main></body></html>`;
+  }
+  return null;
+}
+
 try {
   if (!new Set(["darwin", "linux"]).has(process.platform)) {
     throw new Error(`Real Chrome E2E does not support ${process.platform}`);
@@ -191,6 +225,12 @@ try {
   cpSync(standardManifest, testingManifest);
 
   server = createServer((request, response) => {
+    const extraPage = fixturePages(request);
+    if (extraPage !== null) {
+      response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+      response.end(extraPage);
+      return;
+    }
     const hasSessionCookie = request.headers.cookie?.includes("surf_session=present") === true;
     response.writeHead(200, {
       "content-type": "text/html; charset=utf-8",
@@ -221,6 +261,7 @@ try {
   const address = server.address();
   const fixtureUrl = `http://127.0.0.1:${address.port}/fixture`;
   const navigationUrl = `${fixtureUrl}?navigated`;
+  const baseUrl = `http://127.0.0.1:${address.port}`;
 
   browser = await puppeteer.launch({
     headless: true,
@@ -337,6 +378,33 @@ try {
     "visual indicator",
   );
 
+  // --- page readiness ---------------------------------------------------
+  const readiness = unwrapJson(await runSurf("page.readiness", "--json", "--tab-id", String(fixtureTab.id)));
+  if (readiness.state !== "ready" || readiness.readyState !== "complete") {
+    throw new Error(`page.readiness did not report ready: ${JSON.stringify(readiness)}`);
+  }
+  const waited = unwrapJson(
+    await runSurf("wait.ready", "--json", "--tab-id", String(fixtureTab.id), "--selector", "#fixture-button", "--text", "Clicked by Surf"),
+  );
+  if (waited.state !== "ready" || typeof waited.polls !== "number" || waited.polls < 1) {
+    throw new Error(`wait.ready did not settle on ready: ${JSON.stringify(waited)}`);
+  }
+
+  const loginTab = { tabId: tabIdFromOutput(await runSurf("tab.new", `${baseUrl}/login`)) };
+  const loginFailure = await runSurfExpectingFailure(
+    "wait.ready", "--tab-id", String(loginTab.tabId), "--url-prefix", `${baseUrl}/fixture`, "--timeout", "5000",
+  );
+  if (!loginFailure.stderr.includes("login") || !loginFailure.stderr.includes("password field")) {
+    throw new Error(`wait.ready did not classify the login bounce: ${JSON.stringify(loginFailure)}`);
+  }
+  const acceptedLogin = unwrapJson(
+    await runSurf("wait.ready", "--json", "--tab-id", String(loginTab.tabId), "--url-prefix", `${baseUrl}/fixture`, "--accept", "login"),
+  );
+  if (acceptedLogin.state !== "login" || acceptedLogin.accepted !== true) {
+    throw new Error(`wait.ready --accept login did not return the state: ${JSON.stringify(acceptedLogin)}`);
+  }
+  await runSurf("tab.close", "--id", String(loginTab.tabId), "--json");
+
   await runSurf("screenshot", "--output", screenshotPath);
   const png = readFileSync(screenshotPath);
   if (png.length < 100 || png.subarray(0, 8).toString("hex") !== "89504e470d0a1a0a") {
@@ -379,6 +447,7 @@ try {
         extensionId,
         platform: process.platform,
         result: "pass",
+        readiness: { fixture: readiness.state, loginAccepted: acceptedLogin.state },
         screenshotBytes: png.length,
         serviceWorker: workerTarget.url(),
       },

--- a/test/unit/extract.test.ts
+++ b/test/unit/extract.test.ts
@@ -1,0 +1,448 @@
+import { describe, expect, it, vi } from "vitest";
+
+// @ts-expect-error - CommonJS module without type definitions
+import * as extract from "../../native/extract.cjs";
+
+type Call = { tool: string; args: Record<string, unknown>; tabId?: number };
+
+function ok(payload: unknown) {
+  return {
+    result: {
+      content: [
+        { type: "text", text: typeof payload === "string" ? payload : JSON.stringify(payload) },
+      ],
+    },
+  };
+}
+
+function toolError(text: string, code?: string) {
+  return { error: { content: [{ type: "text", text }], ...(code ? { code } : {}) } };
+}
+
+/**
+ * Scripted fake host: each entry answers the next call to `tool`. The
+ * recorded call list doubles as the protocol assertion, the same way the
+ * Go fork's socket-level retry test worked.
+ */
+function scriptedHost(script: Array<{ tool: string; reply: unknown | (() => unknown) }>) {
+  const calls: Call[] = [];
+  let index = 0;
+  const executeTool = vi.fn(async (tool: string, args: Record<string, unknown>, tabId?: number) => {
+    calls.push({ tool, args, tabId });
+    const entry = script[index++];
+    if (!entry) {
+      throw new Error(`unexpected call ${tool} (#${calls.length})`);
+    }
+    if (entry.tool !== tool) {
+      throw new Error(`expected ${entry.tool} but got ${tool} at call #${calls.length}`);
+    }
+    return typeof entry.reply === "function" ? (entry.reply as () => unknown)() : entry.reply;
+  });
+  return { calls, executeTool, remaining: () => script.length - index };
+}
+
+const ready = ok({
+  state: "ready",
+  evidence: ["document.readyState is complete"],
+  polls: 1,
+  waited: 12,
+});
+const rowsResult = ok({
+  rows: [
+    { title: "A", href: "/a" },
+    { title: "B", href: "/b" },
+  ],
+  total: 2,
+});
+
+describe("runExtraction (owned tab)", () => {
+  it("opens, waits, extracts and closes a fresh tab", async () => {
+    const host = scriptedHost([
+      { tool: "tab.new", reply: ok({ success: true, tabId: 41, url: "https://x/" }) },
+      { tool: "wait.ready", reply: ready },
+      { tool: "js", reply: rowsResult },
+      { tool: "tab.close", reply: ok({ success: true }) },
+    ]);
+
+    const result = await extract.runExtraction({
+      executeTool: host.executeTool,
+      url: "https://x/",
+      code: "return SURF_OPTIONS.limit;",
+      options: { limit: 5 },
+      ready: { selector: ".row", timeout: 3000 },
+    });
+
+    expect(result).toMatchObject({
+      rowCount: 2,
+      attempts: 1,
+      mode: "owned-tab",
+      tabId: null,
+      url: "https://x/",
+    });
+    expect(result.rows).toHaveLength(2);
+    expect(result.readiness.state).toBe("ready");
+    expect(host.calls.map((call) => [call.tool, call.tabId])).toEqual([
+      ["tab.new", undefined],
+      ["wait.ready", 41],
+      ["js", 41],
+      ["tab.close", 41],
+    ]);
+    expect(host.calls[0].args).toEqual({ url: "https://x/" });
+    expect(host.calls[1].args).toEqual({ selector: ".row", timeout: 3000 });
+    expect(host.calls[2].args.code).toBe(
+      'const SURF_OPTIONS = Object.freeze({"limit":5});\nreturn SURF_OPTIONS.limit;',
+    );
+    expect(host.calls[3].args).toEqual({ id: 41 });
+    expect(host.remaining()).toBe(0);
+  });
+
+  it("retries with a fresh tab after a transient execution-context failure", async () => {
+    const host = scriptedHost([
+      { tool: "tab.new", reply: ok({ tabId: 1 }) },
+      { tool: "wait.ready", reply: ready },
+      { tool: "js", reply: toolError("Inspected target navigated or closed") },
+      { tool: "tab.close", reply: ok({ success: true }) },
+      { tool: "tab.new", reply: ok({ tabId: 2 }) },
+      { tool: "wait.ready", reply: ready },
+      { tool: "js", reply: rowsResult },
+      { tool: "tab.close", reply: ok({ success: true }) },
+    ]);
+    const sleep = vi.fn(async () => undefined);
+    const events: Array<Record<string, unknown>> = [];
+
+    const result = await extract.runExtraction({
+      executeTool: host.executeTool,
+      url: "https://x/",
+      code: "return 1",
+      retry: { count: 1, delayMs: 250 },
+      sleep,
+      onEvent: (event: Record<string, unknown>) => events.push(event),
+    });
+
+    expect(result.attempts).toBe(2);
+    expect(result.rowCount).toBe(2);
+    expect(sleep).toHaveBeenCalledWith(250);
+    expect(host.calls.map((call) => call.tool)).toEqual([
+      "tab.new",
+      "wait.ready",
+      "js",
+      "tab.close",
+      "tab.new",
+      "wait.ready",
+      "js",
+      "tab.close",
+    ]);
+    expect(host.calls[3].args).toEqual({ id: 1 });
+    expect(events.find((event) => event.type === "attempt-failed")).toMatchObject({
+      attempt: 1,
+      retryable: true,
+    });
+  });
+
+  it("treats zero rows as a failure, retries once, then reports empty_result", async () => {
+    const empty = ok({ rows: [] });
+    const host = scriptedHost([
+      { tool: "tab.new", reply: ok({ tabId: 1 }) },
+      { tool: "wait.ready", reply: ready },
+      { tool: "js", reply: empty },
+      { tool: "tab.close", reply: ok({}) },
+      { tool: "tab.new", reply: ok({ tabId: 2 }) },
+      { tool: "wait.ready", reply: ready },
+      { tool: "js", reply: empty },
+      { tool: "tab.close", reply: ok({}) },
+    ]);
+
+    await expect(
+      extract.runExtraction({
+        executeTool: host.executeTool,
+        url: "https://x/",
+        code: "return []",
+        sleep: async () => undefined,
+      }),
+    ).rejects.toMatchObject({ code: "empty_result", details: { attempts: 2 } });
+    expect(host.remaining()).toBe(0);
+  });
+
+  it("accepts zero rows with allowEmpty and when the page reports its own empty state", async () => {
+    const allow = scriptedHost([
+      { tool: "tab.new", reply: ok({ tabId: 1 }) },
+      { tool: "wait.ready", reply: ready },
+      { tool: "js", reply: ok([]) },
+      { tool: "tab.close", reply: ok({}) },
+    ]);
+    const allowed = await extract.runExtraction({
+      executeTool: allow.executeTool,
+      url: "https://x/",
+      code: "return []",
+      allowEmpty: true,
+    });
+    expect(allowed.rowCount).toBe(0);
+
+    const emptyState = scriptedHost([
+      { tool: "tab.new", reply: ok({ tabId: 1 }) },
+      {
+        tool: "wait.ready",
+        reply: ok({ state: "empty", evidence: ['empty-state text "No results" found'] }),
+      },
+      { tool: "js", reply: ok({ rows: [] }) },
+      { tool: "tab.close", reply: ok({}) },
+    ]);
+    const explicit = await extract.runExtraction({
+      executeTool: emptyState.executeTool,
+      url: "https://x/",
+      code: "return {rows: []}",
+      ready: { emptyText: "No results" },
+    });
+    expect(explicit.rowCount).toBe(0);
+    expect(explicit.readiness.state).toBe("empty");
+  });
+
+  it("does not retry a login bounce and still closes the tab", async () => {
+    const host = scriptedHost([
+      { tool: "tab.new", reply: ok({ tabId: 1 }) },
+      {
+        tool: "wait.ready",
+        reply: toolError("Page is not ready: login at https://x/login", "page_login"),
+      },
+      { tool: "tab.close", reply: ok({}) },
+    ]);
+
+    await expect(
+      extract.runExtraction({
+        executeTool: host.executeTool,
+        url: "https://x/",
+        code: "return 1",
+        retry: { count: 3 },
+      }),
+    ).rejects.toMatchObject({
+      code: "page_login",
+      message: expect.stringContaining("login at https://x/login"),
+    });
+    expect(host.calls.map((call) => call.tool)).toEqual(["tab.new", "wait.ready", "tab.close"]);
+  });
+
+  it("does not retry a script error and reports a single attempt", async () => {
+    const host = scriptedHost([
+      { tool: "tab.new", reply: ok({ tabId: 1 }) },
+      { tool: "wait.ready", reply: ready },
+      { tool: "js", reply: toolError("SyntaxError: Unexpected token ')'") },
+      { tool: "tab.close", reply: ok({}) },
+    ]);
+    await expect(
+      extract.runExtraction({
+        executeTool: host.executeTool,
+        url: "https://x/",
+        code: "return )",
+        retry: { count: 2 },
+      }),
+    ).rejects.toMatchObject({ code: "tool_error", details: { stage: "js", attempts: 1 } });
+    expect(host.remaining()).toBe(0);
+  });
+
+  it("retries a readiness timeout but gives up after the retry budget", async () => {
+    const host = scriptedHost([
+      { tool: "tab.new", reply: ok({ tabId: 1 }) },
+      {
+        tool: "wait.ready",
+        reply: toolError("Page did not become ready within 20000ms", "page_timeout"),
+      },
+      { tool: "tab.close", reply: ok({}) },
+      { tool: "tab.new", reply: ok({ tabId: 2 }) },
+      {
+        tool: "wait.ready",
+        reply: toolError("Page did not become ready within 20000ms", "page_timeout"),
+      },
+      { tool: "tab.close", reply: ok({}) },
+    ]);
+    await expect(
+      extract.runExtraction({
+        executeTool: host.executeTool,
+        url: "https://x/",
+        code: "return 1",
+        sleep: async () => undefined,
+      }),
+    ).rejects.toMatchObject({ code: "page_timeout" });
+    expect(host.remaining()).toBe(0);
+  });
+
+  it("keeps the tab open on success when asked and reports its id", async () => {
+    const host = scriptedHost([
+      { tool: "tab.new", reply: ok({ tabId: 9 }) },
+      { tool: "wait.ready", reply: ready },
+      { tool: "js", reply: rowsResult },
+    ]);
+    const result = await extract.runExtraction({
+      executeTool: host.executeTool,
+      url: "https://x/",
+      code: "return 1",
+      keepTab: true,
+    });
+    expect(result.tabId).toBe(9);
+    expect(host.calls.map((call) => call.tool)).toEqual(["tab.new", "wait.ready", "js"]);
+  });
+
+  it("surfaces a script that returns nothing or non-JSON", async () => {
+    const host = scriptedHost([
+      { tool: "tab.new", reply: ok({ tabId: 1 }) },
+      { tool: "wait.ready", reply: ready },
+      { tool: "js", reply: ok("undefined") },
+      { tool: "tab.close", reply: ok({}) },
+    ]);
+    await expect(
+      extract.runExtraction({
+        executeTool: host.executeTool,
+        url: "https://x/",
+        code: "document.title",
+      }),
+    ).rejects.toMatchObject({ code: "no_output" });
+    expect(host.remaining()).toBe(0);
+  });
+
+  it("rejects missing script or URL before touching the browser", async () => {
+    const executeTool = vi.fn();
+    await expect(
+      extract.runExtraction({ executeTool, url: "https://x/", code: "" }),
+    ).rejects.toMatchObject({ code: "no_script" });
+    await expect(extract.runExtraction({ executeTool, code: "return 1" })).rejects.toMatchObject({
+      code: "no_url",
+    });
+    expect(executeTool).not.toHaveBeenCalled();
+  });
+});
+
+describe("runExtraction (caller-supplied target)", () => {
+  it("navigates once, never opens or closes tabs, never retries", async () => {
+    const host = scriptedHost([
+      { tool: "navigate", reply: ok({ success: true }) },
+      { tool: "wait.ready", reply: ready },
+      { tool: "js", reply: toolError("Inspected target navigated or closed") },
+    ]);
+    await expect(
+      extract.runExtraction({
+        executeTool: host.executeTool,
+        target: true,
+        url: "https://x/",
+        code: "return 1",
+        retry: { count: 3 },
+      }),
+    ).rejects.toMatchObject({ code: "tool_error" });
+    expect(host.calls.map((call) => [call.tool, call.tabId])).toEqual([
+      ["navigate", undefined],
+      ["wait.ready", undefined],
+      ["js", undefined],
+    ]);
+  });
+
+  it("reads the current page in place when no URL is given", async () => {
+    const host = scriptedHost([
+      { tool: "wait.ready", reply: ready },
+      { tool: "js", reply: ok([{ a: 1 }]) },
+    ]);
+    const result = await extract.runExtraction({
+      executeTool: host.executeTool,
+      target: true,
+      code: "return [{a: 1}]",
+    });
+    expect(result).toMatchObject({ mode: "target", attempts: 1, rowCount: 1, url: null });
+  });
+});
+
+describe("tabIdFromResponse", () => {
+  it("reads JSON and the host's text form", () => {
+    expect(extract.tabIdFromResponse(ok({ success: true, tabId: 12 }))).toBe(12);
+    expect(extract.tabIdFromResponse(ok({ id: 13 }))).toBe(13);
+    expect(extract.tabIdFromResponse(ok("Created tab 1076931763: http://127.0.0.1/list"))).toBe(
+      1076931763,
+    );
+    expect(() => extract.tabIdFromResponse(ok("OK"))).toThrow(/did not return a tab id/);
+    expect(() => extract.tabIdFromResponse(toolError("tab_busy", "tab_busy"))).toThrow(/tab_busy/);
+  });
+});
+
+describe("helpers", () => {
+  it("classifies transient tab errors and retryable codes", () => {
+    expect(extract.isTransientTabError(new Error("Inspected target navigated or closed"))).toBe(
+      true,
+    );
+    expect(extract.isTransientTabError("Cannot find default execution context")).toBe(true);
+    expect(
+      extract.isTransientTabError({ content: [{ text: "Receiving end does not exist" }] }),
+    ).toBe(true);
+    expect(extract.isTransientTabError(new Error("selector not found"))).toBe(false);
+
+    expect(extract.isRetryableExtractionError(new extract.ExtractError("empty_result", "x"))).toBe(
+      true,
+    );
+    expect(extract.isRetryableExtractionError({ code: "page_timeout", message: "slow" })).toBe(
+      true,
+    );
+    expect(
+      extract.isRetryableExtractionError({
+        code: "page_login",
+        message: "Detached while handling command",
+      }),
+    ).toBe(false);
+    expect(extract.isRetryableExtractionError(new Error("syntax error"))).toBe(false);
+  });
+
+  it("selects rows from arrays, conventional keys or an explicit key", () => {
+    expect(extract.selectRows([1, 2])).toEqual([1, 2]);
+    expect(extract.selectRows({ total: 2, items: [{ a: 1 }] })).toEqual([{ a: 1 }]);
+    expect(extract.selectRows({ jobs: [{ a: 1 }] }, "jobs")).toEqual([{ a: 1 }]);
+    expect(extract.selectRows({ title: "x" })).toBeNull();
+    expect(() => extract.selectRows({ title: "x" }, "jobs")).toThrow(/no array at "jobs"/);
+  });
+
+  it("enforces the zero-rows invariant only for row arrays", () => {
+    expect(() => extract.enforceRowsInvariant([])).toThrow(/zero rows/);
+    expect(() => extract.enforceRowsInvariant([], { allowEmpty: true })).not.toThrow();
+    expect(() => extract.enforceRowsInvariant([], { readiness: { state: "empty" } })).not.toThrow();
+    expect(() => extract.enforceRowsInvariant(null)).not.toThrow();
+    expect(() => extract.enforceRowsInvariant([{ a: 1 }])).not.toThrow();
+  });
+
+  it("parses script output and rejects undefined or non-JSON", () => {
+    expect(extract.parseExtractionOutput('{"a":1}')).toEqual({ a: 1 });
+    expect(() => extract.parseExtractionOutput("undefined")).toThrow(/returned nothing/);
+    expect(() => extract.parseExtractionOutput("hello")).toThrow(/did not return JSON/);
+  });
+
+  it("renders metadata bullets and a table with escaped cells", () => {
+    const markdown = extract.renderExtractionMarkdown(
+      {
+        query: "a|b",
+        total: 2,
+        rows: [
+          { title: "First", href: "/1" },
+          { title: "Second\nline", extra: true },
+        ],
+      },
+      [
+        { title: "First", href: "/1" },
+        { title: "Second\nline", extra: true },
+      ],
+      { title: "Search" },
+    );
+    expect(markdown).toBe(
+      [
+        "# Search",
+        "",
+        "- query: a\\|b",
+        "- total: 2",
+        "",
+        "2 rows",
+        "",
+        "| title | href | extra |",
+        "| --- | --- | --- |",
+        "| First | /1 |  |",
+        "| Second line |  | true |",
+      ].join("\n"),
+    );
+  });
+
+  it("renders scalar rows as bullets and row-less results as JSON", () => {
+    expect(extract.renderExtractionMarkdown(["x", "y"], ["x", "y"])).toContain("- x\n- y");
+    expect(extract.renderExtractionMarkdown({ title: "T" }, null)).toContain('"title": "T"');
+    expect(extract.renderExtractionMarkdown([], [])).toBe("# Extraction\n\n0 rows");
+  });
+});

--- a/test/unit/host-helpers.test.ts
+++ b/test/unit/host-helpers.test.ts
@@ -543,3 +543,62 @@ describe("formatToolContent", () => {
     });
   });
 });
+
+describe("readiness tools", () => {
+  it("maps wait.ready with CLI flag spelling", () => {
+    const msg = helpers.mapToolToMessage(
+      "wait.ready",
+      {
+        selector: ".x",
+        "url-prefix": "https://a/",
+        "empty-text": "None",
+        timeout: 5000,
+        interval: 200,
+        accept: "login",
+      },
+      7,
+    );
+    expect(msg).toEqual({
+      type: "WAIT_FOR_READY",
+      expect: { selector: ".x", urlPrefix: "https://a/", emptyText: "None" },
+      timeout: 5000,
+      interval: 200,
+      accept: "login",
+      tabId: 7,
+    });
+  });
+
+  it("maps page.readiness with socket API spelling and drops empty values", () => {
+    const msg = helpers.mapToolToMessage(
+      "page.readiness",
+      { urlPrefix: "https://a/", text: "  ", selector: "" },
+      7,
+    );
+    expect(msg).toEqual({ type: "PAGE_READINESS", expect: { urlPrefix: "https://a/" }, tabId: 7 });
+  });
+
+  it("renders wait.ready results as JSON rather than the generic page-loaded line", () => {
+    const content = helpers.formatToolContent({
+      state: "ready",
+      evidence: ["document.readyState is complete"],
+      readyState: "complete",
+      polls: 2,
+      waited: 410,
+      _resolvedTabId: 7,
+    });
+    expect(content).toHaveLength(1);
+    expect(JSON.parse(content[0].text)).toEqual({
+      state: "ready",
+      evidence: ["document.readyState is complete"],
+      readyState: "complete",
+      polls: 2,
+      waited: 410,
+    });
+  });
+
+  it("prefers camelCase over hyphenated spelling when both are present", () => {
+    expect(helpers.readinessExpectations({ urlPrefix: "a", "url-prefix": "b" })).toEqual({
+      urlPrefix: "a",
+    });
+  });
+});

--- a/test/unit/page-readiness.test.ts
+++ b/test/unit/page-readiness.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectReadinessSnapshot,
+  probePageReadiness,
+  type ReadinessProbeDom,
+} from "../../src/content/page-readiness-probe";
+import { classifyReadiness, type ReadinessSnapshot } from "../../src/utils/page-readiness";
+import { parseAcceptStates, readinessErrorCode } from "../../src/utils/readiness-poll";
+
+function snapshot(overrides: Partial<ReadinessSnapshot> = {}): ReadinessSnapshot {
+  const body =
+    overrides.bodyTextSample ??
+    "Welcome to the dashboard. Here are your projects and recent activity across the workspace.";
+  return {
+    href: "https://app.example.com/projects",
+    title: "Projects - Example",
+    readyState: "complete",
+    bodyTextSample: body,
+    bodyTextLength: body.length,
+    headings: ["Projects"],
+    visiblePasswordInputs: 0,
+    visibleTextInputs: 1,
+    challengeMarkers: [],
+    captchaFrames: 0,
+    ...overrides,
+  };
+}
+
+describe("classifyReadiness", () => {
+  it("reports ready for a loaded page without expectations", () => {
+    const verdict = classifyReadiness(snapshot());
+    expect(verdict.state).toBe("ready");
+    expect(verdict.evidence).toEqual(["document.readyState is complete"]);
+  });
+
+  it("reports loading while the document is still parsing", () => {
+    const verdict = classifyReadiness(
+      snapshot({ readyState: "interactive", tabStatus: "loading" }),
+    );
+    expect(verdict.state).toBe("loading");
+    expect(verdict.evidence).toEqual([
+      "document.readyState is interactive",
+      "tab status is loading",
+    ]);
+  });
+
+  it("treats a blank URL as loading", () => {
+    expect(classifyReadiness(snapshot({ href: "about:blank" })).state).toBe("loading");
+    expect(classifyReadiness(snapshot({ href: "" })).state).toBe("loading");
+  });
+
+  it("accepts about:blank when that is the expected prefix", () => {
+    const verdict = classifyReadiness(
+      snapshot({ href: "about:blank", urlPrefix: { expected: "about:blank", matched: true } }),
+    );
+    expect(verdict.state).toBe("ready");
+  });
+
+  it("detects an anti-bot interstitial by title", () => {
+    const verdict = classifyReadiness(
+      snapshot({
+        title: "Just a moment...",
+        bodyTextSample: "Checking your browser before accessing the site.",
+      }),
+    );
+    expect(verdict.state).toBe("challenge");
+    expect(verdict.evidence[0]).toContain("Just a moment");
+  });
+
+  it("detects an anti-bot interstitial by vendor markup", () => {
+    const verdict = classifyReadiness(snapshot({ challengeMarkers: ["#challenge-running"] }));
+    expect(verdict.state).toBe("challenge");
+    expect(verdict.evidence).toEqual(["challenge markup present: #challenge-running"]);
+  });
+
+  it("does not flag an article that merely mentions captchas", () => {
+    const body = `${"How captcha systems verify you are human. ".repeat(40)}`;
+    const verdict = classifyReadiness(
+      snapshot({
+        title: "Blog - Example",
+        bodyTextSample: body,
+        bodyTextLength: body.length,
+        captchaFrames: 1,
+      }),
+    );
+    expect(verdict.state).toBe("ready");
+  });
+
+  it("does not treat a lone captcha badge on a short page as a challenge", () => {
+    const body = "Subscribe to our newsletter. Email address. Subscribe.";
+    const verdict = classifyReadiness(
+      snapshot({ bodyTextSample: body, bodyTextLength: body.length, captchaFrames: 1 }),
+    );
+    expect(verdict.state).toBe("ready");
+  });
+
+  it("detects not-found pages by title or heading", () => {
+    expect(classifyReadiness(snapshot({ title: "404 Not Found" })).state).toBe("not-found");
+    expect(classifyReadiness(snapshot({ headings: ["This page doesn't exist"] })).state).toBe(
+      "not-found",
+    );
+  });
+
+  it("detects a login bounce: password field plus URL prefix mismatch", () => {
+    const verdict = classifyReadiness(
+      snapshot({
+        href: "https://accounts.example.com/session?next=%2Fprojects",
+        title: "Example",
+        visiblePasswordInputs: 1,
+        urlPrefix: { expected: "https://app.example.com/", matched: false },
+      }),
+    );
+    expect(verdict.state).toBe("login");
+    expect(verdict.evidence).toContain("1 visible password field(s)");
+    expect(verdict.evidence.some((line) => line.includes("left the expected prefix"))).toBe(true);
+  });
+
+  it("detects a login page by route and title without a password field", () => {
+    const verdict = classifyReadiness(
+      snapshot({
+        href: "https://app.example.com/login",
+        title: "Sign in - Example",
+        visiblePasswordInputs: 0,
+      }),
+    );
+    expect(verdict.state).toBe("login");
+  });
+
+  it("keeps a page with a visible password field ready when nothing else points at login", () => {
+    const verdict = classifyReadiness(snapshot({ visiblePasswordInputs: 1 }));
+    expect(verdict.state).toBe("ready");
+    expect(verdict.evidence.some((line) => line.includes("password field"))).toBe(true);
+  });
+
+  it("detects browser error pages", () => {
+    expect(classifyReadiness(snapshot({ href: "chrome-error://chromewebdata/" })).state).toBe(
+      "error",
+    );
+    const body = "This site can't be reached. ERR_CONNECTION_REFUSED";
+    expect(
+      classifyReadiness(snapshot({ bodyTextSample: body, bodyTextLength: body.length })).state,
+    ).toBe("error");
+  });
+
+  it("reports loading until an expected selector or text appears", () => {
+    const missingSelector = classifyReadiness(
+      snapshot({ selector: { expected: ".results", matched: false } }),
+    );
+    expect(missingSelector.state).toBe("loading");
+    expect(missingSelector.evidence).toEqual(['selector ".results" not found']);
+
+    const found = classifyReadiness(
+      snapshot({ selector: { expected: ".results", matched: true } }),
+    );
+    expect(found.state).toBe("ready");
+    expect(found.evidence).toEqual(['selector ".results" found']);
+  });
+
+  it("lets present content override a non-complete readyState", () => {
+    const verdict = classifyReadiness(
+      snapshot({ readyState: "interactive", text: { expected: "Projects", matched: true } }),
+    );
+    expect(verdict.state).toBe("ready");
+  });
+
+  it("reports empty for an explicit no-results render even when the content selector is missing", () => {
+    const verdict = classifyReadiness(
+      snapshot({
+        selector: { expected: ".result-card", matched: false },
+        emptyText: { expected: "No results found", matched: true },
+      }),
+    );
+    expect(verdict.state).toBe("empty");
+  });
+
+  it("reports loading while the URL is outside the expected prefix and no login signal exists", () => {
+    const verdict = classifyReadiness(
+      snapshot({
+        href: "https://app.example.com/redirecting",
+        urlPrefix: { expected: "https://app.example.com/projects", matched: false },
+      }),
+    );
+    expect(verdict.state).toBe("loading");
+  });
+
+  it("prefers a negative state over loading", () => {
+    const verdict = classifyReadiness(
+      snapshot({
+        readyState: "loading",
+        title: "Attention Required!",
+        challengeMarkers: ["#challenge-form"],
+      }),
+    );
+    expect(verdict.state).toBe("challenge");
+  });
+});
+
+describe("readinessErrorCode", () => {
+  it("maps negative states to error codes and others to null", () => {
+    expect(readinessErrorCode("challenge")).toBe("page_challenge");
+    expect(readinessErrorCode("login")).toBe("page_login");
+    expect(readinessErrorCode("not-found")).toBe("page_not_found");
+    expect(readinessErrorCode("error")).toBe("page_error");
+    expect(readinessErrorCode("ready")).toBeNull();
+    expect(readinessErrorCode("loading")).toBeNull();
+  });
+});
+
+describe("parseAcceptStates", () => {
+  it("parses comma lists and arrays, de-duplicating", () => {
+    expect(parseAcceptStates("login, challenge,login")).toEqual(["login", "challenge"]);
+    expect(parseAcceptStates(["not-found"])).toEqual(["not-found"]);
+    expect(parseAcceptStates(undefined)).toEqual([]);
+  });
+
+  it("rejects unknown states", () => {
+    expect(() => parseAcceptStates("blocked")).toThrow(/Unknown readiness state "blocked"/);
+  });
+});
+
+function fakeDom(
+  overrides: Partial<ReadinessProbeDom> & { counts?: Record<string, number> } = {},
+): ReadinessProbeDom {
+  const counts = overrides.counts ?? {};
+  return {
+    href: "https://app.example.com/projects",
+    title: "  Projects   -  Example ",
+    readyState: "complete",
+    bodyText: () => "Projects Alpha Beta No results found",
+    countVisible: (selector) => counts[selector] ?? 0,
+    visibleHeadings: () => [" Projects "],
+    ...overrides,
+  };
+}
+
+describe("collectReadinessSnapshot", () => {
+  it("counts visible fields, markers and captcha frames", () => {
+    const dom = fakeDom({
+      counts: {
+        "input[type='password']": 1,
+        "#challenge-running": 1,
+        "iframe[src*='captcha' i]": 2,
+        "iframe[title*='captcha' i]": 1,
+      },
+    });
+    const result = collectReadinessSnapshot(dom);
+    expect(result.title).toBe("Projects - Example");
+    expect(result.headings).toEqual(["Projects"]);
+    expect(result.visiblePasswordInputs).toBe(1);
+    expect(result.challengeMarkers).toEqual(["#challenge-running"]);
+    expect(result.captchaFrames).toBe(3);
+    expect(result.bodyTextLength).toBe("Projects Alpha Beta No results found".length);
+  });
+
+  it("evaluates expectations case-insensitively and never throws on bad selectors", () => {
+    const dom = fakeDom({
+      counts: { ".card": 2 },
+      countVisible: (selector) => {
+        if (selector === "!!bad") {
+          throw new Error("invalid selector");
+        }
+        return selector === ".card" ? 2 : 0;
+      },
+    });
+    const result = collectReadinessSnapshot(dom, {
+      selector: ".card",
+      text: "no RESULTS found",
+      urlPrefix: "https://app.example.com/",
+      emptyText: "  no results  ",
+    });
+    expect(result.selector).toEqual({ expected: ".card", matched: true });
+    expect(result.text).toEqual({ expected: "no RESULTS found", matched: true });
+    expect(result.urlPrefix).toEqual({ expected: "https://app.example.com/", matched: true });
+    expect(result.emptyText).toEqual({ expected: "  no results  ", matched: true });
+    expect(collectReadinessSnapshot(dom, { selector: "!!bad" }).selector).toEqual({
+      expected: "!!bad",
+      matched: false,
+    });
+  });
+
+  it("omits expectation fields that were not requested", () => {
+    const result = collectReadinessSnapshot(fakeDom());
+    expect(result.selector).toBeUndefined();
+    expect(result.text).toBeUndefined();
+    expect(result.urlPrefix).toBeUndefined();
+    expect(result.emptyText).toBeUndefined();
+  });
+});
+
+describe("probePageReadiness", () => {
+  it("returns a verdict with page identity and a snapshot without the text sample", () => {
+    const report = probePageReadiness(fakeDom(), { selector: ".card" });
+    expect(report.state).toBe("loading");
+    expect(report.href).toBe("https://app.example.com/projects");
+    expect(report.title).toBe("Projects - Example");
+    expect(report.readyState).toBe("complete");
+    expect("bodyTextSample" in report.snapshot).toBe(false);
+    expect(report.snapshot.selector).toEqual({ expected: ".card", matched: false });
+  });
+});

--- a/test/unit/readiness-poll.test.ts
+++ b/test/unit/readiness-poll.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import {
+  clampReadinessBudget,
+  DEFAULT_READINESS_INTERVAL_MS,
+  DEFAULT_READINESS_TIMEOUT_MS,
+  MAX_READINESS_TIMEOUT_MS,
+  MIN_READINESS_INTERVAL_MS,
+  pollReadiness,
+  type ReadinessProbeResult,
+  type ReadinessState,
+} from "../../src/utils/readiness-poll";
+
+function fakeClock() {
+  let time = 0;
+  const sleeps: number[] = [];
+  return {
+    now: () => time,
+    sleep: async (ms: number) => {
+      sleeps.push(ms);
+      time += ms;
+    },
+    advance: (ms: number) => {
+      time += ms;
+    },
+    sleeps,
+  };
+}
+
+function sequence(states: ReadinessState[]): () => Promise<ReadinessProbeResult> {
+  let index = 0;
+  return async () => {
+    const state = states[Math.min(index, states.length - 1)];
+    index += 1;
+    return { state, evidence: [`probe ${index}`] };
+  };
+}
+
+describe("clampReadinessBudget", () => {
+  it("applies defaults for missing or invalid input", () => {
+    expect(clampReadinessBudget({})).toEqual({
+      timeoutMs: DEFAULT_READINESS_TIMEOUT_MS,
+      intervalMs: DEFAULT_READINESS_INTERVAL_MS,
+    });
+    expect(clampReadinessBudget({ timeoutMs: "abc", intervalMs: -5 })).toEqual({
+      timeoutMs: DEFAULT_READINESS_TIMEOUT_MS,
+      intervalMs: DEFAULT_READINESS_INTERVAL_MS,
+    });
+  });
+
+  it("caps the timeout, floors the interval and keeps the interval within the timeout", () => {
+    expect(clampReadinessBudget({ timeoutMs: 10_000_000, intervalMs: 1 })).toEqual({
+      timeoutMs: MAX_READINESS_TIMEOUT_MS,
+      intervalMs: MIN_READINESS_INTERVAL_MS,
+    });
+    expect(clampReadinessBudget({ timeoutMs: 200, intervalMs: 5000 })).toEqual({
+      timeoutMs: 200,
+      intervalMs: 200,
+    });
+  });
+});
+
+describe("pollReadiness", () => {
+  it("keeps polling through loading and settles on ready", async () => {
+    const clock = fakeClock();
+    const outcome = await pollReadiness({
+      timeoutMs: 5000,
+      intervalMs: 400,
+      probe: sequence(["loading", "loading", "ready"]),
+      sleep: clock.sleep,
+      now: clock.now,
+    });
+    expect(outcome.kind).toBe("settled");
+    expect(outcome.result.state).toBe("ready");
+    expect(outcome.polls).toBe(3);
+    expect(clock.sleeps).toEqual([400, 400]);
+    expect(outcome.waitedMs).toBe(800);
+  });
+
+  it("treats empty as settled", async () => {
+    const clock = fakeClock();
+    const outcome = await pollReadiness({
+      timeoutMs: 5000,
+      intervalMs: 100,
+      probe: sequence(["empty"]),
+      sleep: clock.sleep,
+      now: clock.now,
+    });
+    expect(outcome.kind).toBe("settled");
+    expect(outcome.polls).toBe(1);
+  });
+
+  it("stops on a negative state without waiting for the timeout", async () => {
+    const clock = fakeClock();
+    const outcome = await pollReadiness({
+      timeoutMs: 60_000,
+      intervalMs: 400,
+      probe: sequence(["loading", "login"]),
+      sleep: clock.sleep,
+      now: clock.now,
+    });
+    expect(outcome.kind).toBe("negative");
+    expect(outcome.result.state).toBe("login");
+    expect(outcome.polls).toBe(2);
+  });
+
+  it("returns accepted when the negative state is in the accept list", async () => {
+    const clock = fakeClock();
+    const outcome = await pollReadiness({
+      timeoutMs: 1000,
+      intervalMs: 100,
+      accept: ["login"],
+      probe: sequence(["login"]),
+      sleep: clock.sleep,
+      now: clock.now,
+    });
+    expect(outcome.kind).toBe("accepted");
+  });
+
+  it("times out with the last loading result and never sleeps past the deadline", async () => {
+    const clock = fakeClock();
+    const seen: number[] = [];
+    const outcome = await pollReadiness({
+      timeoutMs: 1000,
+      intervalMs: 400,
+      probe: sequence(["loading"]),
+      sleep: clock.sleep,
+      now: clock.now,
+      onPoll: (_result, poll) => seen.push(poll),
+    });
+    expect(outcome.kind).toBe("timeout");
+    expect(outcome.result.state).toBe("loading");
+    expect(clock.sleeps).toEqual([400, 400, 200]);
+    expect(outcome.polls).toBe(4);
+    expect(seen).toEqual([1, 2, 3, 4]);
+    expect(outcome.waitedMs).toBe(1000);
+  });
+
+  it("always makes at least one probe even with a spent budget", async () => {
+    const clock = fakeClock();
+    const outcome = await pollReadiness({
+      timeoutMs: 0,
+      intervalMs: 50,
+      probe: sequence(["loading"]),
+      sleep: clock.sleep,
+      now: clock.now,
+    });
+    expect(outcome.kind).toBe("timeout");
+    expect(outcome.polls).toBe(1);
+    expect(clock.sleeps).toEqual([]);
+  });
+});

--- a/test/unit/script-options.test.ts
+++ b/test/unit/script-options.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+// @ts-expect-error - CommonJS module without type definitions
+import * as scriptOptions from "../../native/script-options.cjs";
+
+describe("parseScriptOptions", () => {
+  it("returns an empty object for missing input", () => {
+    expect(scriptOptions.parseScriptOptions(undefined)).toEqual({});
+    expect(scriptOptions.parseScriptOptions(null)).toEqual({});
+    expect(scriptOptions.parseScriptOptions("")).toEqual({});
+  });
+
+  it("accepts JSON strings and plain objects", () => {
+    expect(scriptOptions.parseScriptOptions('{"limit": 20, "query": "x"}')).toEqual({
+      limit: 20,
+      query: "x",
+    });
+    expect(scriptOptions.parseScriptOptions({ mode: "list" })).toEqual({ mode: "list" });
+  });
+
+  it("rejects non-object values and invalid JSON", () => {
+    expect(() => scriptOptions.parseScriptOptions("[1]")).toThrow(/must be a JSON object/);
+    expect(() => scriptOptions.parseScriptOptions("42")).toThrow(/must be a JSON object/);
+    expect(() => scriptOptions.parseScriptOptions("{oops")).toThrow(/not valid JSON/);
+    expect(() => scriptOptions.parseScriptOptions(true)).toThrow(/needs a JSON object/);
+  });
+
+  it("strips functions and undefined values by JSON round-trip", () => {
+    const parsed = scriptOptions.parseScriptOptions({ keep: 1, fn: () => 1, gone: undefined });
+    expect(parsed).toEqual({ keep: 1 });
+  });
+});
+
+describe("buildOptionsPrelude", () => {
+  it("defines a frozen SURF_OPTIONS constant that is valid JavaScript on its own", () => {
+    const prelude = scriptOptions.buildOptionsPrelude({ limit: 3 });
+    expect(prelude).toBe('const SURF_OPTIONS = Object.freeze({"limit":3});\n');
+    const evaluate = new Function(`${prelude}return SURF_OPTIONS;`);
+    expect(evaluate()).toEqual({ limit: 3 });
+    expect(Object.isFrozen(evaluate())).toBe(true);
+  });
+
+  it("still defines the constant for empty options and prefixes the code", () => {
+    expect(scriptOptions.applyOptionsPrelude("return 1;", undefined)).toBe(
+      "const SURF_OPTIONS = Object.freeze({});\nreturn 1;",
+    );
+  });
+});

--- a/test/unit/service-worker/javascript-handlers.test.ts
+++ b/test/unit/service-worker/javascript-handlers.test.ts
@@ -13,28 +13,52 @@ async function loadHandleMessage() {
   return mod.handleMessage;
 }
 
-function mockRuntimeEvaluate(chrome: ReturnType<typeof createChromeMock>) {
+function exceptionDetails(error: unknown) {
+  const text = error instanceof Error ? error.message : String(error);
+  const description = error instanceof Error ? error.toString() : String(error);
+  return { exceptionDetails: { text, exception: { description } } };
+}
+
+/** Page-side parser check (Runtime.compileScript): compile without running. */
+function compileWith(FunctionImpl: FunctionConstructor, expression: string) {
+  try {
+    new FunctionImpl(expression);
+    return {};
+  } catch (error) {
+    return exceptionDetails(error);
+  }
+}
+
+async function evaluateWith(FunctionImpl: FunctionConstructor, expression: string) {
+  if (expression.includes("if(!window.piHelpers)")) {
+    return { result: { value: undefined, type: "undefined" } };
+  }
+  try {
+    const value = await new FunctionImpl(`return (${expression});`)();
+    return { result: { value, type: typeof value } };
+  } catch (error) {
+    return exceptionDetails(error);
+  }
+}
+
+/**
+ * Emulate the page runtime. `FunctionImpl` is the constructor used for the
+ * page side, so a test can block the service worker's global `Function`
+ * (as the extension CSP does) while the page keeps parsing and evaluating.
+ */
+function mockRuntimeEvaluate(
+  chrome: ReturnType<typeof createChromeMock>,
+  FunctionImpl: FunctionConstructor = Function,
+) {
   chrome.debugger.sendCommand.mockImplementation(
     async (_target: any, method: string, params?: any) => {
-      if (method !== "Runtime.evaluate") {
-        return {};
+      if (method === "Runtime.compileScript") {
+        return compileWith(FunctionImpl, params.expression);
       }
-      if (params.expression.includes("if(!window.piHelpers)")) {
-        return { result: { value: undefined, type: "undefined" } };
+      if (method === "Runtime.evaluate") {
+        return evaluateWith(FunctionImpl, params.expression);
       }
-
-      try {
-        const evaluateExpression = new Function(`return (${params.expression});`);
-        const value = await evaluateExpression();
-        return { result: { value, type: typeof value } };
-      } catch (error) {
-        return {
-          exceptionDetails: {
-            text: error instanceof Error ? error.message : String(error),
-            exception: { description: error instanceof Error ? error.toString() : String(error) },
-          },
-        };
-      }
+      return {};
     },
   );
 }
@@ -42,6 +66,32 @@ function mockRuntimeEvaluate(chrome: ReturnType<typeof createChromeMock>) {
 describe("JavaScript command handlers", () => {
   beforeEach(() => {
     resetChromeMock();
+  });
+
+  it("falls back to statement mode when the extension CSP blocks new Function", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    // The page parser is available even when the service worker cannot eval.
+    mockRuntimeEvaluate(chrome, Function);
+    // Emulate `script-src 'self'`: any attempt to compile a string throws an EvalError.
+    vi.stubGlobal("Function", function BlockedFunction() {
+      throw new EvalError(
+        "Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source",
+      );
+    });
+    try {
+      const result = await handleMessage(
+        {
+          type: "EXECUTE_JAVASCRIPT",
+          tabId: 1,
+          code: "const a = 40;\nconst b = 2;\nreturn a + b;",
+        },
+        {},
+      );
+      expect(result).toEqual({ output: "42" });
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it("returns final expression values", async () => {

--- a/test/unit/service-worker/readiness-handlers.test.ts
+++ b/test/unit/service-worker/readiness-handlers.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createChromeMock, resetChromeMock } from "../../mocks/chrome";
+
+vi.mock("../../../src/native/port-manager", () => ({
+  initNativeMessaging: vi.fn(),
+  postToNativeHost: vi.fn(),
+}));
+
+async function loadHandleMessage() {
+  vi.resetModules();
+  (globalThis as any).chrome = createChromeMock();
+  const mod = await import("../../../src/service-worker/index");
+  return mod.handleMessage;
+}
+
+function report(state: string, extra: Record<string, unknown> = {}) {
+  return {
+    state,
+    evidence: [`${state} evidence`],
+    href: "https://example.com/page",
+    title: "Page",
+    readyState: "complete",
+    ...extra,
+  };
+}
+
+describe("readiness handlers", () => {
+  beforeEach(() => {
+    resetChromeMock();
+  });
+
+  it("PAGE_READINESS forwards expectations to the content script and adds the tab status", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    chrome.tabs.get.mockResolvedValue({
+      id: 5,
+      url: "https://example.com/page",
+      status: "complete",
+    });
+    chrome.tabs.sendMessage.mockResolvedValue(report("ready"));
+
+    const result = await handleMessage(
+      {
+        type: "PAGE_READINESS",
+        tabId: 5,
+        expect: { selector: ".x", urlPrefix: "https://example.com/", bogus: 1, text: "" },
+      },
+      {},
+    );
+
+    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(
+      5,
+      { type: "PAGE_READINESS", expect: { selector: ".x", urlPrefix: "https://example.com/" } },
+      { frameId: 0 },
+    );
+    expect(result).toEqual({ ...report("ready"), tabStatus: "complete" });
+  });
+
+  it("PAGE_READINESS reports loading for a blank tab and error for restricted pages", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+
+    chrome.tabs.get.mockResolvedValue({ id: 5, url: "about:blank", status: "loading" });
+    const blank = await handleMessage({ type: "PAGE_READINESS", tabId: 5 }, {});
+    expect(blank.state).toBe("loading");
+    expect(chrome.tabs.sendMessage).not.toHaveBeenCalled();
+
+    chrome.tabs.get.mockResolvedValue({ id: 5, url: "chrome://settings/", status: "complete" });
+    const restricted = await handleMessage({ type: "PAGE_READINESS", tabId: 5 }, {});
+    expect(restricted.state).toBe("error");
+    expect(restricted.evidence[0]).toContain("chrome://settings/");
+  });
+
+  it("PAGE_READINESS treats an unreachable content script as loading", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    chrome.tabs.get.mockResolvedValue({ id: 5, url: "https://example.com/", status: "loading" });
+    chrome.tabs.sendMessage.mockRejectedValue(new Error("Receiving end does not exist"));
+
+    const result = await handleMessage({ type: "PAGE_READINESS", tabId: 5 }, {});
+    expect(result.state).toBe("loading");
+    expect(result.evidence[0]).toContain("content script unreachable");
+    expect(result.tabStatus).toBe("loading");
+  });
+
+  it("WAIT_FOR_READY polls until the page is ready", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    chrome.tabs.get.mockResolvedValue({
+      id: 5,
+      url: "https://example.com/page",
+      status: "complete",
+    });
+    chrome.tabs.sendMessage
+      .mockResolvedValueOnce(report("loading"))
+      .mockResolvedValueOnce(report("loading"))
+      .mockResolvedValue(report("ready"));
+
+    const result = await handleMessage(
+      { type: "WAIT_FOR_READY", tabId: 5, timeout: 2000, interval: 10 },
+      {},
+    );
+
+    expect(result.success).toBeUndefined();
+    expect(result.state).toBe("ready");
+    expect(result.accepted).toBe(false);
+    expect(result.polls).toBe(3);
+    expect(result.interval).toBe(50);
+    expect(chrome.tabs.sendMessage).toHaveBeenCalledTimes(3);
+  });
+
+  it("WAIT_FOR_READY fails fast with a typed code on a login bounce", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    chrome.tabs.get.mockResolvedValue({
+      id: 5,
+      url: "https://example.com/login",
+      status: "complete",
+    });
+    chrome.tabs.sendMessage.mockResolvedValue(
+      report("login", { href: "https://example.com/login" }),
+    );
+
+    const promise = handleMessage({ type: "WAIT_FOR_READY", tabId: 5, timeout: 5000 }, {});
+    await expect(promise).rejects.toMatchObject({
+      code: "page_login",
+      message: expect.stringContaining("login at https://example.com/login (login evidence)"),
+      details: expect.objectContaining({ state: "login", polls: 1, tabId: 5 }),
+    });
+    expect(chrome.tabs.sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("WAIT_FOR_READY returns an accepted negative state", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    chrome.tabs.get.mockResolvedValue({ id: 5, url: "https://example.com/", status: "complete" });
+    chrome.tabs.sendMessage.mockResolvedValue(report("challenge"));
+
+    const result = await handleMessage(
+      { type: "WAIT_FOR_READY", tabId: 5, accept: "challenge,login" },
+      {},
+    );
+    expect(result).toMatchObject({ accepted: true, state: "challenge" });
+    expect(result.success).toBeUndefined();
+  });
+
+  it("WAIT_FOR_READY rejects unknown accept states before polling", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    await expect(
+      handleMessage({ type: "WAIT_FOR_READY", tabId: 5, accept: "blocked" }, {}),
+    ).rejects.toThrow(/Unknown readiness state/);
+    expect(chrome.tabs.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("WAIT_FOR_READY times out with page_timeout and the last state", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    chrome.tabs.get.mockResolvedValue({ id: 5, url: "https://example.com/", status: "loading" });
+    chrome.tabs.sendMessage.mockResolvedValue(report("loading"));
+
+    await expect(
+      handleMessage({ type: "WAIT_FOR_READY", tabId: 5, timeout: 120, interval: 50 }, {}),
+    ).rejects.toMatchObject({
+      code: "page_timeout",
+      message: expect.stringContaining("did not become ready within 120ms"),
+      details: expect.objectContaining({ state: "loading" }),
+    });
+  });
+});

--- a/test/unit/tool-scope.test.ts
+++ b/test/unit/tool-scope.test.ts
@@ -48,6 +48,19 @@ describe("tool scope classification", () => {
     expect(classified.resourceKeys).toEqual([`file:${require("node:path").resolve("same.har")}`]);
   });
 
+  it("keeps readiness probes on the tab lane", () => {
+    expect(classifyTool("wait.ready", { selector: ".x" })).toEqual({
+      scope: "tab",
+      targetUse: "default-tab",
+      resourceKeys: [],
+    });
+    expect(classifyTool("page.readiness", {})).toEqual({
+      scope: "tab",
+      targetUse: "default-tab",
+      resourceKeys: [],
+    });
+  });
+
   it("fails conservative for unclassified browser commands", () => {
     expect(classifyTool("future.browser.command")).toMatchObject({
       scope: "browser-write",


### PR DESCRIPTION
> **Stacked PR.** Based on #255 (typed page readiness): `extract` runs `wait.ready` between `tab.new` and `js`. It also carries the one fix commit from #253 because the `SURF_OPTIONS` prelude starts the script with a `const` declaration, which only runs in real Chrome once statement mode works. Only the last four commits are new here; I will rebase onto `main` as #255 and #253 land.

## Summary

Agents keep re-deriving the same sequence by hand: open a tab, wait for real content, run an extractor, close the tab, retry once if the target went away, and do not call an empty result a success. This adds it as one read-only compound command, plus the script-parameter mechanism it needs.

- **`surf extract <url> --file script.js | --code '...' [--options JSON | --options-file f] [--ready-selector/--ready-text/--ready-url-prefix/--empty-text/--ready-timeout/--ready-interval] [--rows key] [--retry N --retry-delay-ms N] [--allow-empty] [--keep-tab] [--json]`** — `tab.new -> wait.ready -> js -> tab.close` in an owned tab. Transient target failures, readiness timeouts and zero-row results retry in a fresh tab (`--retry`, default 1); login bounces, challenges and not-found pages never retry because the next tab would land on the same page. Zero rows is a failure (`empty_result`) unless `--allow-empty` is set or the page showed its own empty state (`--empty-text` -> readiness `empty`), which separates "no results" from "logged out, blocked, or the selectors missed". Output is a Markdown table (metadata bullets, escaped cells; scalar rows as bullets; row-less results as fenced JSON) or `--json` `{data, rows, rowCount, attempts, readiness, mode, url, tabId}`. Error codes: `empty_result`, `no_output`, `invalid_output`, `rows_key_missing`, `no_tab`, plus the `page_*` readiness codes.
- **Caller-supplied targets are never re-navigated or closed**: with `--tab-id`/`--session` the script runs in place (navigating only when a URL is given), with no retry and no `tab.close`.
- **`surf js --options '{"limit": 20}'`** (and `frame.js`, and `extract`) exposes the object to the script as a frozen `SURF_OPTIONS` constant, so one plain script file works from the CLI, from `extract` and elsewhere. Invalid JSON and non-object values are rejected locally with a clear message.
- `extract` is a client-side compound command like `do` (it composes socket tools; it is not a socket tool itself), implemented in `native/extract.cjs` with an injectable `executeTool` so the unit tests script the whole host conversation.

Documented as read-only because the sequence may replay; mutations belong in `surf js` on an explicit target.

## Observed on real pages (Brave 151, throwaway profile)

- GitHub releases page with a 20-line script and `--options '{"limit":5}' --ready-selector 'a[href*="/releases/tag/"]'`: Markdown table with 5 rows, 1,057 ms end to end including tab open/close.
- Hacker News front page `--json`: 3 rows, `readiness {state: ready, polls: 3, waited: 804}`, `attempts: 1`, 903 ms.
- PyPI search with no hits and `--empty-text "no results"`: `readiness.state: "empty"`, `rowCount: 0`, exit 0.
- A script of mine that picked the wrong container: `empty_result` after two fresh-tab attempts in 1.5 s and no leaked tab, instead of an empty success. `tab.list` counts were unchanged after every failing run.
- A script that reloads its own page: attempt 1 fails, "retrying with a fresh tab", attempt 2 fails, exit 1 with `browser_error`.
- `--rows rows` on a result without that key -> `rows_key_missing`; a script without `return` -> `no_output` with a hint.
- `js --file opts.js --options '{"limit": 2}'` on npmjs.com: `{frozen: true, limit: 2, ...}`; `--options '{limit: 2}'` and `--options '[1,2]'` are rejected locally in 40 ms.

## Questions for the maintainer

1. `extract` is a top-level verb here. Would you rather see it as a `do` step type or a playbook `read` strategy (`using: "extract"`)?
2. `chrome.debugger` returns dictionaries with keys sorted, so `js` output and the Markdown table columns come back alphabetically. Known/accepted? (The E2E asserts on content, not column order.)
3. `tab.new` answers with prose ("Created tab <id>: <url>") even under `--json`; `extract` parses the id from that line. A structured `tab.new --json` would remove the regex — happy to do that as a follow-up.
4. Observation, not fixed: `js` (CDP `Runtime.evaluate`) on a tab that is not the active tab of its window stalled for 25-60 s in Brave 151, with this branch and with pristine 2.18.0 alike (content-script tools answered in 50 ms; the result was correct when it arrived). `extract` is unaffected because its owned tab is active. I documented the practical rule (switch to the tab first, or use `extract`) in the README; a Chromium control run was not possible here. Is this known?

## Follow-ups considered, not included

`extract --id-key <key>` (fail when a row lacks an upsert key); a prepare/apply form split (`form.plan` / `form.apply --file plan.json [--submit]`) with refuse-on-empty-required and click-only-the-named-button defaults, kept out so its safety semantics get their own review.

## Attribution

The owned-tab lifecycle, zero-rows invariant, never-retry-mutations rule and the page-side script contract were studied in the surf-cli Go fork by Manuel Odendahl (MIT) and re-implemented from scratch in TypeScript/CommonJS for this codebase; no code was copied and nothing site-specific was ported.

## Validation

- `npm ci --ignore-scripts`
- `npm run lint` (existing `FakeNode` warning only)
- `npm run check`
- `npm test` — 65 files, 845 tests passed, 2 skipped (+25 on top of #255 and #253: `extract` lifecycle with a scripted fake host asserting the exact open -> ready -> js -> close -> reopen sequence, retry classification, rows selection and invariant, Markdown rendering, target mode never re-navigating or retrying; `--options` parsing and prelude)
- `npm run build`
- `npm run test:e2e:chrome` with the pinned Chrome for Testing 152.0.7977.54 — pass; new `/list` fixture and a page-side extractor that starts with a declaration and reads `SURF_OPTIONS.limit`: `js --file --options`, `extract` rows as JSON and as a Markdown table, accepted empty state, rejected zero rows (`empty_result` after two attempts) and no leaked tab

Co-authored with Claude Code.
