### PR TITLE
feat(frame): add frame diagnosis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - **Typed page readiness** - `surf wait.ready` polls with a bounded budget and reports `ready`, `empty`, `login`, `challenge`, `not-found` or `error` instead of timing out silently; negative states exit with `page_login`, `page_challenge`, `page_not_found`, `page_error` or `page_timeout`, and `--accept` returns them to the caller. `surf page.readiness` classifies the page once. Detection uses visible UI state and the caller's expectations (`--selector`, `--text`, `--url-prefix`, `--empty-text`), not site-specific selectors.
+- **`surf frame.diagnose`** - DOM `<iframe>` elements (including those inside open shadow roots, reported with their `shadowHost`), extension frames with a content-script reachability check, and the CDP frame tree side by side, correlated by URL and by `name`/`id` for `srcdoc`/`about:blank` frames, with warnings for blank frames, sandboxes without `allow-scripts`, cross-origin frames, out-of-process frames that `frame.js` cannot reach (and which commands still work there), still-loading frames and count mismatches. The text report abbreviates long frame URLs; `--json` keeps them whole.
 
 Thanks to [@tryingET](https://github.com/tryingET) for #255.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Thanks to [@tryingET](https://github.com/tryingET) for #255.
 - **`js --file` statement scripts** - Scripts starting with a declaration failed with `SyntaxError: Unexpected token 'const'` in real Chrome because the statement-mode fallback relied on `new Function`, which the extension CSP blocks in the service worker. The fallback now uses CDP `Runtime.compileScript`.
 - **Bounded screenshot capture** - Screenshot requests now settle when Chromium stops responding, preserving successful primary output and releasing queued work. Thanks to [@Whamp](https://github.com/Whamp) for #250.
 
-Thanks to [@tryingET](https://github.com/tryingET) for #251.
+Thanks to [@tryingET](https://github.com/tryingET) for #251 and #256.
 Thanks to [@tryingET](https://github.com/tryingET) for #253.
 
 ## [2.18.0] - 2026-09-04

--- a/README.md
+++ b/README.md
@@ -280,6 +280,13 @@ surf locate.role button --action click
 surf frame.main                     # Return to main page
 ```
 
+When a selector never matches, `frame.diagnose` shows the three frame views side by side (DOM `<iframe>` elements, the extension's frames with content-script reachability, and the CDP frame tree) and explains the mismatches: `srcdoc`/`about:blank` frames (matched to their CDP frame by `name`/`id`), sandboxes without `allow-scripts`, cross-origin frames, out-of-process frames that the CDP tree does not list (`frame.js` cannot reach them; `frame.switch` and `page.read` can when the content script answers), and frames still loading. The DOM inventory walks open shadow roots, so frames rendered by custom elements are listed with their `shadowHost` path. The text report abbreviates long frame URLs; `--json` keeps them whole.
+
+```bash
+surf frame.diagnose                 # Human-readable report with warnings
+surf frame.diagnose --json          # Full inventories
+```
+
 ### Interaction
 
 ```bash
@@ -950,7 +957,7 @@ echo '{"type":"tool_request","method":"execute_tool","params":{"tool":"tab.list"
 | `page.*` | `read`, `text`, `state`, `readiness` |
 | `locate.*` | `role`, `text`, `label` |
 | `element.*` | `styles` |
-| `frame.*` | `list`, `switch`, `main`, `js` |
+| `frame.*` | `list`, `diagnose`, `switch`, `main`, `js` |
 | `wait.*` | `element`, `network`, `url`, `dom`, `load`, `ready` |
 | `cookie` / `cookie.*` | `list`, `get`, `set`, `clear`, `delete` |
 | `bookmark.*` | `add`, `remove`, `list` |

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -3897,10 +3897,10 @@ async function handleResponse(response) {
       }
     }
     if (Array.isArray(data.extensionFrames) && data.extensionFrames.length > 0) {
-      lines.push("", "Extension frames (frame.switch ids):");
+      lines.push("", "Extension frames (frame.switch indexes, webNavigation ids):");
       for (const f of data.extensionFrames) {
         const reach = f.contentScriptReachable ? "content-script ok" : `content-script unreachable${f.contentScriptError ? ` (${f.contentScriptError})` : ""}`;
-        lines.push(`  #${f.frameId}${f.isMain ? " main" : ` parent ${f.parentFrameId}`} ${abbreviateUrl(f.url)}${f.crossOrigin ? " [cross-origin]" : ""} - ${reach}`);
+        lines.push(`  ${f.isMain ? "main" : `[${f.switchIndex}]`} #${f.frameId}${f.isMain ? "" : ` parent ${f.parentFrameId}`} ${abbreviateUrl(f.url)}${f.crossOrigin ? " [cross-origin]" : ""} - ${reach}`);
       }
     }
     if (Array.isArray(data.cdpFrames) && data.cdpFrames.length > 0) {

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -3864,6 +3864,18 @@ async function handleResponse(response) {
     for (const item of Array.isArray(data?.evidence) ? data.evidence : []) lines.push(`- ${item}`);
     console.log(lines.join("\n"));
   } else if (tool === "frame.diagnose" && data?.counts) {
+    // Keep frame URLs readable: embed runners carry kilobyte-long state
+    // parameters that bury the report (use --json for the full URLs).
+    const abbreviateUrl = (url, max = 100) => {
+      if (typeof url !== "string" || url.length <= max) return url;
+      try {
+        const parsed = new URL(url);
+        const base = `${parsed.origin}${parsed.pathname}`;
+        const trailing = url.length - base.length;
+        if (trailing > 0 && base.length <= max - 12) return `${base}?...(+${trailing} chars)`;
+      } catch {}
+      return `${url.slice(0, max - 3)}...`;
+    };
     const lines = [];
     lines.push(`Frame diagnosis for ${data.mainPage?.href ?? "?"}${data.mainPage?.title ? ` (${data.mainPage.title})` : ""}`);
     lines.push(`DOM iframes: ${data.counts.domIframes}, extension frames: ${data.counts.extensionFrames} (incl. main), CDP frames: ${data.counts.cdpFrames}`);
@@ -3880,20 +3892,20 @@ async function handleResponse(response) {
           f.extensionFrameIds?.length ? `ext ${f.extensionFrameIds.join("/")}` : "ext -",
           f.cdpFrameIds?.length ? `cdp ${f.cdpFrameIds.join("/")}` : "cdp -",
         ].join(", ");
-        lines.push(`  [${f.domIndex}] ${f.srcdoc ? "srcdoc" : (f.src || "about:blank")} ${Math.round(f.rect?.width ?? 0)}x${Math.round(f.rect?.height ?? 0)}${f.name ? ` name=${f.name}` : ""}${f.sandbox !== null && f.sandbox !== undefined ? ` sandbox="${f.sandbox}"` : ""}${flags ? ` [${flags}]` : ""} -> ${links}`);
+        lines.push(`  [${f.domIndex}] ${f.srcdoc ? "srcdoc" : abbreviateUrl(f.src || "about:blank")} ${Math.round(f.rect?.width ?? 0)}x${Math.round(f.rect?.height ?? 0)}${f.name ? ` name=${f.name}` : f.id ? ` id=${f.id}` : ""}${f.sandbox !== null && f.sandbox !== undefined ? ` sandbox="${f.sandbox}"` : ""}${f.shadowHost ? ` in shadow root of ${f.shadowHost}` : ""}${flags ? ` [${flags}]` : ""} -> ${links}`);
       }
     }
     if (Array.isArray(data.extensionFrames) && data.extensionFrames.length > 0) {
       lines.push("", "Extension frames (frame.switch ids):");
       for (const f of data.extensionFrames) {
         const reach = f.contentScriptReachable ? "content-script ok" : `content-script unreachable${f.contentScriptError ? ` (${f.contentScriptError})` : ""}`;
-        lines.push(`  #${f.frameId}${f.isMain ? " main" : ` parent ${f.parentFrameId}`} ${f.url}${f.crossOrigin ? " [cross-origin]" : ""} - ${reach}`);
+        lines.push(`  #${f.frameId}${f.isMain ? " main" : ` parent ${f.parentFrameId}`} ${abbreviateUrl(f.url)}${f.crossOrigin ? " [cross-origin]" : ""} - ${reach}`);
       }
     }
     if (Array.isArray(data.cdpFrames) && data.cdpFrames.length > 0) {
       lines.push("", "CDP frames (frame.js ids):");
       for (const f of data.cdpFrames) {
-        lines.push(`  ${f.frameId}${f.isMain ? " main" : ` parent ${f.parentId}`} ${f.url}${f.name ? ` name=${f.name}` : ""}${f.extensionFrameIds?.length ? ` -> ext ${f.extensionFrameIds.join("/")}` : ""}`);
+        lines.push(`  ${f.frameId}${f.isMain ? " main" : ` parent ${f.parentId}`} ${abbreviateUrl(f.url)}${f.name ? ` name=${f.name}` : ""}${f.extensionFrameIds?.length ? ` -> ext ${f.extensionFrameIds.join("/")}` : ""}`);
       }
     }
     lines.push("", Array.isArray(data.warnings) && data.warnings.length > 0 ? "Warnings:" : "No warnings.");

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -1784,6 +1784,7 @@ Video recording: surf video start ./demo.webm --fps 30; surf video stop
 Animation audit: surf animate-audit --selector ".thing" --duration 2000 --fps 10
 Performance audit: surf perf-audit --duration 3000 --trigger "click:.cta" --output /tmp/perf.json
 JavaScript: surf js "return document.title"
+Frames: surf frame.list | surf frame.diagnose      # diagnose explains why a selector misses inside iframes (shadow roots, srcdoc, out-of-process)
 Scroll: surf scroll down 800 | surf scroll up 400 | surf scroll bottom | surf scroll top
 Find by semantics: surf locate.role button --name "Submit" --action click
 Device/viewport: surf emulate.device "iPhone 14" | surf resize 375 812

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -3863,6 +3863,42 @@ async function handleResponse(response) {
     if (data?.accepted) lines.push("accepted: negative state returned because of --accept");
     for (const item of Array.isArray(data?.evidence) ? data.evidence : []) lines.push(`- ${item}`);
     console.log(lines.join("\n"));
+  } else if (tool === "frame.diagnose" && data?.counts) {
+    const lines = [];
+    lines.push(`Frame diagnosis for ${data.mainPage?.href ?? "?"}${data.mainPage?.title ? ` (${data.mainPage.title})` : ""}`);
+    lines.push(`DOM iframes: ${data.counts.domIframes}, extension frames: ${data.counts.extensionFrames} (incl. main), CDP frames: ${data.counts.cdpFrames}`);
+    if (Array.isArray(data.domIframes) && data.domIframes.length > 0) {
+      lines.push("", "DOM iframes:");
+      for (const f of data.domIframes) {
+        const flags = [
+          f.blank ? "blank" : null,
+          f.crossOrigin ? "cross-origin" : null,
+          f.scriptsBlocked ? "scripts-blocked" : null,
+          f.zeroSize ? "0-size" : null,
+        ].filter(Boolean).join(",");
+        const links = [
+          f.extensionFrameIds?.length ? `ext ${f.extensionFrameIds.join("/")}` : "ext -",
+          f.cdpFrameIds?.length ? `cdp ${f.cdpFrameIds.join("/")}` : "cdp -",
+        ].join(", ");
+        lines.push(`  [${f.domIndex}] ${f.srcdoc ? "srcdoc" : (f.src || "about:blank")} ${Math.round(f.rect?.width ?? 0)}x${Math.round(f.rect?.height ?? 0)}${f.name ? ` name=${f.name}` : ""}${f.sandbox !== null && f.sandbox !== undefined ? ` sandbox="${f.sandbox}"` : ""}${flags ? ` [${flags}]` : ""} -> ${links}`);
+      }
+    }
+    if (Array.isArray(data.extensionFrames) && data.extensionFrames.length > 0) {
+      lines.push("", "Extension frames (frame.switch ids):");
+      for (const f of data.extensionFrames) {
+        const reach = f.contentScriptReachable ? "content-script ok" : `content-script unreachable${f.contentScriptError ? ` (${f.contentScriptError})` : ""}`;
+        lines.push(`  #${f.frameId}${f.isMain ? " main" : ` parent ${f.parentFrameId}`} ${f.url}${f.crossOrigin ? " [cross-origin]" : ""} - ${reach}`);
+      }
+    }
+    if (Array.isArray(data.cdpFrames) && data.cdpFrames.length > 0) {
+      lines.push("", "CDP frames (frame.js ids):");
+      for (const f of data.cdpFrames) {
+        lines.push(`  ${f.frameId}${f.isMain ? " main" : ` parent ${f.parentId}`} ${f.url}${f.name ? ` name=${f.name}` : ""}${f.extensionFrameIds?.length ? ` -> ext ${f.extensionFrameIds.join("/")}` : ""}`);
+      }
+    }
+    lines.push("", Array.isArray(data.warnings) && data.warnings.length > 0 ? "Warnings:" : "No warnings.");
+    for (const w of Array.isArray(data.warnings) ? data.warnings : []) lines.push(`  - ${w}`);
+    console.log(lines.join("\n"));
   } else if (tool === "js") {
     if (data?.result !== undefined) {
       const val = data.result.value ?? data.result;

--- a/native/host-helpers.cjs
+++ b/native/host-helpers.cjs
@@ -910,6 +910,8 @@ function mapToolToMessage(tool, args, tabId) {
       return { type: "WAIT_FOR_LOAD", timeout: a.timeout || 30000, ...baseMsg };
     case "frame.list":
       return { type: "GET_FRAMES", ...baseMsg };
+    case "frame.diagnose":
+      return { type: "FRAME_DIAGNOSE", ...baseMsg };
     case "frame.switch":
       return { 
         type: "FRAME_SWITCH", 

--- a/native/mcp-server.cjs
+++ b/native/mcp-server.cjs
@@ -263,6 +263,10 @@ const TOOL_SCHEMAS = {
     desc: "List all frames in page",
     schema: {}
   },
+  "frame.diagnose": {
+    desc: "Compare DOM iframes, extension frames (with content-script reachability) and the CDP frame tree, with warnings",
+    schema: {}
+  },
   "frame.js": {
     desc: "Execute JS in specific frame",
     schema: {

--- a/native/tool-scope.cjs
+++ b/native/tool-scope.cjs
@@ -46,7 +46,7 @@ const TAB_TOOLS = new Set([
   "search", "locate.role", "locate.text", "locate.label", "element.styles",
   "js", "javascript_tool", "eval",
   "wait.element", "wait.url", "wait.network", "wait.dom", "wait.load", "wait.ready", "page.readiness", "health",
-  "frame.list", "frame.switch", "frame.main", "frame.js",
+  "frame.list", "frame.diagnose", "frame.switch", "frame.main", "frame.js",
   "dialog.accept", "dialog.dismiss", "dialog.info",
   "console", "network", "network.get", "network.body", "network.curl", "network.path",
   "network.origins", "network.clear", "network.stats", "network.export",

--- a/skills/surf/SKILL.md
+++ b/skills/surf/SKILL.md
@@ -321,6 +321,7 @@ surf page.text                 # Plain text content only
 surf page.html --strip-scripts # Rendered HTML without scripts
 surf page.save --selector "#artifact" --strip-scripts --output page.html # Save one static element
 surf page.state                # Modals, loading state, scroll info
+surf frame.diagnose            # Why a selector misses: DOM iframes (incl. open shadow roots) vs extension frames vs CDP tree, with warnings; out-of-process frames need frame.switch, not frame.js
 ```
 
 ### Export Rendered HTML

--- a/src/cdp/controller.ts
+++ b/src/cdp/controller.ts
@@ -217,12 +217,18 @@ export class CDPController {
     } catch (e) {}
   }
 
-  async detach(tabId: number): Promise<void> {
+  isAttached(tabId: number): boolean {
+    return this.targets.has(tabId);
+  }
+
+  async detach(tabId: number): Promise<{ success: boolean; error?: string }> {
     const target = this.targets.get(tabId);
+    let error: string | undefined;
     if (target) {
       try {
         await chrome.debugger.detach(target);
       } catch (e) {
+        error = e instanceof Error ? e.message : String(e);
         console.warn("[CDPController] Error detaching:", e);
       }
       this.targets.delete(tabId);
@@ -243,6 +249,7 @@ export class CDPController {
       this.clearRequestStartTimes(tabId);
       this.detachReasons.delete(tabId);
     }
+    return error ? { success: false, error } : { success: true };
   }
 
   async detachAll(): Promise<void> {

--- a/src/content/accessibility-tree.ts
+++ b/src/content/accessibility-tree.ts
@@ -1588,6 +1588,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       }
       break;
     }
+    case "PING": {
+      sendResponse({ success: true, href: location.href, readyState: document.readyState });
+      break;
+    }
     case "EVAL_IN_PAGE": {
       try {
         const script = document.createElement('script');

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -1,5 +1,11 @@
 import { CDPController } from "../cdp/controller";
 import { debugLog } from "../utils/debug";
+import {
+  DOM_IFRAME_INVENTORY_EXPRESSION,
+  type DomIframeEntry,
+  type ExtensionFrameEntry,
+  buildFrameDiagnosis,
+} from "../utils/frame-diagnose";
 import type { ReadinessExpectations } from "../utils/page-readiness";
 import {
   type ReadinessProbeResult,
@@ -216,6 +222,52 @@ function describeReadiness(result: ReadinessProbeResult): string {
   const where = result.href ? ` at ${result.href}` : "";
   const evidence = result.evidence.length > 0 ? ` (${result.evidence.join("; ")})` : "";
   return `${result.state}${where}${evidence}`;
+}
+
+async function collectDomIframeInventory(
+  tabId: number,
+): Promise<{ href: string; title: string; iframes: DomIframeEntry[] }> {
+  const result = await cdp.evaluateScript(tabId, DOM_IFRAME_INVENTORY_EXPRESSION);
+  if (result.exceptionDetails) {
+    throw new Error(
+      result.exceptionDetails.exception?.description ||
+        result.exceptionDetails.text ||
+        "Failed to collect the DOM iframe inventory",
+    );
+  }
+  const value = result.result?.value;
+  if (!value || typeof value !== "object" || !Array.isArray(value.iframes)) {
+    throw new Error("Unexpected DOM iframe inventory result shape");
+  }
+  return value as { href: string; title: string; iframes: DomIframeEntry[] };
+}
+
+/** webNavigation frames plus a content-script PING per frame. */
+async function collectExtensionFrames(tabId: number): Promise<ExtensionFrameEntry[]> {
+  const frames = (await chrome.webNavigation.getAllFrames({ tabId })) ?? [];
+  const entries: ExtensionFrameEntry[] = [];
+  for (const frame of frames) {
+    const entry: ExtensionFrameEntry = {
+      frameId: frame.frameId,
+      parentFrameId: frame.parentFrameId,
+      url: frame.url,
+      errorOccurred: frame.errorOccurred === true,
+      contentScriptReachable: false,
+    };
+    try {
+      const ping = await chrome.tabs.sendMessage(tabId, { type: "PING" }, { frameId: frame.frameId });
+      if (ping?.success) {
+        entry.contentScriptReachable = true;
+        entry.contentScript = { href: ping.href, readyState: ping.readyState };
+      } else {
+        entry.contentScriptError = ping?.error ? String(ping.error) : "no response";
+      }
+    } catch (err) {
+      entry.contentScriptError = err instanceof Error ? err.message : String(err);
+    }
+    entries.push(entry);
+  }
+  return entries;
 }
 
 const screenshotCache = new Map<string, { base64: string; width: number; height: number }>();

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -2363,7 +2363,6 @@ export async function handleMessage(
       return diagnosis;
     }
 
->>>>>>> 2dde726 (fix(frame): make diagnosis attachment-neutral)
     case "FRAME_SWITCH": {
       if (!tabId) throw new Error("No tabId provided");
       const { selector, name, index } = message;
@@ -2385,7 +2384,7 @@ export async function handleMessage(
         throw new Error("No iframes found on this page");
       }
 
-
+      let targetFrame: chrome.webNavigation.GetAllFrameResultDetails | null = null;
       if (index !== undefined) {
         if (index < 0 || index >= childFrames.length) {
           throw new Error(`Frame index ${index} out of range. Found ${childFrames.length} frame(s).`);

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -2308,6 +2308,7 @@ export async function handleMessage(
       const mainExtensionFrame = extensionFrames.find((frame) => frame.parentFrameId === -1);
       let dom = { href: mainExtensionFrame?.url ?? "", title: "", iframes: [] as DomIframeEntry[] };
       let cdpFrames: CdpFrameEntry[] = [];
+      let cdpFramesAvailable = true;
       const inventoryWarnings: string[] = [];
       const ownedAttachment = !cdp.isAttached(tabId);
       try {
@@ -2317,6 +2318,7 @@ export async function handleMessage(
           } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
             inventoryWarnings.push(`CDP inventories unavailable: ${message}`);
+            cdpFramesAvailable = false;
           }
         }
         if (cdp.isAttached(tabId)) {
@@ -2332,10 +2334,12 @@ export async function handleMessage(
               cdpFrames = cdpResult.frames ?? [];
             } else {
               inventoryWarnings.push(`CDP frame tree unavailable: ${cdpResult.error}`);
+              cdpFramesAvailable = false;
             }
           } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
             inventoryWarnings.push(`CDP frame tree unavailable: ${message}`);
+            cdpFramesAvailable = false;
           }
         }
       } finally {
@@ -2351,6 +2355,7 @@ export async function handleMessage(
         domIframes: dom.iframes,
         extensionFrames,
         cdpFrames,
+        cdpFramesAvailable,
       });
       diagnosis.warnings.unshift(...inventoryWarnings);
       // No `success` key on purpose: formatToolContent renders {success, frames}

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -1,6 +1,7 @@
 import { CDPController } from "../cdp/controller";
 import { debugLog } from "../utils/debug";
 import {
+  type CdpFrameEntry,
   DOM_IFRAME_INVENTORY_EXPRESSION,
   type DomIframeEntry,
   type ExtensionFrameEntry,
@@ -2301,6 +2302,65 @@ export async function handleMessage(
       return { success: true, frames: result.frames };
     }
 
+    case "FRAME_DIAGNOSE": {
+      if (!tabId) throw new Error("No tabId provided");
+      const extensionFrames = await collectExtensionFrames(tabId);
+      const mainExtensionFrame = extensionFrames.find((frame) => frame.parentFrameId === -1);
+      let dom = { href: mainExtensionFrame?.url ?? "", title: "", iframes: [] as DomIframeEntry[] };
+      let cdpFrames: CdpFrameEntry[] = [];
+      const inventoryWarnings: string[] = [];
+      const ownedAttachment = !cdp.isAttached(tabId);
+      let cdpAvailable = true;
+      try {
+        if (ownedAttachment) {
+          try {
+            await cdp.attach(tabId);
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            inventoryWarnings.push(`CDP inventories unavailable: ${message}`);
+            cdpAvailable = false;
+          }
+        }
+        if (cdpAvailable) {
+          try {
+            dom = await collectDomIframeInventory(tabId);
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            inventoryWarnings.push(`DOM iframe inventory unavailable: ${message}`);
+          }
+          try {
+            const cdpResult = await cdp.getFrames(tabId);
+            if (cdpResult.success) {
+              cdpFrames = cdpResult.frames ?? [];
+            } else {
+              inventoryWarnings.push(`CDP frame tree unavailable: ${cdpResult.error}`);
+            }
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            inventoryWarnings.push(`CDP frame tree unavailable: ${message}`);
+          }
+        }
+      } finally {
+        if (ownedAttachment && cdp.isAttached(tabId)) {
+          const detachResult = await cdp.detach(tabId);
+          if (!detachResult.success) {
+            inventoryWarnings.push(`CDP detach failed: ${detachResult.error}`);
+          }
+        }
+      }
+      const diagnosis = buildFrameDiagnosis({
+        mainPage: { href: dom.href, title: dom.title },
+        domIframes: dom.iframes,
+        extensionFrames,
+        cdpFrames,
+      });
+      diagnosis.warnings.unshift(...inventoryWarnings);
+      // No `success` key on purpose: formatToolContent renders {success, frames}
+      // as the bare frame list.
+      return diagnosis;
+    }
+
+>>>>>>> 2dde726 (fix(frame): make diagnosis attachment-neutral)
     case "FRAME_SWITCH": {
       if (!tabId) throw new Error("No tabId provided");
       const { selector, name, index } = message;
@@ -2322,7 +2382,6 @@ export async function handleMessage(
         throw new Error("No iframes found on this page");
       }
 
-      let targetFrame: chrome.webNavigation.GetAllFrameResultDetails | null = null;
 
       if (index !== undefined) {
         if (index < 0 || index >= childFrames.length) {

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -2310,7 +2310,6 @@ export async function handleMessage(
       let cdpFrames: CdpFrameEntry[] = [];
       const inventoryWarnings: string[] = [];
       const ownedAttachment = !cdp.isAttached(tabId);
-      let cdpAvailable = true;
       try {
         if (ownedAttachment) {
           try {
@@ -2318,10 +2317,9 @@ export async function handleMessage(
           } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
             inventoryWarnings.push(`CDP inventories unavailable: ${message}`);
-            cdpAvailable = false;
           }
         }
-        if (cdpAvailable) {
+        if (cdp.isAttached(tabId)) {
           try {
             dom = await collectDomIframeInventory(tabId);
           } catch (error) {

--- a/src/utils/frame-diagnose.ts
+++ b/src/utils/frame-diagnose.ts
@@ -81,6 +81,8 @@ export interface DiagnosedDomIframe extends DomIframeEntry {
 
 export interface DiagnosedExtensionFrame extends ExtensionFrameEntry {
   isMain: boolean;
+  /** Position accepted by frame.switch --index; null for the main frame. */
+  switchIndex: number | null;
   origin: string | null;
   crossOrigin: boolean;
 }
@@ -142,9 +144,13 @@ export function buildFrameDiagnosis(input: FrameDiagnosisInput): FrameDiagnosis 
 
   const extensionFrames: DiagnosedExtensionFrame[] = input.extensionFrames.map((frame) => {
     const origin = originOf(frame.url);
+    const isMain = frame.parentFrameId === -1;
     return {
       ...frame,
-      isMain: frame.parentFrameId === -1,
+      isMain,
+      switchIndex: isMain
+        ? null
+        : childExtensionFrames.findIndex((candidate) => candidate.frameId === frame.frameId),
       origin,
       crossOrigin: origin !== null && mainOrigin !== null && origin !== mainOrigin,
     };
@@ -188,7 +194,7 @@ export function buildFrameDiagnosis(input: FrameDiagnosisInput): FrameDiagnosis 
   const unmatchedBlank = domIframes.filter((iframe) => iframe.blank && iframe.cdpFrameIds.length === 0);
   if (unmatchedBlank.length > 0) {
     warnings.push(
-      `${unmatchedBlank.length} iframe(s) have no URL (about:blank or srcdoc): DOM indexes ${unmatchedBlank.map((iframe) => iframe.domIndex).join(", ")}. No CDP frame carries their name or id, so their content cannot be matched; give them a name or id attribute, or use frame.switch --index.`,
+      `${unmatchedBlank.length} iframe(s) have no URL (about:blank or srcdoc): DOM indexes ${unmatchedBlank.map((iframe) => iframe.domIndex).join(", ")}. No CDP frame carries their name or id, so their content cannot be matched; give them a name or id attribute. To try frame.switch --index, use the switch index shown in the extension inventory, not these DOM indexes.`,
     );
   }
 
@@ -204,6 +210,9 @@ export function buildFrameDiagnosis(input: FrameDiagnosisInput): FrameDiagnosis 
     }
     if (iframe.extensionFrameIds.length > 1) {
       warnings.push(`iframe ${iframe.domIndex} (${short(iframe.src)}) matches ${iframe.extensionFrameIds.length} extension frames by URL (${iframe.extensionFrameIds.join(", ")}); use frame.switch --index to pick one.`);
+    }
+    if (iframe.cdpFrameIds.length > 1) {
+      warnings.push(`iframe ${iframe.domIndex} (${short(iframe.src)}) matches ${iframe.cdpFrameIds.length} CDP frames (${iframe.cdpFrameIds.join(", ")}); correlation is ambiguous, so frame.js requires an explicit CDP frame id.`);
     }
     if (!iframe.blank && iframe.extensionFrameIds.length > 0 && iframe.cdpFrameIds.length === 0) {
       const reachable = iframe.extensionFrameIds.every(

--- a/src/utils/frame-diagnose.ts
+++ b/src/utils/frame-diagnose.ts
@@ -1,0 +1,252 @@
+/**
+ * Frame diagnosis: three inventories of the same page side by side.
+ *
+ * A page can carry frames that each inventory sees differently:
+ *
+ * - The DOM lists `<iframe>` elements with their attributes and layout,
+ *   but a `srcdoc` or script-created frame shows up as `about:blank`.
+ * - `chrome.webNavigation.getAllFrames` lists the frames the extension can
+ *   message, with the numeric ids `frame.switch` uses; a frame the content
+ *   script did not load in (sandboxed, restricted, still loading) is
+ *   listed but unreachable.
+ * - The CDP frame tree (`Page.getFrameTree`) lists what the renderer knows,
+ *   with the string ids `frame.js` uses, including out-of-process frames.
+ *
+ * `buildFrameDiagnosis` correlates the three by URL and explains the
+ * mismatches, so an agent can pick the right frame command instead of
+ * guessing why a selector never matches.
+ */
+
+export interface FrameRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface DomIframeEntry {
+  domIndex: number;
+  /** Resolved absolute URL (`iframe.src`), empty for srcdoc/blank frames. */
+  src: string;
+  /** The literal `src` attribute, useful when it is relative. */
+  srcAttribute?: string;
+  srcdoc: boolean;
+  title: string;
+  name: string;
+  id: string;
+  sandbox: string | null;
+  allow: string;
+  rect: FrameRect;
+}
+
+export interface ExtensionFrameEntry {
+  frameId: number;
+  parentFrameId: number;
+  url: string;
+  errorOccurred: boolean;
+  contentScriptReachable: boolean;
+  contentScript?: { href?: string; readyState?: string };
+  contentScriptError?: string;
+}
+
+export interface CdpFrameEntry {
+  frameId: string;
+  parentId?: string;
+  url: string;
+  name: string;
+}
+
+export interface FrameDiagnosisInput {
+  mainPage: { href: string; title: string };
+  domIframes: DomIframeEntry[];
+  extensionFrames: ExtensionFrameEntry[];
+  cdpFrames: CdpFrameEntry[];
+}
+
+export interface DiagnosedDomIframe extends DomIframeEntry {
+  origin: string | null;
+  crossOrigin: boolean;
+  blank: boolean;
+  zeroSize: boolean;
+  scriptsBlocked: boolean;
+  extensionFrameIds: number[];
+  cdpFrameIds: string[];
+}
+
+export interface DiagnosedExtensionFrame extends ExtensionFrameEntry {
+  isMain: boolean;
+  origin: string | null;
+  crossOrigin: boolean;
+}
+
+export interface DiagnosedCdpFrame extends CdpFrameEntry {
+  isMain: boolean;
+  origin: string | null;
+  crossOrigin: boolean;
+  extensionFrameIds: number[];
+}
+
+export interface FrameDiagnosis {
+  mainPage: { href: string; title: string; origin: string | null };
+  counts: { domIframes: number; extensionFrames: number; cdpFrames: number };
+  domIframes: DiagnosedDomIframe[];
+  extensionFrames: DiagnosedExtensionFrame[];
+  cdpFrames: DiagnosedCdpFrame[];
+  warnings: string[];
+}
+
+export function originOf(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    return parsed.origin === "null" ? null : parsed.origin;
+  } catch {
+    return null;
+  }
+}
+
+export function isBlankFrameUrl(url: string): boolean {
+  return url === "" || url === "about:blank" || url.startsWith("about:blank?") || url === "about:srcdoc";
+}
+
+/** Sandboxed frames run no scripts unless `allow-scripts` is present. */
+export function sandboxBlocksScripts(sandbox: string | null): boolean {
+  if (sandbox === null) return false;
+  return !sandbox.split(/\s+/).includes("allow-scripts");
+}
+
+function sameUrl(a: string, b: string): boolean {
+  if (isBlankFrameUrl(a) && isBlankFrameUrl(b)) return true;
+  return a === b;
+}
+
+function short(url: string, max = 80): string {
+  if (url.length <= max) return url;
+  return `${url.slice(0, max - 3)}...`;
+}
+
+export function buildFrameDiagnosis(input: FrameDiagnosisInput): FrameDiagnosis {
+  const mainOrigin = originOf(input.mainPage.href);
+  const childExtensionFrames = input.extensionFrames.filter((frame) => frame.parentFrameId !== -1);
+  const warnings: string[] = [];
+
+  const extensionFrames: DiagnosedExtensionFrame[] = input.extensionFrames.map((frame) => {
+    const origin = originOf(frame.url);
+    return {
+      ...frame,
+      isMain: frame.parentFrameId === -1,
+      origin,
+      crossOrigin: origin !== null && mainOrigin !== null && origin !== mainOrigin,
+    };
+  });
+
+  const cdpFrames: DiagnosedCdpFrame[] = input.cdpFrames.map((frame) => {
+    const origin = originOf(frame.url);
+    return {
+      ...frame,
+      isMain: frame.parentId === undefined,
+      origin,
+      crossOrigin: origin !== null && mainOrigin !== null && origin !== mainOrigin,
+      extensionFrameIds: childExtensionFrames
+        .filter((candidate) => !isBlankFrameUrl(frame.url) && sameUrl(candidate.url, frame.url))
+        .map((candidate) => candidate.frameId),
+    };
+  });
+
+  const domIframes: DiagnosedDomIframe[] = input.domIframes.map((iframe) => {
+    const blank = iframe.srcdoc || isBlankFrameUrl(iframe.src);
+    const origin = blank ? null : originOf(iframe.src);
+    const matchesUrl = (url: string): boolean => !blank && sameUrl(url, iframe.src);
+    return {
+      ...iframe,
+      origin,
+      crossOrigin: origin !== null && mainOrigin !== null && origin !== mainOrigin,
+      blank,
+      zeroSize: iframe.rect.width <= 0 || iframe.rect.height <= 0,
+      scriptsBlocked: sandboxBlocksScripts(iframe.sandbox),
+      extensionFrameIds: childExtensionFrames.filter((frame) => matchesUrl(frame.url)).map((frame) => frame.frameId),
+      cdpFrameIds: input.cdpFrames.filter((frame) => frame.parentId !== undefined && matchesUrl(frame.url)).map((frame) => frame.frameId),
+    };
+  });
+
+  const blankIframes = domIframes.filter((iframe) => iframe.blank);
+  if (blankIframes.length > 0) {
+    warnings.push(
+      `${blankIframes.length} iframe(s) have no URL (about:blank or srcdoc): DOM indexes ${blankIframes.map((iframe) => iframe.domIndex).join(", ")}. Their content cannot be matched by URL; reach it through frame.list / frame.js with the CDP frame id, or frame.switch --index.`,
+    );
+  }
+
+  for (const iframe of domIframes) {
+    if (iframe.scriptsBlocked) {
+      warnings.push(`iframe ${iframe.domIndex} (${short(iframe.src) || "no src"}) is sandboxed without allow-scripts: no content script or page script runs inside it.`);
+    }
+    if (iframe.zeroSize) {
+      warnings.push(`iframe ${iframe.domIndex} (${short(iframe.src) || "no src"}) is rendered at ${iframe.rect.width}x${iframe.rect.height}: hidden, collapsed, or not yet laid out.`);
+    }
+    if (!iframe.blank && iframe.extensionFrameIds.length === 0) {
+      warnings.push(`iframe ${iframe.domIndex} (${short(iframe.src)}) has no matching extension frame: it may still be loading, be blocked, or have navigated elsewhere.`);
+    }
+    if (iframe.extensionFrameIds.length > 1) {
+      warnings.push(`iframe ${iframe.domIndex} (${short(iframe.src)}) matches ${iframe.extensionFrameIds.length} extension frames by URL (${iframe.extensionFrameIds.join(", ")}); use frame.switch --index to pick one.`);
+    }
+  }
+
+  for (const frame of extensionFrames) {
+    if (frame.isMain) continue;
+    if (!frame.contentScriptReachable) {
+      const reason = frame.contentScriptError ? ` (${frame.contentScriptError})` : "";
+      warnings.push(`extension frame ${frame.frameId} (${short(frame.url)}) has no reachable content script${reason}: page.read, click by ref and frame.switch will not work inside it; frame.js with its CDP frame id may.`);
+    }
+    if (frame.errorOccurred) {
+      warnings.push(`extension frame ${frame.frameId} (${short(frame.url)}) reported a navigation error.`);
+    }
+  }
+
+  const unseenByExtension = cdpFrames.filter(
+    (frame) => !frame.isMain && !isBlankFrameUrl(frame.url) && frame.extensionFrameIds.length === 0,
+  );
+  for (const frame of unseenByExtension) {
+    warnings.push(`CDP frame ${frame.frameId} (${short(frame.url)}) is not reported by chrome.webNavigation: likely out-of-process or detached; only frame.js can reach it.`);
+  }
+
+  const crossOriginCount = domIframes.filter((iframe) => iframe.crossOrigin).length;
+  if (crossOriginCount > 0) {
+    warnings.push(`${crossOriginCount} cross-origin iframe(s): selectors from the main page do not reach them; switch with frame.switch first.`);
+  }
+
+  if (domIframes.length !== childExtensionFrames.length) {
+    warnings.push(`DOM lists ${domIframes.length} iframe(s) but the extension sees ${childExtensionFrames.length} child frame(s); nested or detached frames account for the difference.`);
+  }
+
+  return {
+    mainPage: { ...input.mainPage, origin: mainOrigin },
+    counts: {
+      domIframes: domIframes.length,
+      extensionFrames: extensionFrames.length,
+      cdpFrames: cdpFrames.length,
+    },
+    domIframes,
+    extensionFrames,
+    cdpFrames,
+    warnings,
+  };
+}
+
+/** Page-side expression that returns the DOM iframe inventory as a plain object. */
+export const DOM_IFRAME_INVENTORY_EXPRESSION = `(() => {
+  const iframes = Array.from(document.querySelectorAll("iframe")).map((el, domIndex) => {
+    const rect = el.getBoundingClientRect();
+    return {
+      domIndex,
+      src: el.hasAttribute("srcdoc") ? "" : el.src || "",
+      srcAttribute: el.getAttribute("src") || "",
+      srcdoc: el.hasAttribute("srcdoc"),
+      title: el.title || "",
+      name: el.getAttribute("name") || "",
+      id: el.id || "",
+      sandbox: el.hasAttribute("sandbox") ? el.getAttribute("sandbox") : null,
+      allow: el.getAttribute("allow") || "",
+      rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+    };
+  });
+  return { href: location.href, title: document.title, iframes };
+})()`;

--- a/src/utils/frame-diagnose.ts
+++ b/src/utils/frame-diagnose.ts
@@ -67,6 +67,7 @@ export interface FrameDiagnosisInput {
   domIframes: DomIframeEntry[];
   extensionFrames: ExtensionFrameEntry[];
   cdpFrames: CdpFrameEntry[];
+  cdpFramesAvailable?: boolean;
 }
 
 export interface DiagnosedDomIframe extends DomIframeEntry {
@@ -139,6 +140,7 @@ function frameName(iframe: DomIframeEntry): string {
 
 export function buildFrameDiagnosis(input: FrameDiagnosisInput): FrameDiagnosis {
   const mainOrigin = originOf(input.mainPage.href);
+  const cdpFramesAvailable = input.cdpFramesAvailable !== false;
   const childExtensionFrames = input.extensionFrames.filter((frame) => frame.parentFrameId !== -1);
   const warnings: string[] = [];
 
@@ -164,7 +166,12 @@ export function buildFrameDiagnosis(input: FrameDiagnosisInput): FrameDiagnosis 
       origin,
       crossOrigin: origin !== null && mainOrigin !== null && origin !== mainOrigin,
       extensionFrameIds: childExtensionFrames
-        .filter((candidate) => !isBlankFrameUrl(frame.url) && sameUrl(candidate.url, frame.url))
+        .filter(
+          (candidate) =>
+            frame.parentId !== undefined &&
+            !isBlankFrameUrl(frame.url) &&
+            sameUrl(candidate.url, frame.url),
+        )
         .map((candidate) => candidate.frameId),
     };
   });
@@ -191,7 +198,9 @@ export function buildFrameDiagnosis(input: FrameDiagnosisInput): FrameDiagnosis 
     };
   });
 
-  const unmatchedBlank = domIframes.filter((iframe) => iframe.blank && iframe.cdpFrameIds.length === 0);
+  const unmatchedBlank = cdpFramesAvailable
+    ? domIframes.filter((iframe) => iframe.blank && iframe.cdpFrameIds.length === 0)
+    : [];
   if (unmatchedBlank.length > 0) {
     warnings.push(
       `${unmatchedBlank.length} iframe(s) have no URL (about:blank or srcdoc): DOM indexes ${unmatchedBlank.map((iframe) => iframe.domIndex).join(", ")}. No CDP frame carries their name or id, so their content cannot be matched; give them a name or id. For frame.switch --index, use extension-inventory indexes, not DOM indexes.`,
@@ -214,7 +223,7 @@ export function buildFrameDiagnosis(input: FrameDiagnosisInput): FrameDiagnosis 
     if (iframe.cdpFrameIds.length > 1) {
       warnings.push(`iframe ${iframe.domIndex} (${short(iframe.src)}) matches ${iframe.cdpFrameIds.length} CDP frames (${iframe.cdpFrameIds.join(", ")}); correlation is ambiguous, so frame.js requires an explicit CDP frame id.`);
     }
-    if (!iframe.blank && iframe.extensionFrameIds.length > 0 && iframe.cdpFrameIds.length === 0) {
+    if (cdpFramesAvailable && !iframe.blank && iframe.extensionFrameIds.length > 0 && iframe.cdpFrameIds.length === 0) {
       const reachable = iframe.extensionFrameIds.every(
         (id) => input.extensionFrames.find((frame) => frame.frameId === id)?.contentScriptReachable === true,
       );
@@ -231,6 +240,28 @@ export function buildFrameDiagnosis(input: FrameDiagnosisInput): FrameDiagnosis 
           `iframe ${iframe.domIndex} (${short(iframe.src)}) has an extension frame but no CDP frame: it is still loading, navigated, or runs out of process; retry, or use frame.switch.`,
         );
       }
+    }
+  }
+
+  for (const frame of childExtensionFrames) {
+    const domMatches = domIframes.filter((iframe) => iframe.extensionFrameIds.includes(frame.frameId));
+    if (domMatches.length > 1) {
+      warnings.push(`extension frame ${frame.frameId} (${short(frame.url)}) matches ${domMatches.length} DOM iframes (${domMatches.map((iframe) => iframe.domIndex).join(", ")}); correlation is ambiguous.`);
+    }
+    const cdpMatches = cdpFrames.filter((candidate) => candidate.extensionFrameIds.includes(frame.frameId));
+    if (cdpMatches.length > 1) {
+      warnings.push(`extension frame ${frame.frameId} (${short(frame.url)}) matches ${cdpMatches.length} CDP frames (${cdpMatches.map((candidate) => candidate.frameId).join(", ")}) by URL; correlation is ambiguous.`);
+    }
+  }
+
+  for (const frame of cdpFrames) {
+    if (frame.isMain) continue;
+    const domMatches = domIframes.filter((iframe) => iframe.cdpFrameIds.includes(frame.frameId));
+    if (domMatches.length > 1) {
+      warnings.push(`CDP frame ${frame.frameId} (${short(frame.url)}) matches ${domMatches.length} DOM iframes (${domMatches.map((iframe) => iframe.domIndex).join(", ")}); correlation is ambiguous.`);
+    }
+    if (frame.extensionFrameIds.length > 1) {
+      warnings.push(`CDP frame ${frame.frameId} (${short(frame.url)}) matches ${frame.extensionFrameIds.length} extension frames by URL (${frame.extensionFrameIds.join(", ")}); correlation is ambiguous.`);
     }
   }
 

--- a/src/utils/frame-diagnose.ts
+++ b/src/utils/frame-diagnose.ts
@@ -37,6 +37,12 @@ export interface DomIframeEntry {
   sandbox: string | null;
   allow: string;
   rect: FrameRect;
+  /**
+   * Path of shadow hosts the iframe sits under (`div#host > x-widget`), or
+   * null when it is in the light DOM. `document.querySelectorAll("iframe")`
+   * never sees the former.
+   */
+  shadowHost?: string | null;
 }
 
 export interface ExtensionFrameEntry {
@@ -124,6 +130,11 @@ function short(url: string, max = 80): string {
   return `${url.slice(0, max - 3)}...`;
 }
 
+/** The name CDP reports for a frame is the iframe's `name`, else its `id`. */
+function frameName(iframe: DomIframeEntry): string {
+  return iframe.name || iframe.id || "";
+}
+
 export function buildFrameDiagnosis(input: FrameDiagnosisInput): FrameDiagnosis {
   const mainOrigin = originOf(input.mainPage.href);
   const childExtensionFrames = input.extensionFrames.filter((frame) => frame.parentFrameId !== -1);
@@ -156,22 +167,28 @@ export function buildFrameDiagnosis(input: FrameDiagnosisInput): FrameDiagnosis 
     const blank = iframe.srcdoc || isBlankFrameUrl(iframe.src);
     const origin = blank ? null : originOf(iframe.src);
     const matchesUrl = (url: string): boolean => !blank && sameUrl(url, iframe.src);
+    const name = frameName(iframe);
+    // CDP names frames after the iframe's name/id, which is the only handle a
+    // srcdoc or about:blank frame has.
+    const matchesCdp = (frame: CdpFrameEntry): boolean =>
+      frame.parentId !== undefined && (matchesUrl(frame.url) || (name !== "" && frame.name === name));
     return {
       ...iframe,
+      shadowHost: iframe.shadowHost ?? null,
       origin,
       crossOrigin: origin !== null && mainOrigin !== null && origin !== mainOrigin,
       blank,
       zeroSize: iframe.rect.width <= 0 || iframe.rect.height <= 0,
       scriptsBlocked: sandboxBlocksScripts(iframe.sandbox),
       extensionFrameIds: childExtensionFrames.filter((frame) => matchesUrl(frame.url)).map((frame) => frame.frameId),
-      cdpFrameIds: input.cdpFrames.filter((frame) => frame.parentId !== undefined && matchesUrl(frame.url)).map((frame) => frame.frameId),
+      cdpFrameIds: input.cdpFrames.filter(matchesCdp).map((frame) => frame.frameId),
     };
   });
 
-  const blankIframes = domIframes.filter((iframe) => iframe.blank);
-  if (blankIframes.length > 0) {
+  const unmatchedBlank = domIframes.filter((iframe) => iframe.blank && iframe.cdpFrameIds.length === 0);
+  if (unmatchedBlank.length > 0) {
     warnings.push(
-      `${blankIframes.length} iframe(s) have no URL (about:blank or srcdoc): DOM indexes ${blankIframes.map((iframe) => iframe.domIndex).join(", ")}. Their content cannot be matched by URL; reach it through frame.list / frame.js with the CDP frame id, or frame.switch --index.`,
+      `${unmatchedBlank.length} iframe(s) have no URL (about:blank or srcdoc): DOM indexes ${unmatchedBlank.map((iframe) => iframe.domIndex).join(", ")}. No CDP frame carries their name or id, so their content cannot be matched; give them a name or id attribute, or use frame.switch --index.`,
     );
   }
 
@@ -187,6 +204,24 @@ export function buildFrameDiagnosis(input: FrameDiagnosisInput): FrameDiagnosis 
     }
     if (iframe.extensionFrameIds.length > 1) {
       warnings.push(`iframe ${iframe.domIndex} (${short(iframe.src)}) matches ${iframe.extensionFrameIds.length} extension frames by URL (${iframe.extensionFrameIds.join(", ")}); use frame.switch --index to pick one.`);
+    }
+    if (!iframe.blank && iframe.extensionFrameIds.length > 0 && iframe.cdpFrameIds.length === 0) {
+      const reachable = iframe.extensionFrameIds.every(
+        (id) => input.extensionFrames.find((frame) => frame.frameId === id)?.contentScriptReachable === true,
+      );
+      if (iframe.crossOrigin) {
+        warnings.push(
+          `iframe ${iframe.domIndex} (${short(iframe.src)}) is out-of-process: it is missing from this tab's CDP frame tree, so frame.js cannot reach it; ${
+            reachable
+              ? "its content script answers, so frame.switch, page.read and click by ref work there."
+              : "its content script is unreachable too, so nothing in this tab can drive it."
+          }`,
+        );
+      } else {
+        warnings.push(
+          `iframe ${iframe.domIndex} (${short(iframe.src)}) has an extension frame but no CDP frame: it is still loading, navigated, or runs out of process; retry, or use frame.switch.`,
+        );
+      }
     }
   }
 
@@ -214,7 +249,16 @@ export function buildFrameDiagnosis(input: FrameDiagnosisInput): FrameDiagnosis 
   }
 
   if (domIframes.length !== childExtensionFrames.length) {
-    warnings.push(`DOM lists ${domIframes.length} iframe(s) but the extension sees ${childExtensionFrames.length} child frame(s); nested or detached frames account for the difference.`);
+    const nested = childExtensionFrames.filter((frame) => frame.parentFrameId !== 0).length;
+    const shadowed = domIframes.filter((iframe) => iframe.shadowHost).length;
+    const explained = domIframes.length === childExtensionFrames.length - nested;
+    warnings.push(
+      `DOM lists ${domIframes.length} iframe(s)${shadowed > 0 ? ` (${shadowed} inside open shadow roots)` : ""} but the extension sees ${childExtensionFrames.length} child frame(s)${nested > 0 ? `, ${nested} of them nested below another frame` : ""}; ${
+        explained
+          ? "the nested frames account for the difference."
+          : "the rest live in closed shadow roots, were created after the snapshot, or are detached."
+      }`,
+    );
   }
 
   return {
@@ -233,10 +277,22 @@ export function buildFrameDiagnosis(input: FrameDiagnosisInput): FrameDiagnosis 
 
 /** Page-side expression that returns the DOM iframe inventory as a plain object. */
 export const DOM_IFRAME_INVENTORY_EXPRESSION = `(() => {
-  const iframes = Array.from(document.querySelectorAll("iframe")).map((el, domIndex) => {
+  const describe = (el) => el.tagName.toLowerCase() + (el.id ? "#" + el.id : "") + (el.classList.length ? "." + Array.from(el.classList).slice(0, 2).join(".") : "");
+  const found = [];
+  // Walk open shadow roots too: querySelectorAll("iframe") on the document
+  // misses every frame a custom element renders inside its shadow tree.
+  const walk = (root, hostPath) => {
+    for (const el of root.querySelectorAll("iframe")) found.push({ el, hostPath });
+    for (const host of root.querySelectorAll("*")) {
+      if (host.shadowRoot) walk(host.shadowRoot, hostPath ? hostPath + " > " + describe(host) : describe(host));
+    }
+  };
+  walk(document, "");
+  const iframes = found.map(({ el, hostPath }, domIndex) => {
     const rect = el.getBoundingClientRect();
     return {
       domIndex,
+      shadowHost: hostPath || null,
       src: el.hasAttribute("srcdoc") ? "" : el.src || "",
       srcAttribute: el.getAttribute("src") || "",
       srcdoc: el.hasAttribute("srcdoc"),

--- a/src/utils/frame-diagnose.ts
+++ b/src/utils/frame-diagnose.ts
@@ -194,7 +194,7 @@ export function buildFrameDiagnosis(input: FrameDiagnosisInput): FrameDiagnosis 
   const unmatchedBlank = domIframes.filter((iframe) => iframe.blank && iframe.cdpFrameIds.length === 0);
   if (unmatchedBlank.length > 0) {
     warnings.push(
-      `${unmatchedBlank.length} iframe(s) have no URL (about:blank or srcdoc): DOM indexes ${unmatchedBlank.map((iframe) => iframe.domIndex).join(", ")}. No CDP frame carries their name or id, so their content cannot be matched; give them a name or id attribute. To try frame.switch --index, use the switch index shown in the extension inventory, not these DOM indexes.`,
+      `${unmatchedBlank.length} iframe(s) have no URL (about:blank or srcdoc): DOM indexes ${unmatchedBlank.map((iframe) => iframe.domIndex).join(", ")}. No CDP frame carries their name or id, so their content cannot be matched; give them a name or id. For frame.switch --index, use extension-inventory indexes, not DOM indexes.`,
     );
   }
 

--- a/test/e2e/real-chrome.mjs
+++ b/test/e2e/real-chrome.mjs
@@ -34,6 +34,7 @@ const screenshotPath = join(scratch, "shot.png");
 const hostPidPath = join(scratch, "native-host.pid");
 let browser;
 let browserPid;
+let crossOriginServer;
 let chromeExecutablePath;
 let puppeteer;
 let server;
@@ -132,8 +133,19 @@ async function runSurfExpectingFailure(...args) {
   }
 }
 
-function fixturePages(request) {
+function fixturePages(request, { crossOriginBase }) {
   const url = new URL(request.url, "http://127.0.0.1");
+  if (url.pathname === "/frames") {
+    return `<!doctype html><html><head><title>Surf frames fixture</title></head>
+<body><h1>Frames</h1>
+<iframe id="same-origin" src="/fixture" width="300" height="120"></iframe>
+<iframe id="inline" srcdoc="<p>inline</p>" width="200" height="60"></iframe>
+<iframe id="cross-origin" src="${crossOriginBase}/fixture" width="300" height="120"></iframe>
+<iframe id="sandboxed" src="/fixture?sandboxed" sandbox="allow-forms" width="200" height="60"></iframe>
+<div id="host"></div>
+<script>document.getElementById("host").attachShadow({ mode: "open" }).innerHTML = '<iframe id="shadowed" src="/fixture?shadowed" width="200" height="60"></iframe>';</script>
+</body></html>`;
+  }
   if (url.pathname === "/login") {
     return `<!doctype html><html><head><title>Sign in - Surf fixture</title></head>
 <body><main><h1>Sign in</h1><form><label>Email <input type="email" name="email"></label>
@@ -224,8 +236,18 @@ try {
   mkdirSync(join(profileDir, "NativeMessagingHosts"), { recursive: true });
   cpSync(standardManifest, testingManifest);
 
+  crossOriginServer = createServer((request, response) => {
+    response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+    response.end(`<!doctype html><html><head><title>Cross-origin fixture</title></head><body><p>cross-origin ${request.url}</p></body></html>`);
+  });
+  await new Promise((resolve, reject) => {
+    crossOriginServer.once("error", reject);
+    crossOriginServer.listen(0, "127.0.0.1", resolve);
+  });
+  const crossOriginBase = `http://127.0.0.1:${crossOriginServer.address().port}`;
+
   server = createServer((request, response) => {
-    const extraPage = fixturePages(request);
+    const extraPage = fixturePages(request, { crossOriginBase });
     if (extraPage !== null) {
       response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
       response.end(extraPage);
@@ -418,6 +440,36 @@ try {
   }
   await runSurf("tab.close", "--id", String(loginTab.tabId), "--json");
 
+  // --- frame.diagnose ----------------------------------------------------
+  const framesTab = { tabId: tabIdFromOutput(await runSurf("tab.new", `${baseUrl}/frames`)) };
+  await runSurf("wait.element", "#sandboxed", "--tab-id", String(framesTab.tabId), "--json");
+  await runSurf("wait.dom", "--tab-id", String(framesTab.tabId), "--json");
+  const diagnosis = unwrapJson(await runSurf("frame.diagnose", "--json", "--tab-id", String(framesTab.tabId)));
+  const byId = Object.fromEntries(diagnosis.domIframes.map((frame) => [frame.id, frame]));
+  if (diagnosis.counts.domIframes !== 5 || !byId["same-origin"] || !byId["inline"] || !byId["cross-origin"] || !byId["sandboxed"] || !byId["shadowed"]) {
+    throw new Error(`frame.diagnose did not list the five fixture iframes: ${JSON.stringify(diagnosis)}`);
+  }
+  if (byId["same-origin"].extensionFrameIds.length !== 1 || byId["same-origin"].cdpFrameIds.length !== 1) {
+    throw new Error(`same-origin iframe was not correlated: ${JSON.stringify(byId["same-origin"])}`);
+  }
+  if (byId["shadowed"].shadowHost !== "div#host" || byId["shadowed"].extensionFrameIds.length !== 1) {
+    throw new Error(`shadow-hosted iframe was not inventoried: ${JSON.stringify(byId["shadowed"])}`);
+  }
+  if (byId["inline"].cdpFrameIds.length !== 1) {
+    throw new Error(`srcdoc iframe was not matched to its CDP frame by id: ${JSON.stringify(byId["inline"])}`);
+  }
+  if (!byId["inline"].blank || byId["cross-origin"].crossOrigin !== true || byId["sandboxed"].scriptsBlocked !== true) {
+    throw new Error(`frame flags are wrong: ${JSON.stringify(byId)}`);
+  }
+  const sameOriginFrame = diagnosis.extensionFrames.find((frame) => frame.frameId === byId["same-origin"].extensionFrameIds[0]);
+  if (!sameOriginFrame?.contentScriptReachable) {
+    throw new Error(`content script PING did not reach the same-origin iframe: ${JSON.stringify(diagnosis.extensionFrames)}`);
+  }
+  if (!diagnosis.warnings.some((line) => line.includes("srcdoc")) || !diagnosis.warnings.some((line) => line.includes("allow-scripts"))) {
+    throw new Error(`frame.diagnose warnings missing: ${JSON.stringify(diagnosis.warnings)}`);
+  }
+  await runSurf("tab.close", "--id", String(framesTab.tabId), "--json");
+
   await runSurf("screenshot", "--output", screenshotPath);
   const png = readFileSync(screenshotPath);
   if (png.length < 100 || png.subarray(0, 8).toString("hex") !== "89504e470d0a1a0a") {
@@ -461,6 +513,7 @@ try {
         platform: process.platform,
         result: "pass",
         readiness: { fixture: readiness.state, loginAccepted: acceptedLogin.state },
+        frameDiagnoseWarnings: diagnosis.warnings.length,
         screenshotBytes: png.length,
         serviceWorker: workerTarget.url(),
       },
@@ -492,6 +545,15 @@ try {
   if (server) {
     await new Promise((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+} catch (error) {
+  cleanupErrors.push(error);
+}
+try {
+  if (crossOriginServer) {
+    await new Promise((resolve, reject) => {
+      crossOriginServer.close((error) => (error ? reject(error) : resolve()));
     });
   }
 } catch (error) {

--- a/test/e2e/real-chrome.mjs
+++ b/test/e2e/real-chrome.mjs
@@ -236,9 +236,9 @@ try {
   mkdirSync(join(profileDir, "NativeMessagingHosts"), { recursive: true });
   cpSync(standardManifest, testingManifest);
 
-  crossOriginServer = createServer((request, response) => {
+  crossOriginServer = createServer((_request, response) => {
     response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
-    response.end(`<!doctype html><html><head><title>Cross-origin fixture</title></head><body><p>cross-origin ${request.url}</p></body></html>`);
+    response.end("<!doctype html><html><head><title>Cross-origin fixture</title></head><body><p>cross-origin fixture</p></body></html>");
   });
   await new Promise((resolve, reject) => {
     crossOriginServer.once("error", reject);

--- a/test/unit/frame-diagnose.test.ts
+++ b/test/unit/frame-diagnose.test.ts
@@ -200,7 +200,84 @@ describe("buildFrameDiagnosis", () => {
     expect(result.warnings).toEqual([
       "iframe 0 (https://late.example.com/) has no matching extension frame: it may still be loading, be blocked, or have navigated elsewhere.",
       "1 cross-origin iframe(s): selectors from the main page do not reach them; switch with frame.switch first.",
-      "DOM lists 1 iframe(s) but the extension sees 0 child frame(s); nested or detached frames account for the difference.",
+      "DOM lists 1 iframe(s) but the extension sees 0 child frame(s); the rest live in closed shadow roots, were created after the snapshot, or are detached.",
+    ]);
+  });
+
+  it("matches srcdoc and about:blank iframes to CDP frames by name or id", () => {
+    const result = buildFrameDiagnosis({
+      mainPage: { href: MAIN, title: "Page" },
+      domIframes: [
+        iframe({ src: "", srcdoc: true, id: "inline" }),
+        iframe({ domIndex: 1, src: "about:blank", name: "hidden" }),
+        iframe({ domIndex: 2, src: "about:blank" }),
+      ],
+      extensionFrames: [
+        mainExt,
+        extFrame({ frameId: 3, url: "about:srcdoc" }),
+        extFrame({ frameId: 4, url: "about:blank" }),
+      ],
+      cdpFrames: [
+        mainCdp,
+        cdpFrame({ frameId: "F3", url: "about:srcdoc", name: "inline" }),
+        cdpFrame({ frameId: "F4", url: "about:blank", name: "hidden" }),
+      ],
+    });
+    expect(result.domIframes.map((entry) => entry.cdpFrameIds)).toEqual([["F3"], ["F4"], []]);
+    expect(result.warnings[0]).toBe(
+      "1 iframe(s) have no URL (about:blank or srcdoc): DOM indexes 2. No CDP frame carries their name or id, so their content cannot be matched; give them a name or id attribute, or use frame.switch --index.",
+    );
+  });
+
+  it("explains out-of-process iframes that the CDP frame tree does not list", () => {
+    const result = buildFrameDiagnosis({
+      mainPage: { href: MAIN, title: "Page" },
+      domIframes: [
+        iframe({ src: "https://www.youtube.com/embed/x" }),
+        iframe({ domIndex: 1, src: "https://example.org/", sandbox: "" }),
+      ],
+      extensionFrames: [
+        mainExt,
+        extFrame({ frameId: 54, url: "https://www.youtube.com/embed/x" }),
+        extFrame({
+          frameId: 57,
+          url: "https://example.org/",
+          contentScriptReachable: false,
+          contentScriptError: "Receiving end does not exist.",
+        }),
+      ],
+      cdpFrames: [mainCdp],
+    });
+    expect(result.domIframes.map((entry) => entry.cdpFrameIds)).toEqual([[], []]);
+    expect(result.warnings).toContain(
+      "iframe 0 (https://www.youtube.com/embed/x) is out-of-process: it is missing from this tab's CDP frame tree, so frame.js cannot reach it; its content script answers, so frame.switch, page.read and click by ref work there.",
+    );
+    expect(result.warnings).toContain(
+      "iframe 1 (https://example.org/) is out-of-process: it is missing from this tab's CDP frame tree, so frame.js cannot reach it; its content script is unreachable too, so nothing in this tab can drive it.",
+    );
+    expect(result.warnings.some((line) => line.includes("DOM lists"))).toBe(false);
+  });
+
+  it("reports shadow-hosted iframes and nested frames in the count mismatch", () => {
+    const result = buildFrameDiagnosis({
+      mainPage: { href: MAIN, title: "Page" },
+      domIframes: [
+        iframe({ src: "https://app.example.com/inner", shadowHost: "div#host > x-widget" }),
+      ],
+      extensionFrames: [
+        mainExt,
+        extFrame({ frameId: 5, url: "https://app.example.com/inner" }),
+        extFrame({ frameId: 6, parentFrameId: 5, url: "https://app.example.com/inner/nested" }),
+      ],
+      cdpFrames: [
+        mainCdp,
+        cdpFrame({ frameId: "F5", url: "https://app.example.com/inner" }),
+        cdpFrame({ frameId: "F6", parentId: "F5", url: "https://app.example.com/inner/nested" }),
+      ],
+    });
+    expect(result.domIframes[0].shadowHost).toBe("div#host > x-widget");
+    expect(result.warnings).toEqual([
+      "DOM lists 1 iframe(s) (1 inside open shadow roots) but the extension sees 2 child frame(s), 1 of them nested below another frame; the nested frames account for the difference.",
     ]);
   });
 });

--- a/test/unit/frame-diagnose.test.ts
+++ b/test/unit/frame-diagnose.test.ts
@@ -263,7 +263,7 @@ describe("buildFrameDiagnosis", () => {
     });
     expect(result.domIframes.map((entry) => entry.cdpFrameIds)).toEqual([["F3"], ["F4"], []]);
     expect(result.warnings[0]).toBe(
-      "1 iframe(s) have no URL (about:blank or srcdoc): DOM indexes 2. No CDP frame carries their name or id, so their content cannot be matched; give them a name or id attribute. To try frame.switch --index, use the switch index shown in the extension inventory, not these DOM indexes.",
+      "1 iframe(s) have no URL (about:blank or srcdoc): DOM indexes 2. No CDP frame carries their name or id, so their content cannot be matched; give them a name or id. For frame.switch --index, use extension-inventory indexes, not DOM indexes.",
     );
   });
 

--- a/test/unit/frame-diagnose.test.ts
+++ b/test/unit/frame-diagnose.test.ts
@@ -97,6 +97,8 @@ describe("buildFrameDiagnosis", () => {
       cdpFrameIds: ["F2"],
     });
     expect(result.extensionFrames[0].isMain).toBe(true);
+    expect(result.extensionFrames[0].switchIndex).toBeNull();
+    expect(result.extensionFrames[1].switchIndex).toBe(0);
     expect(result.extensionFrames[1].crossOrigin).toBe(true);
     expect(result.cdpFrames[1].extensionFrameIds).toEqual([7]);
     expect(result.warnings).toEqual([
@@ -190,6 +192,42 @@ describe("buildFrameDiagnosis", () => {
     ).toHaveLength(2);
   });
 
+  it("reports repeated CDP URLs as ambiguous", () => {
+    const result = buildFrameDiagnosis({
+      mainPage: { href: MAIN, title: "Page" },
+      domIframes: [iframe()],
+      extensionFrames: [mainExt, extFrame()],
+      cdpFrames: [mainCdp, cdpFrame({ frameId: "F2" }), cdpFrame({ frameId: "F3" })],
+    });
+
+    expect(result.domIframes[0].cdpFrameIds).toEqual(["F2", "F3"]);
+    expect(result.warnings).toContain(
+      "iframe 0 (https://widgets.example.net/embed) matches 2 CDP frames (F2, F3); correlation is ambiguous, so frame.js requires an explicit CDP frame id.",
+    );
+  });
+
+  it("correlates by URL when DOM and webNavigation ordering differ", () => {
+    const firstUrl = "https://app.example.com/first";
+    const secondUrl = "https://app.example.com/second";
+    const result = buildFrameDiagnosis({
+      mainPage: { href: MAIN, title: "Page" },
+      domIframes: [iframe({ src: firstUrl }), iframe({ domIndex: 1, src: secondUrl })],
+      extensionFrames: [
+        mainExt,
+        extFrame({ frameId: 8, url: secondUrl }),
+        extFrame({ frameId: 7, url: firstUrl }),
+      ],
+      cdpFrames: [
+        mainCdp,
+        cdpFrame({ frameId: "F2", url: firstUrl }),
+        cdpFrame({ frameId: "F3", url: secondUrl }),
+      ],
+    });
+
+    expect(result.domIframes.map((entry) => entry.extensionFrameIds)).toEqual([[7], [8]]);
+    expect(result.extensionFrames.map((entry) => entry.switchIndex)).toEqual([null, 0, 1]);
+  });
+
   it("reports DOM iframes the extension does not list and count mismatches", () => {
     const result = buildFrameDiagnosis({
       mainPage: { href: MAIN, title: "Page" },
@@ -225,7 +263,7 @@ describe("buildFrameDiagnosis", () => {
     });
     expect(result.domIframes.map((entry) => entry.cdpFrameIds)).toEqual([["F3"], ["F4"], []]);
     expect(result.warnings[0]).toBe(
-      "1 iframe(s) have no URL (about:blank or srcdoc): DOM indexes 2. No CDP frame carries their name or id, so their content cannot be matched; give them a name or id attribute, or use frame.switch --index.",
+      "1 iframe(s) have no URL (about:blank or srcdoc): DOM indexes 2. No CDP frame carries their name or id, so their content cannot be matched; give them a name or id attribute. To try frame.switch --index, use the switch index shown in the extension inventory, not these DOM indexes.",
     );
   });
 

--- a/test/unit/frame-diagnose.test.ts
+++ b/test/unit/frame-diagnose.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFrameDiagnosis,
+  type CdpFrameEntry,
+  type DomIframeEntry,
+  type ExtensionFrameEntry,
+  isBlankFrameUrl,
+  originOf,
+  sandboxBlocksScripts,
+} from "../../src/utils/frame-diagnose";
+
+const MAIN = "https://app.example.com/page";
+
+function iframe(overrides: Partial<DomIframeEntry> = {}): DomIframeEntry {
+  return {
+    domIndex: 0,
+    src: "https://widgets.example.net/embed",
+    srcdoc: false,
+    title: "",
+    name: "",
+    id: "",
+    sandbox: null,
+    allow: "",
+    rect: { x: 0, y: 0, width: 300, height: 200 },
+    ...overrides,
+  };
+}
+
+function extFrame(overrides: Partial<ExtensionFrameEntry> = {}): ExtensionFrameEntry {
+  return {
+    frameId: 7,
+    parentFrameId: 0,
+    url: "https://widgets.example.net/embed",
+    errorOccurred: false,
+    contentScriptReachable: true,
+    contentScript: { href: "https://widgets.example.net/embed", readyState: "complete" },
+    ...overrides,
+  };
+}
+
+const mainExt: ExtensionFrameEntry = {
+  frameId: 0,
+  parentFrameId: -1,
+  url: MAIN,
+  errorOccurred: false,
+  contentScriptReachable: true,
+};
+
+function cdpFrame(overrides: Partial<CdpFrameEntry> = {}): CdpFrameEntry {
+  return {
+    frameId: "F2",
+    parentId: "F1",
+    url: "https://widgets.example.net/embed",
+    name: "",
+    ...overrides,
+  };
+}
+
+const mainCdp: CdpFrameEntry = { frameId: "F1", url: MAIN, name: "" };
+
+describe("helpers", () => {
+  it("computes origins and blank URLs", () => {
+    expect(originOf("https://a.example.com/x?y")).toBe("https://a.example.com");
+    expect(originOf("about:blank")).toBeNull();
+    expect(originOf("not a url")).toBeNull();
+    expect(isBlankFrameUrl("")).toBe(true);
+    expect(isBlankFrameUrl("about:blank?x")).toBe(true);
+    expect(isBlankFrameUrl("about:srcdoc")).toBe(true);
+    expect(isBlankFrameUrl("https://a/")).toBe(false);
+  });
+
+  it("knows when a sandbox blocks scripts", () => {
+    expect(sandboxBlocksScripts(null)).toBe(false);
+    expect(sandboxBlocksScripts("")).toBe(true);
+    expect(sandboxBlocksScripts("allow-forms")).toBe(true);
+    expect(sandboxBlocksScripts("allow-forms allow-scripts")).toBe(false);
+  });
+});
+
+describe("buildFrameDiagnosis", () => {
+  it("correlates a healthy cross-origin iframe across all three inventories", () => {
+    const result = buildFrameDiagnosis({
+      mainPage: { href: MAIN, title: "Page" },
+      domIframes: [iframe()],
+      extensionFrames: [mainExt, extFrame()],
+      cdpFrames: [mainCdp, cdpFrame()],
+    });
+
+    expect(result.mainPage.origin).toBe("https://app.example.com");
+    expect(result.counts).toEqual({ domIframes: 1, extensionFrames: 2, cdpFrames: 2 });
+    expect(result.domIframes[0]).toMatchObject({
+      crossOrigin: true,
+      blank: false,
+      zeroSize: false,
+      scriptsBlocked: false,
+      extensionFrameIds: [7],
+      cdpFrameIds: ["F2"],
+    });
+    expect(result.extensionFrames[0].isMain).toBe(true);
+    expect(result.extensionFrames[1].crossOrigin).toBe(true);
+    expect(result.cdpFrames[1].extensionFrameIds).toEqual([7]);
+    expect(result.warnings).toEqual([
+      "1 cross-origin iframe(s): selectors from the main page do not reach them; switch with frame.switch first.",
+    ]);
+  });
+
+  it("returns no warnings for a page without frames", () => {
+    const result = buildFrameDiagnosis({
+      mainPage: { href: MAIN, title: "Page" },
+      domIframes: [],
+      extensionFrames: [mainExt],
+      cdpFrames: [mainCdp],
+    });
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("explains blank and srcdoc iframes and points at the CDP ids", () => {
+    const result = buildFrameDiagnosis({
+      mainPage: { href: MAIN, title: "Page" },
+      domIframes: [iframe({ src: "", srcdoc: true }), iframe({ domIndex: 1, src: "about:blank" })],
+      extensionFrames: [
+        mainExt,
+        extFrame({ frameId: 3, url: "about:blank" }),
+        extFrame({ frameId: 4, url: "about:srcdoc" }),
+      ],
+      cdpFrames: [mainCdp, cdpFrame({ frameId: "F3", url: "about:blank" })],
+    });
+
+    expect(result.domIframes.map((entry) => entry.blank)).toEqual([true, true]);
+    expect(result.domIframes[0].extensionFrameIds).toEqual([]);
+    expect(result.warnings[0]).toContain(
+      "2 iframe(s) have no URL (about:blank or srcdoc): DOM indexes 0, 1",
+    );
+    expect(result.warnings.some((line) => line.includes("has no matching extension frame"))).toBe(
+      false,
+    );
+  });
+
+  it("flags unreachable content scripts, navigation errors and CDP-only frames", () => {
+    const result = buildFrameDiagnosis({
+      mainPage: { href: MAIN, title: "Page" },
+      domIframes: [iframe({ src: "https://app.example.com/inner" })],
+      extensionFrames: [
+        mainExt,
+        extFrame({
+          frameId: 5,
+          url: "https://app.example.com/inner",
+          contentScriptReachable: false,
+          contentScriptError: "Could not establish connection",
+          errorOccurred: true,
+        }),
+      ],
+      cdpFrames: [
+        mainCdp,
+        cdpFrame({ frameId: "F5", url: "https://app.example.com/inner" }),
+        cdpFrame({ frameId: "F9", url: "https://oop.example.org/" }),
+      ],
+    });
+
+    expect(result.domIframes[0].crossOrigin).toBe(false);
+    expect(result.warnings).toEqual([
+      "extension frame 5 (https://app.example.com/inner) has no reachable content script (Could not establish connection): page.read, click by ref and frame.switch will not work inside it; frame.js with its CDP frame id may.",
+      "extension frame 5 (https://app.example.com/inner) reported a navigation error.",
+      "CDP frame F9 (https://oop.example.org/) is not reported by chrome.webNavigation: likely out-of-process or detached; only frame.js can reach it.",
+    ]);
+  });
+
+  it("flags sandboxes without allow-scripts, zero-size frames and ambiguous URL matches", () => {
+    const result = buildFrameDiagnosis({
+      mainPage: { href: MAIN, title: "Page" },
+      domIframes: [
+        iframe({ sandbox: "allow-forms", rect: { x: 0, y: 0, width: 0, height: 0 } }),
+        iframe({ domIndex: 1 }),
+      ],
+      extensionFrames: [mainExt, extFrame({ frameId: 7 }), extFrame({ frameId: 8 })],
+      cdpFrames: [mainCdp],
+    });
+
+    expect(result.domIframes[0]).toMatchObject({
+      scriptsBlocked: true,
+      zeroSize: true,
+      extensionFrameIds: [7, 8],
+    });
+    expect(result.warnings.some((line) => line.includes("sandboxed without allow-scripts"))).toBe(
+      true,
+    );
+    expect(result.warnings.some((line) => line.includes("rendered at 0x0"))).toBe(true);
+    expect(
+      result.warnings.filter((line) => line.includes("matches 2 extension frames by URL (7, 8)")),
+    ).toHaveLength(2);
+  });
+
+  it("reports DOM iframes the extension does not list and count mismatches", () => {
+    const result = buildFrameDiagnosis({
+      mainPage: { href: MAIN, title: "Page" },
+      domIframes: [iframe({ src: "https://late.example.com/" })],
+      extensionFrames: [mainExt],
+      cdpFrames: [mainCdp],
+    });
+    expect(result.warnings).toEqual([
+      "iframe 0 (https://late.example.com/) has no matching extension frame: it may still be loading, be blocked, or have navigated elsewhere.",
+      "1 cross-origin iframe(s): selectors from the main page do not reach them; switch with frame.switch first.",
+      "DOM lists 1 iframe(s) but the extension sees 0 child frame(s); nested or detached frames account for the difference.",
+    ]);
+  });
+});

--- a/test/unit/frame-diagnose.test.ts
+++ b/test/unit/frame-diagnose.test.ts
@@ -206,6 +206,66 @@ describe("buildFrameDiagnosis", () => {
     );
   });
 
+  it("reports extension and CDP candidates claimed by multiple DOM iframes", () => {
+    const result = buildFrameDiagnosis({
+      mainPage: { href: MAIN, title: "Page" },
+      domIframes: [iframe(), iframe({ domIndex: 1 })],
+      extensionFrames: [mainExt, extFrame()],
+      cdpFrames: [mainCdp, cdpFrame()],
+    });
+
+    expect(result.domIframes.map((entry) => entry.extensionFrameIds)).toEqual([[7], [7]]);
+    expect(result.domIframes.map((entry) => entry.cdpFrameIds)).toEqual([["F2"], ["F2"]]);
+    expect(result.warnings).toContain(
+      "extension frame 7 (https://widgets.example.net/embed) matches 2 DOM iframes (0, 1); correlation is ambiguous.",
+    );
+    expect(result.warnings).toContain(
+      "CDP frame F2 (https://widgets.example.net/embed) matches 2 DOM iframes (0, 1); correlation is ambiguous.",
+    );
+  });
+
+  it("reports ambiguous CDP and extension URL links without DOM entries", () => {
+    const otherUrl = "https://widgets.example.net/other";
+    const result = buildFrameDiagnosis({
+      mainPage: { href: MAIN, title: "Page" },
+      domIframes: [],
+      extensionFrames: [
+        mainExt,
+        extFrame({ frameId: 7 }),
+        extFrame({ frameId: 8 }),
+        extFrame({ frameId: 9, url: otherUrl }),
+      ],
+      cdpFrames: [
+        mainCdp,
+        cdpFrame({ frameId: "F2" }),
+        cdpFrame({ frameId: "F3", url: otherUrl }),
+        cdpFrame({ frameId: "F4", url: otherUrl }),
+      ],
+    });
+
+    expect(result.warnings).toContain(
+      "CDP frame F2 (https://widgets.example.net/embed) matches 2 extension frames by URL (7, 8); correlation is ambiguous.",
+    );
+    expect(result.warnings).toContain(
+      "extension frame 9 (https://widgets.example.net/other) matches 2 CDP frames (F3, F4) by URL; correlation is ambiguous.",
+    );
+  });
+
+  it("does not infer CDP absence when the frame inventory is unavailable", () => {
+    const result = buildFrameDiagnosis({
+      mainPage: { href: MAIN, title: "Page" },
+      domIframes: [iframe()],
+      extensionFrames: [mainExt, extFrame({ contentScriptReachable: false })],
+      cdpFrames: [],
+      cdpFramesAvailable: false,
+    });
+
+    expect(result.warnings.some((line) => line.includes("out-of-process"))).toBe(false);
+    expect(result.warnings.some((line) => line.includes("nothing in this tab can drive it"))).toBe(
+      false,
+    );
+  });
+
   it("correlates by URL when DOM and webNavigation ordering differ", () => {
     const firstUrl = "https://app.example.com/first";
     const secondUrl = "https://app.example.com/second";

--- a/test/unit/host-helpers.test.ts
+++ b/test/unit/host-helpers.test.ts
@@ -544,6 +544,15 @@ describe("formatToolContent", () => {
   });
 });
 
+describe("frame.diagnose", () => {
+  it("maps to FRAME_DIAGNOSE with the tab id", () => {
+    expect(helpers.mapToolToMessage("frame.diagnose", {}, 9)).toEqual({
+      type: "FRAME_DIAGNOSE",
+      tabId: 9,
+    });
+  });
+});
+
 describe("readiness tools", () => {
   it("maps wait.ready with CLI flag spelling", () => {
     const msg = helpers.mapToolToMessage(

--- a/test/unit/service-worker/frame-diagnose-handlers.test.ts
+++ b/test/unit/service-worker/frame-diagnose-handlers.test.ts
@@ -125,16 +125,36 @@ describe("FRAME_DIAGNOSE", () => {
     mockCdp(chrome, { frameTreeError: "Target closed" });
     chrome.webNavigation.getAllFrames.mockResolvedValue([
       { frameId: 0, parentFrameId: -1, url: "https://app.example.com/page", errorOccurred: false },
+      {
+        frameId: 7,
+        parentFrameId: 0,
+        url: "https://widgets.example.net/embed",
+        errorOccurred: false,
+      },
     ]);
-    chrome.tabs.sendMessage.mockResolvedValue({
-      success: true,
-      href: "https://app.example.com/page",
-      readyState: "complete",
+    chrome.tabs.sendMessage.mockImplementation(async (_tabId: number, _msg: any, opts: any) => {
+      if (opts.frameId === 0) {
+        return {
+          success: true,
+          href: "https://app.example.com/page",
+          readyState: "complete",
+        };
+      }
+      throw new Error("Could not establish connection");
     });
 
     const result = await handleMessage({ type: "FRAME_DIAGNOSE", tabId: 5 }, {});
     expect(result.counts.cdpFrames).toBe(0);
     expect(result.warnings[0]).toBe("CDP frame tree unavailable: Target closed");
+    expect(result.domIframes[0]).toMatchObject({
+      crossOrigin: true,
+      extensionFrameIds: [7],
+      cdpFrameIds: [],
+    });
+    expect(result.warnings.some((line: string) => line.includes("is out-of-process"))).toBe(false);
+    expect(
+      result.warnings.some((line: string) => line.includes("nothing in this tab can drive it")),
+    ).toBe(false);
     expect(chrome.debugger.detach).toHaveBeenCalledTimes(1);
   });
 

--- a/test/unit/service-worker/frame-diagnose-handlers.test.ts
+++ b/test/unit/service-worker/frame-diagnose-handlers.test.ts
@@ -33,10 +33,13 @@ const inventory = {
 
 function mockCdp(
   chrome: ReturnType<typeof createChromeMock>,
-  options: { frameTreeError?: string } = {},
+  options: { domInventoryError?: string; frameTreeError?: string } = {},
 ) {
   chrome.debugger.sendCommand.mockImplementation(async (_target: any, method: string) => {
     if (method === "Runtime.evaluate") {
+      if (options.domInventoryError) {
+        throw new Error(options.domInventoryError);
+      }
       return { result: { value: inventory, type: "object" } };
     }
     if (method === "Page.getFrameTree") {
@@ -112,6 +115,8 @@ describe("FRAME_DIAGNOSE", () => {
           line.includes("extension frame 7") && line.includes("no reachable content script"),
       ),
     ).toBe(true);
+    expect(chrome.debugger.attach).toHaveBeenCalledTimes(1);
+    expect(chrome.debugger.detach).toHaveBeenCalledTimes(1);
   });
 
   it("keeps going when the CDP frame tree is unavailable", async () => {
@@ -130,6 +135,80 @@ describe("FRAME_DIAGNOSE", () => {
     const result = await handleMessage({ type: "FRAME_DIAGNOSE", tabId: 5 }, {});
     expect(result.counts.cdpFrames).toBe(0);
     expect(result.warnings[0]).toBe("CDP frame tree unavailable: Target closed");
+    expect(chrome.debugger.detach).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps extension and CDP inventories when DOM evaluation fails", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    mockCdp(chrome, { domInventoryError: "Execution context destroyed" });
+    chrome.webNavigation.getAllFrames.mockResolvedValue([
+      { frameId: 0, parentFrameId: -1, url: "https://app.example.com/page", errorOccurred: false },
+    ]);
+    chrome.tabs.sendMessage.mockResolvedValue({ success: true });
+
+    const result = await handleMessage({ type: "FRAME_DIAGNOSE", tabId: 5 }, {});
+
+    expect(result.counts).toEqual({ domIframes: 0, extensionFrames: 1, cdpFrames: 2 });
+    expect(result.mainPage.href).toBe("https://app.example.com/page");
+    expect(result.warnings[0]).toBe(
+      "DOM iframe inventory unavailable: Execution context destroyed",
+    );
+    expect(chrome.debugger.detach).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the extension inventory when debugger attachment fails", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    chrome.debugger.attach.mockRejectedValue(new Error("Attach denied"));
+    chrome.webNavigation.getAllFrames.mockResolvedValue([
+      { frameId: 0, parentFrameId: -1, url: "https://app.example.com/page", errorOccurred: false },
+    ]);
+    chrome.tabs.sendMessage.mockResolvedValue({ success: true });
+
+    const result = await handleMessage({ type: "FRAME_DIAGNOSE", tabId: 5 }, {});
+
+    expect(result.counts).toEqual({ domIframes: 0, extensionFrames: 1, cdpFrames: 0 });
+    expect(result.warnings[0]).toContain("CDP inventories unavailable: Failed to attach debugger");
+    expect(chrome.debugger.attach).toHaveBeenCalledTimes(1);
+    expect(chrome.debugger.detach).not.toHaveBeenCalled();
+  });
+
+  it("reports detach failures after returning all inventories", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {
+      // Expected for this failure-path assertion.
+    });
+    mockCdp(chrome);
+    chrome.debugger.detach.mockRejectedValue(new Error("Detach denied"));
+    chrome.webNavigation.getAllFrames.mockResolvedValue([
+      { frameId: 0, parentFrameId: -1, url: "https://app.example.com/page", errorOccurred: false },
+    ]);
+    chrome.tabs.sendMessage.mockResolvedValue({ success: true });
+
+    const result = await handleMessage({ type: "FRAME_DIAGNOSE", tabId: 5 }, {});
+
+    expect(result.counts).toEqual({ domIframes: 1, extensionFrames: 1, cdpFrames: 2 });
+    expect(result.warnings[0]).toBe("CDP detach failed: Detach denied");
+    expect(warn).toHaveBeenCalledWith("[CDPController] Error detaching:", expect.any(Error));
+    warn.mockRestore();
+  });
+
+  it("does not detach a pre-existing Surf debugger attachment", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    mockCdp(chrome);
+    chrome.webNavigation.getAllFrames.mockResolvedValue([
+      { frameId: 0, parentFrameId: -1, url: "https://app.example.com/page", errorOccurred: false },
+    ]);
+    chrome.tabs.sendMessage.mockResolvedValue({ success: true });
+    await handleMessage({ type: "GET_FRAMES", tabId: 5 }, {});
+
+    await handleMessage({ type: "FRAME_DIAGNOSE", tabId: 5 }, {});
+
+    expect(chrome.debugger.attach).toHaveBeenCalledTimes(1);
+    expect(chrome.debugger.detach).not.toHaveBeenCalled();
   });
 
   it("requires a tab id", async () => {

--- a/test/unit/service-worker/frame-diagnose-handlers.test.ts
+++ b/test/unit/service-worker/frame-diagnose-handlers.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createChromeMock, resetChromeMock } from "../../mocks/chrome";
+
+vi.mock("../../../src/native/port-manager", () => ({
+  initNativeMessaging: vi.fn(),
+  postToNativeHost: vi.fn(),
+}));
+
+async function loadHandleMessage() {
+  vi.resetModules();
+  (globalThis as any).chrome = createChromeMock();
+  const mod = await import("../../../src/service-worker/index");
+  return mod.handleMessage;
+}
+
+const inventory = {
+  href: "https://app.example.com/page",
+  title: "Page",
+  iframes: [
+    {
+      domIndex: 0,
+      src: "https://widgets.example.net/embed",
+      srcdoc: false,
+      title: "",
+      name: "widget",
+      id: "",
+      sandbox: null,
+      allow: "",
+      rect: { x: 0, y: 0, width: 300, height: 200 },
+    },
+  ],
+};
+
+function mockCdp(
+  chrome: ReturnType<typeof createChromeMock>,
+  options: { frameTreeError?: string } = {},
+) {
+  chrome.debugger.sendCommand.mockImplementation(async (_target: any, method: string) => {
+    if (method === "Runtime.evaluate") {
+      return { result: { value: inventory, type: "object" } };
+    }
+    if (method === "Page.getFrameTree") {
+      if (options.frameTreeError) {
+        throw new Error(options.frameTreeError);
+      }
+      return {
+        frameTree: {
+          frame: { id: "F1", url: "https://app.example.com/page", name: "" },
+          childFrames: [
+            { frame: { id: "F2", url: "https://widgets.example.net/embed", name: "widget" } },
+          ],
+        },
+      };
+    }
+    return {};
+  });
+}
+
+describe("FRAME_DIAGNOSE", () => {
+  beforeEach(() => {
+    resetChromeMock();
+  });
+
+  it("combines the DOM inventory, webNavigation frames with PING results and the CDP tree", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    mockCdp(chrome);
+    chrome.webNavigation.getAllFrames.mockResolvedValue([
+      { frameId: 0, parentFrameId: -1, url: "https://app.example.com/page", errorOccurred: false },
+      {
+        frameId: 7,
+        parentFrameId: 0,
+        url: "https://widgets.example.net/embed",
+        errorOccurred: false,
+      },
+    ]);
+    chrome.tabs.sendMessage.mockImplementation(async (_tabId: number, _msg: any, opts: any) => {
+      if (opts.frameId === 0) {
+        return { success: true, href: "https://app.example.com/page", readyState: "complete" };
+      }
+      throw new Error("Could not establish connection");
+    });
+
+    const result = await handleMessage({ type: "FRAME_DIAGNOSE", tabId: 5 }, {});
+
+    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(5, { type: "PING" }, { frameId: 0 });
+    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(5, { type: "PING" }, { frameId: 7 });
+    expect(result.success).toBeUndefined();
+    expect(result.mainPage).toEqual({
+      href: "https://app.example.com/page",
+      title: "Page",
+      origin: "https://app.example.com",
+    });
+    expect(result.counts).toEqual({ domIframes: 1, extensionFrames: 2, cdpFrames: 2 });
+    expect(result.domIframes[0]).toMatchObject({
+      extensionFrameIds: [7],
+      cdpFrameIds: ["F2"],
+      crossOrigin: true,
+    });
+    expect(result.extensionFrames[1]).toMatchObject({
+      frameId: 7,
+      contentScriptReachable: false,
+      contentScriptError: "Could not establish connection",
+    });
+    expect(result.extensionFrames[0].contentScript).toEqual({
+      href: "https://app.example.com/page",
+      readyState: "complete",
+    });
+    expect(
+      result.warnings.some(
+        (line: string) =>
+          line.includes("extension frame 7") && line.includes("no reachable content script"),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps going when the CDP frame tree is unavailable", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    mockCdp(chrome, { frameTreeError: "Target closed" });
+    chrome.webNavigation.getAllFrames.mockResolvedValue([
+      { frameId: 0, parentFrameId: -1, url: "https://app.example.com/page", errorOccurred: false },
+    ]);
+    chrome.tabs.sendMessage.mockResolvedValue({
+      success: true,
+      href: "https://app.example.com/page",
+      readyState: "complete",
+    });
+
+    const result = await handleMessage({ type: "FRAME_DIAGNOSE", tabId: 5 }, {});
+    expect(result.counts.cdpFrames).toBe(0);
+    expect(result.warnings[0]).toBe("CDP frame tree unavailable: Target closed");
+  });
+
+  it("requires a tab id", async () => {
+    const handleMessage = await loadHandleMessage();
+    await expect(handleMessage({ type: "FRAME_DIAGNOSE" }, {})).rejects.toThrow(
+      "No tabId provided",
+    );
+  });
+});

--- a/test/unit/tool-scope.test.ts
+++ b/test/unit/tool-scope.test.ts
@@ -61,6 +61,13 @@ describe("tool scope classification", () => {
     });
   });
 
+  it("keeps frame.diagnose on the tab lane", () => {
+    expect(classifyTool("frame.diagnose", {})).toMatchObject({
+      scope: "tab",
+      targetUse: "default-tab",
+    });
+  });
+
   it("fails conservative for unclassified browser commands", () => {
     expect(classifyTool("future.browser.command")).toMatchObject({
       scope: "browser-write",


### PR DESCRIPTION
## Summary

- add `frame.diagnose` with DOM, webNavigation/content-script, and CDP frame inventories
- correlate URL and name/id evidence without guessing ambiguous matches
- expose `switchIndex` using the same child ordering as `frame.switch --index`
- report ambiguity symmetrically in both directions
- suppress CDP-absence conclusions when the CDP tree is unavailable while retaining available evidence

Supersedes #256 while preserving all four contributor commits, authorship, and attribution trailers. Thanks to @tryingET for the implementation; profile-linked changelog credit is included.

## Validation

- focused frame diagnosis, handler, tool-scope, and host-helper tests
- complete test suite on Node 24/Vitest 5
- TypeScript checks, lint, production build, and real-Chrome fixture
- contributor-author and changelog-credit assertions
- `git diff --check`

The replacement completed two challenges, retained-writer deslop/simplification, fresh review, two evidence-backed ambiguity/availability corrections, and fresh re-review with no blockers.