### PR TITLE
fix(cdp): surface readable debugger errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Thanks to [@tryingET](https://github.com/tryingET) for #255.
 - **Bounded screenshot capture** - Screenshot requests now settle when Chromium stops responding, preserving successful primary output and releasing queued work. Thanks to [@Whamp](https://github.com/Whamp) for #250.
 
 Thanks to [@tryingET](https://github.com/tryingET) for #251 and #256.
+Thanks to [@tryingET](https://github.com/tryingET) for #252.
 Thanks to [@tryingET](https://github.com/tryingET) for #253.
 
 ## [2.18.0] - 2026-09-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 Thanks to [@tryingET](https://github.com/tryingET) for #255.
 
 ### Fixed
+- **Readable CDP errors** - `chrome.debugger` failures surfaced as a JSON blob (`{"code":-32000,"message":"Inspected target navigated or closed"}`); the message is now unwrapped and the CDP code and method are kept on the error as `cdpCode`/`cdpMethod`.
 - **Native host stalled replies** - The host stopped reading its stdin buffer after an `EXTENSION_HELLO` or `TARGET_EVENT` frame, so a tool reply that arrived in the same chunk sat unread until the next message from the extension (typically the 60 s client timeout on the first request after host start). Every complete frame in a chunk is now processed.
 - **`js --file` statement scripts** - Scripts starting with a declaration failed with `SyntaxError: Unexpected token 'const'` in real Chrome because the statement-mode fallback relied on `new Function`, which the extension CSP blocks in the service worker. The fallback now uses CDP `Runtime.compileScript`.
 - **Bounded screenshot capture** - Screenshot requests now settle when Chromium stops responding, preserving successful primary output and releasing queued work. Thanks to [@Whamp](https://github.com/Whamp) for #250.

--- a/src/cdp/controller.ts
+++ b/src/cdp/controller.ts
@@ -13,6 +13,39 @@ class CDPControllerError extends Error {
   }
 }
 
+export interface DebuggerCommandError extends Error {
+  /** CDP error code (for example -32000) when the browser reported one. */
+  cdpCode?: number;
+  /** The CDP method that failed. */
+  cdpMethod?: string;
+}
+
+/**
+ * `chrome.debugger.sendCommand` rejects with the CDP error serialised as
+ * JSON in the message (`{"code":-32000,"message":"Inspected target navigated
+ * or closed"}`). Surface the message itself and keep the code as a property,
+ * so callers and users see "Inspected target navigated or closed" instead
+ * of a JSON blob. Anything that is not such a JSON object passes through.
+ */
+export function describeDebuggerError(err: unknown, method?: string): Error {
+  const raw = err instanceof Error ? err.message : String(err);
+  const trimmed = raw.trim();
+  if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
+    try {
+      const parsed = JSON.parse(trimmed) as { code?: unknown; message?: unknown };
+      if (parsed && typeof parsed.message === "string" && parsed.message.length > 0) {
+        const error = new Error(parsed.message) as DebuggerCommandError;
+        if (typeof parsed.code === "number") error.cdpCode = parsed.code;
+        if (method) error.cdpMethod = method;
+        return error;
+      }
+    } catch {
+      // not JSON after all; fall through
+    }
+  }
+  return err instanceof Error ? err : new Error(raw);
+}
+
 interface ConsoleMessage {
   type: string;
   text: string;
@@ -1338,7 +1371,11 @@ export class CDPController {
   ): Promise<any> {
     await this.ensureAttached(tabId);
     const target = this.targets.get(tabId)!;
-    return chrome.debugger.sendCommand(target, method, params);
+    try {
+      return await chrome.debugger.sendCommand(target, method, params);
+    } catch (err) {
+      throw describeDebuggerError(err, method);
+    }
   }
 
   async sendCommand(

--- a/test/unit/cdp/controller.test.ts
+++ b/test/unit/cdp/controller.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, vi } from "vitest";
-import { CDPController } from "../../../src/cdp/controller";
+import { CDPController, describeDebuggerError } from "../../../src/cdp/controller";
 
 // Mock chrome.debugger API
 const mockChrome = {
@@ -15,9 +15,44 @@ const mockChrome = {
 // Set global chrome before tests
 vi.stubGlobal("chrome", mockChrome);
 
+describe("describeDebuggerError", () => {
+  it("unwraps the JSON-encoded CDP error chrome.debugger rejects with", () => {
+    const error = describeDebuggerError(
+      new Error('{"code":-32000,"message":"Inspected target navigated or closed"}'),
+      "Runtime.evaluate",
+    );
+    expect(error.message).toBe("Inspected target navigated or closed");
+    expect(error).toMatchObject({ cdpCode: -32000, cdpMethod: "Runtime.evaluate" });
+  });
+
+  it("passes plain errors and non-JSON messages through unchanged", () => {
+    const plain = new Error("Detached while handling command.");
+    expect(describeDebuggerError(plain, "Page.enable")).toBe(plain);
+    expect(describeDebuggerError("{not json", "Page.enable").message).toBe("{not json");
+    expect(describeDebuggerError('{"code":1}', "Page.enable").message).toBe('{"code":1}');
+  });
+});
+
 describe("CDPController", () => {
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  describe("send", () => {
+    it("rethrows CDP failures with the browser's message instead of a JSON blob", async () => {
+      const controller = new CDPController();
+      mockChrome.debugger.attach.mockResolvedValue(undefined);
+      mockChrome.debugger.sendCommand.mockRejectedValue(
+        new Error('{"code":-32000,"message":"Inspected target navigated or closed"}'),
+      );
+      await expect(
+        controller.sendCommand(7, "Runtime.evaluate", { expression: "1" }),
+      ).rejects.toMatchObject({
+        message: "Inspected target navigated or closed",
+        cdpCode: -32000,
+        cdpMethod: "Runtime.evaluate",
+      });
+    });
   });
 
   beforeEach(() => {


### PR DESCRIPTION
## Summary

- unwrap structured `chrome.debugger` error envelopes at the shared command boundary
- preserve readable messages plus numeric CDP code and failing method metadata
- leave ordinary errors and malformed envelopes unchanged

Supersedes #252 while preserving both contributor commits, authorship, and attribution trailers. Thanks to @tryingET; profile-linked credit is included in the changelog.

## Validation

- 90 focused controller tests
- complete suite and TypeScript checks on the reviewed candidate
- production build after promotion onto current main
- contributor-author and changelog-credit checks
- `git diff --check`

The original exact head and mechanically promoted replacement both received independent review with no blockers.