### PR TITLE
fix(host): process every stdin frame in a chunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixed
 - **Native host stalled replies** - The host stopped reading its stdin buffer after an `EXTENSION_HELLO` or `TARGET_EVENT` frame, so a tool reply that arrived in the same chunk sat unread until the next message from the extension (typically the 60 s client timeout on the first request after host start). Every complete frame in a chunk is now processed.
 
+Thanks to [@tryingET](https://github.com/tryingET) for #251.
+
 ## [2.18.0] - 2026-09-04
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Native host stalled replies** - The host stopped reading its stdin buffer after an `EXTENSION_HELLO` or `TARGET_EVENT` frame, so a tool reply that arrived in the same chunk sat unread until the next message from the extension (typically the 60 s client timeout on the first request after host start). Every complete frame in a chunk is now processed.
+
 ## [2.18.0] - 2026-09-04
 
 ### Highlights

--- a/native/host.cjs
+++ b/native/host.cjs
@@ -2919,13 +2919,13 @@ function processInput() {
           if (topLevelResponse && request?.context) {
             completeOwnedRequest(request.context, request.id, "cleanup-settled");
           }
-          return;
+          continue;
         }
         handleFrameContextFailure(pending.request, msg);
         updateFrameContextFromResult(pending.request, pending.tool, msg);
         if (pending.resolve || pending.onComplete) {
           pendingToolRequests.resolve(msg.id, msg);
-          return;
+          continue;
         }
         pendingToolRequests.delete(msg.id);
         {
@@ -3025,7 +3025,7 @@ function processInput() {
                 }
               })
               .catch((error) => failAutoScreenshot(error.message));
-            return;
+            continue;
           } else if (autoScreenshot && pending.autoScreenshotOutput && !msg.error) {
             failAutoScreenshot(tabId ? "screenshot response was invalid" : "no tab available");
           } else if (msg.results && msg.savePath) {

--- a/native/host.cjs
+++ b/native/host.cjs
@@ -20,6 +20,7 @@ const { createOracleHost } = require("./oracle-host.cjs");
 
 const IS_WIN = process.platform === "win32";
 const { SOCKET_PATH, SURF_TMP } = require("./socket-path.cjs");
+const { takeFrames } = require("./stdin-frames.cjs");
 const { parseListenEndpoint } = require("./listener.cjs");
 const { getStateDir } = require("./remote-auth.cjs");
 const { createFrameParser, createServerAuthSession, createSocketWriter, isClientAuthorized, writeFrame, MAX_FRAME_BYTES } = require("./remote-transport.cjs");
@@ -2805,25 +2806,23 @@ function writeMessage(msg) {
 let inputBuffer = Buffer.alloc(0);
 
 function processInput() {
-  while (inputBuffer.length >= 4) {
-    const msgLen = inputBuffer.readUInt32LE(0);
-    if (inputBuffer.length < 4 + msgLen) break;
-    
-    const jsonStr = inputBuffer.slice(4, 4 + msgLen).toString("utf8");
-    inputBuffer = inputBuffer.slice(4 + msgLen);
-    
+  // Take every complete frame out of the buffer before dispatching: one
+  // chunk routinely carries a TARGET_EVENT and the reply to a tool request.
+  const { frames, rest } = takeFrames(inputBuffer);
+  inputBuffer = rest;
+  for (const jsonStr of frames) {
     try {
       const msg = JSON.parse(jsonStr);
       log(`Received from extension: ${msg.type || "unknown"}${msg.id !== undefined ? ` id=${msg.id}` : ""}`);
 
       if (msg.type === "EXTENSION_HELLO") {
         setBrowserIdentity(msg);
-        return;
+        continue;
       }
 
       if (msg.type === "TARGET_EVENT") {
         handleTargetEvent(msg);
-        return;
+        continue;
       }
       
       if (msg.type === "GET_AUTH") {
@@ -2847,12 +2846,12 @@ function processInput() {
             hint: "Failed to read auth credentials. Run 'pi --login anthropic' in terminal to authenticate."
           });
         }
-        return;
+        continue;
       }
       
       if (msg.type === "API_REQUEST") {
         handleApiRequest(msg, writeMessage);
-        return;
+        continue;
       }
 
       if (msg.type === "PLAYBOOK_WATCH_EVENT") {
@@ -2865,14 +2864,14 @@ function processInput() {
           tabId: msg.tabId,
           timestamp: msg.timestamp || new Date().toISOString(),
         });
-        return;
+        continue;
       }
 
       if (msg.type === "VIDEO_FRAME") {
         if (activeVideoRecorder && msg.recorderId === activeVideoRecorder.recorderId && msg.tabId === activeVideoRecorder.tabId) {
           activeVideoRecorder.recorder.addFrame(msg.data, Number.isFinite(msg.receivedAt) ? msg.receivedAt : Date.now());
         }
-        return;
+        continue;
       }
 
       if (msg.type === "VIDEO_ERROR") {
@@ -2882,7 +2881,7 @@ function processInput() {
             msg.error || "Video screencast failed",
           ));
         }
-        return;
+        continue;
       }
       
       if (msg.type === "STREAM_EVENT") {
@@ -2894,7 +2893,7 @@ function processInput() {
             stream.socket.destroy(error);
           });
         }
-        return;
+        continue;
       }
 
       if (msg.type === "STREAM_ERROR") {
@@ -2907,7 +2906,7 @@ function processInput() {
             })
             .finally(() => stopActiveStream(msg.streamId));
         }
-        return;
+        continue;
       }
       
       

--- a/native/stdin-frames.cjs
+++ b/native/stdin-frames.cjs
@@ -1,0 +1,42 @@
+/**
+ * Native messaging framing: every message from the extension arrives as a
+ * 4-byte little-endian length followed by that many bytes of UTF-8 JSON.
+ *
+ * One stdin chunk routinely carries several complete frames (a TARGET_EVENT
+ * followed by the reply to a tool request is the common case), so a reader
+ * must take every complete frame out of the buffer before waiting for more
+ * input. Leaving one behind stalls that reply until the extension sends
+ * something else.
+ */
+
+const HEADER_BYTES = 4;
+
+/**
+ * Split `buffer` into complete frames and the unread remainder.
+ *
+ * @param {Buffer} buffer
+ * @returns {{ frames: string[], rest: Buffer }} decoded frame payloads in
+ *   arrival order, and the bytes of any trailing partial frame.
+ */
+function takeFrames(buffer) {
+  const frames = [];
+  let offset = 0;
+  while (buffer.length - offset >= HEADER_BYTES) {
+    const length = buffer.readUInt32LE(offset);
+    if (buffer.length - offset < HEADER_BYTES + length) break;
+    frames.push(buffer.subarray(offset + HEADER_BYTES, offset + HEADER_BYTES + length).toString("utf8"));
+    offset += HEADER_BYTES + length;
+  }
+  return { frames, rest: offset === 0 ? buffer : buffer.subarray(offset) };
+}
+
+/** Encode one message the way the extension does, for tests and tools. */
+function encodeFrame(message) {
+  const json = Buffer.from(typeof message === "string" ? message : JSON.stringify(message), "utf8");
+  const frame = Buffer.alloc(HEADER_BYTES + json.length);
+  frame.writeUInt32LE(json.length, 0);
+  json.copy(frame, HEADER_BYTES);
+  return frame;
+}
+
+module.exports = { HEADER_BYTES, encodeFrame, takeFrames };

--- a/test/integration/native-host-protocol.test.ts
+++ b/test/integration/native-host-protocol.test.ts
@@ -190,6 +190,7 @@ async function runCli(args: string[], socketPath: string): Promise<CliResult> {
 type HostHarness = {
   child: ChildProcessLike;
   send(message: NativeMessage): void;
+  sendAll(messages: NativeMessage[]): void;
   socketPath: string;
   remoteCredentialPath?: string;
   remoteStateDir?: string;
@@ -365,6 +366,9 @@ async function startHostHarness(
     remoteStateDir,
     send(message) {
       child.stdin.write(encodeNativeMessage(message));
+    },
+    sendAll(framedMessages) {
+      child.stdin.write(Buffer.concat(framedMessages.map(encodeNativeMessage)));
     },
     socketPath,
     stderr() {
@@ -1665,6 +1669,47 @@ describe("native host protocol integration", () => {
     await new Promise<void>((resolve) => second.once("data", () => resolve()));
     host.send({ id: extensionRequest.id, tabs: [] });
     second.destroy();
+  });
+
+  it("dispatches every coalesced response after draining an abandoned request", async () => {
+    const host = await startHostHarness();
+    const abandoned = net.createConnection(host.socketPath);
+    await new Promise<void>((resolve) => abandoned.once("connect", resolve));
+    remoteTransport.writeFrame(abandoned, {
+      type: "tool_request",
+      method: "execute_tool",
+      params: { tool: "tab.list", args: {} },
+      id: "abandoned-coalesced",
+    });
+    const abandonedRequest = await host.waitForMessage(
+      (message) => message.type === "LIST_TABS",
+      "abandoned coalesced LIST_TABS",
+    );
+    abandoned.destroy();
+
+    const active = net.createConnection(host.socketPath);
+    await new Promise<void>((resolve) => active.once("connect", resolve));
+    remoteTransport.writeFrame(active, {
+      type: "tool_request",
+      method: "execute_tool",
+      params: { tool: "tab.list", args: {} },
+      id: "active-coalesced",
+    });
+    const activeRequest = await host.waitForMessage(
+      (message) => message.type === "LIST_TABS",
+      "active coalesced LIST_TABS",
+    );
+    const activeResponse = new Promise<string>((resolve) =>
+      active.once("data", (chunk: any) => resolve(chunk.toString("utf8"))),
+    );
+
+    host.sendAll([
+      { id: abandonedRequest.id, tabs: [] },
+      { id: activeRequest.id, tabs: [{ id: 7, title: "Handled", url: "https://example.test/" }] },
+    ]);
+
+    expect(await activeResponse).toContain('"id":"active-coalesced"');
+    active.destroy();
   });
 
   it("retains a nested provider tombstone until its late page response", async () => {

--- a/test/unit/stdin-frames.test.ts
+++ b/test/unit/stdin-frames.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+const Buffer: any = require("node:buffer").Buffer;
+const { encodeFrame, takeFrames } = require("../../native/stdin-frames.cjs") as {
+  encodeFrame(message: unknown): any;
+  takeFrames(buffer: any): { frames: string[]; rest: any };
+};
+
+describe("takeFrames", () => {
+  it("returns nothing for an empty or header-only buffer", () => {
+    expect(takeFrames(Buffer.alloc(0))).toEqual({ frames: [], rest: Buffer.alloc(0) });
+    const header = Buffer.alloc(3);
+    const partial = takeFrames(header);
+    expect(partial.frames).toEqual([]);
+    expect(partial.rest).toBe(header);
+  });
+
+  it("decodes one complete frame", () => {
+    const { frames, rest } = takeFrames(encodeFrame({ type: "TARGET_EVENT" }));
+    expect(frames).toEqual(['{"type":"TARGET_EVENT"}']);
+    expect(rest.length).toBe(0);
+  });
+
+  it("drains every complete frame that arrived in one chunk", () => {
+    // A TARGET_EVENT followed by a tool reply is the common shape; both
+    // must come out of a single chunk or the reply waits for the next one.
+    const chunk = Buffer.concat([
+      encodeFrame({ type: "EXTENSION_HELLO" }),
+      encodeFrame({ type: "TARGET_EVENT", event: "updated" }),
+      encodeFrame({ id: 12, output: '"done"' }),
+    ]);
+    const { frames, rest } = takeFrames(chunk);
+    expect(frames.map((frame: string) => JSON.parse(frame))).toEqual([
+      { type: "EXTENSION_HELLO" },
+      { type: "TARGET_EVENT", event: "updated" },
+      { id: 12, output: '"done"' },
+    ]);
+    expect(rest.length).toBe(0);
+  });
+
+  it("keeps a trailing partial frame for the next chunk", () => {
+    const whole = encodeFrame({ id: 1, ok: true });
+    const next = encodeFrame({ id: 2, ok: true });
+    const cut = next.subarray(0, 7);
+    const first = takeFrames(Buffer.concat([whole, cut]));
+    expect(first.frames).toEqual(['{"id":1,"ok":true}']);
+    expect(first.rest.equals(cut)).toBe(true);
+    const second = takeFrames(Buffer.concat([first.rest, next.subarray(7)]));
+    expect(second.frames).toEqual(['{"id":2,"ok":true}']);
+    expect(second.rest.length).toBe(0);
+  });
+
+  it("decodes multi-byte UTF-8 payloads by byte length", () => {
+    const { frames } = takeFrames(
+      Buffer.concat([encodeFrame({ title: "ünïcödé ✓" }), encodeFrame({ id: 3 })]),
+    );
+    expect(JSON.parse(frames[0])).toEqual({ title: "ünïcödé ✓" });
+    expect(JSON.parse(frames[1])).toEqual({ id: 3 });
+  });
+});


### PR DESCRIPTION
## Summary

- process every complete native-messaging frame delivered in one stdin chunk
- continue after event, abandoned, nested, resolved, and auto-screenshot response frames
- retain partial trailing frames for the next chunk
- add framing and real child-host coalesced-response regressions

This is a focused maintainer replacement for #251. It preserves the original commits and authorship from @tryingET, adds the missing response-path continuations found during review, and includes profile-linked changelog credit. The original PR should remain open until this replacement lands.

## Validation

- `npm test` — 61 files, 781 tests passed
- native-host protocol integration tests — 25/25 passed
- stdin framing tests — 5/5 passed
- coalesced-response regression — 10/10 repeated passes
- `npm run check`
- focused Biome check
- `git diff --check`

Supersedes #251 after merge.