### PR TITLE
fix(js): run statement scripts under the MV3 CSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 ### Fixed
 - **Native host stalled replies** - The host stopped reading its stdin buffer after an `EXTENSION_HELLO` or `TARGET_EVENT` frame, so a tool reply that arrived in the same chunk sat unread until the next message from the extension (typically the 60 s client timeout on the first request after host start). Every complete frame in a chunk is now processed.
+- **`js --file` statement scripts** - Scripts starting with a declaration failed with `SyntaxError: Unexpected token 'const'` in real Chrome because the statement-mode fallback relied on `new Function`, which the extension CSP blocks in the service worker. The fallback now uses CDP `Runtime.compileScript`.
 
 Thanks to [@tryingET](https://github.com/tryingET) for #251.
+Thanks to [@tryingET](https://github.com/tryingET) for #253.
 
 ## [2.18.0] - 2026-09-04
 

--- a/src/cdp/controller.ts
+++ b/src/cdp/controller.ts
@@ -1283,6 +1283,29 @@ export class CDPController {
     return this.send(tabId, "Page.stopScreencast");
   }
 
+  /**
+   * Parse `expression` in the page without running it. Lets the service
+   * worker check syntax although its own CSP forbids `new Function`.
+   */
+  async compileScript(tabId: number, expression: string): Promise<{ parses: boolean; error?: string }> {
+    await this.ensureAttached(tabId);
+    try {
+      await this.send(tabId, "Runtime.enable");
+    } catch (e) {}
+    const result = await this.send(tabId, "Runtime.compileScript", {
+      expression,
+      sourceURL: "",
+      persistScript: false,
+    });
+    if (result?.exceptionDetails) {
+      return {
+        parses: false,
+        error: result.exceptionDetails.exception?.description || result.exceptionDetails.text || "SyntaxError",
+      };
+    }
+    return { parses: true };
+  }
+
   async evaluateScript(tabId: number, expression: string): Promise<{
     result?: { value?: any; type?: string; description?: string };
     exceptionDetails?: { text?: string; exception?: { description?: string } };

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -473,12 +473,24 @@ function codeWithExpressionReturn(code: string): string {
   return `return (\n${code}\n);`;
 }
 
-function scriptParses(code: string): boolean {
+/**
+ * Whether the wrapped statement body parses. The MV3 extension CSP
+ * (`script-src 'self'`) makes `new Function` throw an EvalError inside the
+ * service worker; in that case ask the page's parser through CDP instead,
+ * which compiles without running anything.
+ */
+async function statementBodyParses(tabId: number, body: string): Promise<boolean> {
   try {
-    new Function(code);
+    new Function(body);
     return true;
   } catch (err) {
-    return !(err instanceof SyntaxError);
+    if (err instanceof SyntaxError) return false;
+  }
+  try {
+    const compiled = await cdp.compileScript(tabId, `(async () => { 'use strict'; ${body} })()`);
+    return compiled.parses;
+  } catch {
+    return true;
   }
 }
 
@@ -2234,7 +2246,10 @@ export async function handleMessage(
 
         let result = await cdp.evaluateScript(tabId, expression);
 
-        if (result.exceptionDetails && !scriptParses(body)) {
+        // Statement scripts (declarations, loops, explicit `return`) cannot be
+        // wrapped as an expression; retry them in statement mode when the
+        // expression form failed to parse.
+        if (result.exceptionDetails && !(await statementBodyParses(tabId, body))) {
           result = await cdp.evaluateScript(tabId, `(async () => { 'use strict'; ${message.code} })()`);
         }
 

--- a/test/e2e/real-chrome.mjs
+++ b/test/e2e/real-chrome.mjs
@@ -108,6 +108,12 @@ async function runSurf(...args) {
   return result.stdout;
 }
 
+/** `--json` with an explicit target wraps the payload as {result, target, notice}. */
+function unwrapJson(stdout) {
+  const parsed = JSON.parse(stdout);
+  return parsed && typeof parsed === "object" && "result" in parsed && "target" in parsed ? parsed.result : parsed;
+}
+
 try {
   if (!new Set(["darwin", "linux"]).has(process.platform)) {
     throw new Error(`Real Chrome E2E does not support ${process.platform}`);
@@ -336,6 +342,19 @@ try {
     () => fixturePage.evaluate(() => document.querySelector("#pi-agent-glow") !== null),
     "visual indicator",
   );
+
+  // --- js --file with a statement script (MV3 CSP) -----------------------
+  const statementScript = join(scratch, "statement-script.js");
+  writeFileSync(
+    statementScript,
+    'const heading = document.querySelector("h1")?.textContent ?? "";\nreturn { title: document.title, heading };\n',
+  );
+  const statementResult = unwrapJson(
+    await runSurf("js", "--file", statementScript, "--tab-id", String(fixtureTab.id), "--json"),
+  );
+  if (statementResult?.title !== "Surf real Chrome fixture" || statementResult?.heading !== "Surf real Chrome fixture") {
+    throw new Error(`js --file with a leading declaration did not run: ${JSON.stringify(statementResult)}`);
+  }
 
   await runSurf("screenshot", "--output", screenshotPath);
   const png = readFileSync(screenshotPath);

--- a/test/unit/service-worker/javascript-handlers.test.ts
+++ b/test/unit/service-worker/javascript-handlers.test.ts
@@ -13,28 +13,52 @@ async function loadHandleMessage() {
   return mod.handleMessage;
 }
 
-function mockRuntimeEvaluate(chrome: ReturnType<typeof createChromeMock>) {
+function exceptionDetails(error: unknown) {
+  const text = error instanceof Error ? error.message : String(error);
+  const description = error instanceof Error ? error.toString() : String(error);
+  return { exceptionDetails: { text, exception: { description } } };
+}
+
+/** Page-side parser check (Runtime.compileScript): compile without running. */
+function compileWith(FunctionImpl: FunctionConstructor, expression: string) {
+  try {
+    new FunctionImpl(expression);
+    return {};
+  } catch (error) {
+    return exceptionDetails(error);
+  }
+}
+
+async function evaluateWith(FunctionImpl: FunctionConstructor, expression: string) {
+  if (expression.includes("if(!window.piHelpers)")) {
+    return { result: { value: undefined, type: "undefined" } };
+  }
+  try {
+    const value = await new FunctionImpl(`return (${expression});`)();
+    return { result: { value, type: typeof value } };
+  } catch (error) {
+    return exceptionDetails(error);
+  }
+}
+
+/**
+ * Emulate the page runtime. `FunctionImpl` is the constructor used for the
+ * page side, so a test can block the service worker's global `Function`
+ * (as the extension CSP does) while the page keeps parsing and evaluating.
+ */
+function mockRuntimeEvaluate(
+  chrome: ReturnType<typeof createChromeMock>,
+  FunctionImpl: FunctionConstructor = Function,
+) {
   chrome.debugger.sendCommand.mockImplementation(
     async (_target: any, method: string, params?: any) => {
-      if (method !== "Runtime.evaluate") {
-        return {};
+      if (method === "Runtime.compileScript") {
+        return compileWith(FunctionImpl, params.expression);
       }
-      if (params.expression.includes("if(!window.piHelpers)")) {
-        return { result: { value: undefined, type: "undefined" } };
+      if (method === "Runtime.evaluate") {
+        return evaluateWith(FunctionImpl, params.expression);
       }
-
-      try {
-        const evaluateExpression = new Function(`return (${params.expression});`);
-        const value = await evaluateExpression();
-        return { result: { value, type: typeof value } };
-      } catch (error) {
-        return {
-          exceptionDetails: {
-            text: error instanceof Error ? error.message : String(error),
-            exception: { description: error instanceof Error ? error.toString() : String(error) },
-          },
-        };
-      }
+      return {};
     },
   );
 }
@@ -42,6 +66,32 @@ function mockRuntimeEvaluate(chrome: ReturnType<typeof createChromeMock>) {
 describe("JavaScript command handlers", () => {
   beforeEach(() => {
     resetChromeMock();
+  });
+
+  it("falls back to statement mode when the extension CSP blocks new Function", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    // The page parser is available even when the service worker cannot eval.
+    mockRuntimeEvaluate(chrome, Function);
+    // Emulate `script-src 'self'`: any attempt to compile a string throws an EvalError.
+    vi.stubGlobal("Function", function BlockedFunction() {
+      throw new EvalError(
+        "Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source",
+      );
+    });
+    try {
+      const result = await handleMessage(
+        {
+          type: "EXECUTE_JAVASCRIPT",
+          tabId: 1,
+          code: "const a = 40;\nconst b = 2;\nreturn a + b;",
+        },
+        {},
+      );
+      expect(result).toEqual({ output: "42" });
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it("returns final expression values", async () => {


### PR DESCRIPTION
## Summary

- preserve the contributor implementation from #253
- use CDP `Runtime.compileScript` when MV3 CSP blocks `new Function`
- keep runtime `SyntaxError` behavior from triggering statement fallback
- retain the real-Chrome declaration/explicit-return regression

This is a mechanical maintainer replacement because #253 developed a changelog conflict after earlier backlog landings. All three contributor commits retain @tryingET's authorship; the conflict resolution keeps both Unreleased entries and adds profile-linked credit for #253.

## Validation

- focused JavaScript handler tests
- `npm run check`
- focused Biome check
- `git diff --check`
- original #253 exact-head CI, CodeQL, and Gitleaks were green

Supersedes #253 after merge.