### PR TITLE
fix: bound screenshot capture timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - **Native host stalled replies** - The host stopped reading its stdin buffer after an `EXTENSION_HELLO` or `TARGET_EVENT` frame, so a tool reply that arrived in the same chunk sat unread until the next message from the extension (typically the 60 s client timeout on the first request after host start). Every complete frame in a chunk is now processed.
 - **`js --file` statement scripts** - Scripts starting with a declaration failed with `SyntaxError: Unexpected token 'const'` in real Chrome because the statement-mode fallback relied on `new Function`, which the extension CSP blocks in the service worker. The fallback now uses CDP `Runtime.compileScript`.
+- **Bounded screenshot capture** - Screenshot requests now settle when Chromium stops responding, preserving successful primary output and releasing queued work. Thanks to [@Whamp](https://github.com/Whamp) for #250.
 
 Thanks to [@tryingET](https://github.com/tryingET) for #251.
 Thanks to [@tryingET](https://github.com/tryingET) for #253.
@@ -28,7 +29,6 @@ Thanks to [@tryingET](https://github.com/tryingET) for #253.
 - **Development dependencies** - Updated development tooling dependencies.
 
 ### Fixed
-- **Bounded screenshot capture** - Screenshot requests now settle when Chromium stops responding, preserving successful primary output and releasing queued work. Thanks to [@Whamp](https://github.com/Whamp) for #250.
 - **ChatGPT model and effort selection** - Surf works with ChatGPT's current model menu and effort slider, checks the selected values, and closes the menu between operations. The requested model is checked again before the prompt is sent.
 
 ## [2.17.0] - 2026-08-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Thanks to [@tryingET](https://github.com/tryingET) for #253.
 - **Development dependencies** - Updated development tooling dependencies.
 
 ### Fixed
+- **Bounded screenshot capture** - Screenshot requests now settle when Chromium stops responding, preserving successful primary output and releasing queued work. Thanks to [@Whamp](https://github.com/Whamp) for #250.
 - **ChatGPT model and effort selection** - Surf works with ChatGPT's current model menu and effort slider, checks the selected values, and closes the menu between operations. The requested model is checked again before the prompt is sent.
 
 ## [2.17.0] - 2026-08-28

--- a/native/host.cjs
+++ b/native/host.cjs
@@ -2934,7 +2934,11 @@ function processInput() {
           const tabId = storedTabId || msg._resolvedTabId;
           const failAutoScreenshot = (message) => pending.autoScreenshotOutput
             ? sendToolResponse(socket, originalId, null, `Auto-screenshot failed: ${message}`)
-            : sendToolResponse(socket, originalId, { ...msg, autoScreenshotError: message }, null);
+            : sendToolResponse(socket, originalId, {
+                ...msg,
+                screenshotError: message,
+                autoScreenshotError: message,
+              }, null);
           
           if (pending.networkExport && Array.isArray(msg.entries)) {
             try {

--- a/src/cdp/controller.ts
+++ b/src/cdp/controller.ts
@@ -148,6 +148,7 @@ const KEY_DEFINITIONS: Record<string, KeyDefinition> = {
 };
 
 export class CDPController {
+  private static readonly SCREENSHOT_TIMEOUT_MS = 5000;
   private targets = new Map<number, Debuggee>();
   private consoleMessages: Map<number, ConsoleMessage[]> = new Map();
   private networkRequests: Map<number, NetworkRequest[]> = new Map();
@@ -1368,7 +1369,7 @@ export class CDPController {
     width: number;
     height: number;
   }> {
-    const result = await this.send(tabId, "Page.captureScreenshot", {
+    const result = await this.captureScreenshotData(tabId, {
       format: "png",
       captureBeyondViewport: false,
     });
@@ -1381,11 +1382,33 @@ export class CDPController {
     width: number;
     height: number;
   }> {
-    const result = await this.send(tabId, "Page.captureScreenshot", {
+    const result = await this.captureScreenshotData(tabId, {
       format: "png",
       clip: { x, y, width, height, scale: 1 },
     });
     return { base64: result.data, width, height };
+  }
+
+  private async captureScreenshotData(
+    tabId: number,
+    params: { [key: string]: unknown },
+  ): Promise<any> {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => reject(new CDPControllerError(
+        "screenshot_timeout",
+        `Screenshot capture timed out after ${CDPController.SCREENSHOT_TIMEOUT_MS}ms`,
+        { tabId, timeoutMs: CDPController.SCREENSHOT_TIMEOUT_MS },
+      )), CDPController.SCREENSHOT_TIMEOUT_MS);
+    });
+    try {
+      return await Promise.race([
+        this.send(tabId, "Page.captureScreenshot", params),
+        timeout,
+      ]);
+    } finally {
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+    }
   }
 
   private async dispatchMouseEvent(

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -1274,7 +1274,10 @@ export async function handleMessage(
           const screenshot = await cdp.captureScreenshot(tabId);
           return { ...result, screenshot };
         } catch (err) {
-          return { ...result, screenshotError: "Failed to capture screenshot" };
+          return {
+            ...result,
+            screenshotError: err instanceof Error ? err.message : "Failed to capture screenshot",
+          };
         }
       }
       return result;

--- a/test/integration/native-host-protocol.test.ts
+++ b/test/integration/native-host-protocol.test.ts
@@ -1108,6 +1108,54 @@ describe("native host protocol integration", () => {
     }
   });
 
+  it("preserves primary output and releases same-tab admission after an optional screenshot error", async () => {
+    const host = await startHostHarness();
+    const transport = await openClientTransport({
+      kind: "local",
+      connectionOptions: host.socketPath,
+    });
+    try {
+      const primaryResponse = transport.request({
+        type: "tool_request",
+        method: "execute_tool",
+        params: { tool: "click", args: { selector: "#go", autoScreenshot: true } },
+        tabId: 1,
+        id: "auto-screenshot-timeout",
+      });
+      const click = await host.waitForMessage(
+        (message) => message.type === "CLICK_SELECTOR",
+        "timed screenshot primary action",
+      );
+      host.send({ id: click.id, success: true });
+      const screenshot = await host.waitForMessage(
+        (message) => message.type === "EXECUTE_SCREENSHOT",
+        "timed optional screenshot",
+      );
+      host.send({ id: screenshot.id, error: "Screenshot capture timed out after 5000ms" });
+
+      const settled = await primaryResponse;
+      expect(settled.error).toBeUndefined();
+      expect(settled.result.content[0].text).toContain("OK");
+      expect(settled.result.content[0].text).toContain("Screenshot capture timed out after 5000ms");
+
+      const nextResponse = transport.request({
+        type: "tool_request",
+        method: "execute_tool",
+        params: { tool: "page.read", args: {} },
+        tabId: 1,
+        id: "same-tab-after-screenshot-timeout",
+      });
+      const next = await host.waitForMessage(
+        (message) => message.type === "READ_PAGE",
+        "same-tab request after screenshot timeout",
+      );
+      host.send({ id: next.id, pageContent: "next request admitted" });
+      expect((await nextResponse).error).toBeUndefined();
+    } finally {
+      await transport.close();
+    }
+  });
+
   it("fails remote auto-screenshot downloads without hanging or leaking staging", async () => {
     const reservation = net.createServer();
     await new Promise<void>((resolve) => reservation.listen(0, "127.0.0.1", resolve));

--- a/test/unit/cdp/controller.test.ts
+++ b/test/unit/cdp/controller.test.ts
@@ -1,4 +1,4 @@
-import { vi } from "vitest";
+import { afterEach, vi } from "vitest";
 import { CDPController } from "../../../src/cdp/controller";
 
 // Mock chrome.debugger API
@@ -16,6 +16,10 @@ const mockChrome = {
 vi.stubGlobal("chrome", mockChrome);
 
 describe("CDPController", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -479,6 +483,26 @@ describe("CDPController", () => {
         "Page.captureScreenshot",
         { format: "png", captureBeyondViewport: false },
       );
+    });
+
+    it("rejects when Page.captureScreenshot never settles", async () => {
+      vi.useFakeTimers();
+      mockChrome.debugger.sendCommand
+        .mockResolvedValueOnce({}) // Page.enable
+        .mockReturnValueOnce(
+          new Promise(() => {
+            /* intentionally pending */
+          }),
+        ); // captureScreenshot
+
+      const capture = controller.captureScreenshot(tabId);
+      const rejection = expect(capture).rejects.toMatchObject({
+        code: "screenshot_timeout",
+        message: "Screenshot capture timed out after 5000ms",
+      });
+      await vi.advanceTimersByTimeAsync(5000);
+
+      await rejection;
     });
   });
 

--- a/test/unit/service-worker/session-handlers.test.ts
+++ b/test/unit/service-worker/session-handlers.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createChromeMock, resetChromeMock } from "../../mocks/chrome";
 
 vi.mock("../../../src/native/port-manager", () => ({
@@ -15,6 +15,7 @@ async function loadHandleMessage() {
 
 describe("browser session handlers", () => {
   beforeEach(() => resetChromeMock());
+  afterEach(() => vi.useRealTimers());
 
   it("creates session windows unfocused and labels the bound tab", async () => {
     const handleMessage = await loadHandleMessage();
@@ -113,6 +114,76 @@ describe("browser session handlers", () => {
     ).rejects.toMatchObject({ code: "screenshot_target_not_visible" });
     expect(chrome.tabs.update).not.toHaveBeenCalled();
     expect(chrome.windows.update).not.toHaveBeenCalled();
+  });
+
+  it("settles direct capture after a CDP timeout without capturing another strict tab", async () => {
+    vi.useFakeTimers();
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    chrome.tabs.get.mockResolvedValue({
+      id: 61,
+      windowId: 14,
+      active: false,
+      groupId: -1,
+      url: "https://example.com/",
+    });
+    chrome.tabs.query.mockResolvedValue([{ id: 62, windowId: 14, active: true }]);
+    chrome.debugger.sendCommand.mockImplementation((_target: unknown, method: string) =>
+      method === "Page.captureScreenshot"
+        ? new Promise(() => {
+            /* intentionally pending */
+          })
+        : Promise.resolve({}),
+    );
+
+    const capture = handleMessage(
+      { type: "EXECUTE_SCREENSHOT", tabId: 61, strictTarget: true },
+      {},
+    );
+    const rejection = expect(capture).rejects.toMatchObject({
+      code: "screenshot_target_not_visible",
+    });
+    await vi.advanceTimersByTimeAsync(5050);
+
+    await rejection;
+  });
+
+  it("preserves page output and reports a timed-out optional screenshot", async () => {
+    vi.useFakeTimers();
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    chrome.tabs.sendMessage.mockImplementation((_tabId: number, message: { type: string }) => {
+      if (message.type === "GENERATE_ACCESSIBILITY_TREE") {
+        return Promise.resolve({
+          pageContent: "primary output",
+          viewport: { width: 800, height: 600 },
+        });
+      }
+      return Promise.resolve({});
+    });
+    chrome.debugger.sendCommand.mockImplementation((_target: unknown, method: string) =>
+      method === "Page.captureScreenshot"
+        ? new Promise(() => {
+            /* intentionally pending */
+          })
+        : Promise.resolve({}),
+    );
+
+    const read = handleMessage(
+      {
+        type: "READ_PAGE",
+        tabId: 71,
+        options: { includeScreenshot: true },
+      },
+      {},
+    );
+    await vi.advanceTimersByTimeAsync(5050);
+
+    await expect(read).resolves.toEqual({
+      pageContent: "primary output",
+      viewport: { width: 800, height: 600 },
+      screenshotError: "Screenshot capture timed out after 5000ms",
+    });
   });
 
   it("uses only an explicit host-provided frame context", async () => {


### PR DESCRIPTION
## Summary

- bound `Page.captureScreenshot` at the shared CDP primitive
- preserve successful primary output when optional screenshots time out
- keep direct strict-target fallback from capturing a different active tab
- release same-tab admission after bounded screenshot failure
- add focused primitive, service-worker, and native protocol regressions

Fixes #250. Thanks to @Whamp for the detailed reproduction and raw CDP isolation; the changelog includes profile-linked credit.

## Validation

- focused controller, service-worker, and native protocol tests — 119 passed
- full suite before promotion — 779 passed
- `npm run check`
- focused Biome check
- `git diff --check`

The candidate completed the required two challenge passes, retained-writer deslop and simplification passes, and a final fresh review. The only review finding was changelog placement; it is fixed in this head.