### PR TITLE
feat(js): add script options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- **`surf js --options`** - Exposes a JSON object to `js`/`frame.js` scripts as a frozen `SURF_OPTIONS` constant.
 - **Typed page readiness** - `surf wait.ready` polls with a bounded budget and reports `ready`, `empty`, `login`, `challenge`, `not-found` or `error` instead of timing out silently; negative states exit with `page_login`, `page_challenge`, `page_not_found`, `page_error` or `page_timeout`, and `--accept` returns them to the caller. `surf page.readiness` classifies the page once. Detection uses visible UI state and the caller's expectations (`--selector`, `--text`, `--url-prefix`, `--empty-text`), not site-specific selectors.
 - **`surf frame.diagnose`** - DOM `<iframe>` elements (including those inside open shadow roots, reported with their `shadowHost`), extension frames with a content-script reachability check, and the CDP frame tree side by side, correlated by URL and by `name`/`id` for `srcdoc`/`about:blank` frames, with warnings for blank frames, sandboxes without `allow-scripts`, cross-origin frames, out-of-process frames that `frame.js` cannot reach (and which commands still work there), still-loading frames and count mismatches. The text report abbreviates long frame URLs; `--json` keeps them whole.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - **`surf frame.diagnose`** - DOM `<iframe>` elements (including those inside open shadow roots, reported with their `shadowHost`), extension frames with a content-script reachability check, and the CDP frame tree side by side, correlated by URL and by `name`/`id` for `srcdoc`/`about:blank` frames, with warnings for blank frames, sandboxes without `allow-scripts`, cross-origin frames, out-of-process frames that `frame.js` cannot reach (and which commands still work there), still-loading frames and count mismatches. The text report abbreviates long frame URLs; `--json` keeps them whole.
 
 Thanks to [@tryingET](https://github.com/tryingET) for #255.
+Thanks to [@tryingET](https://github.com/tryingET) for the `js`/`frame.js --options` split from #257.
 
 ### Fixed
 - **Readable CDP errors** - `chrome.debugger` failures surfaced as a JSON blob (`{"code":-32000,"message":"Inspected target navigated or closed"}`); the message is now unwrapped and the CDP code and method are kept on the error as `cdpCode`/`cdpMethod`.

--- a/README.md
+++ b/README.md
@@ -589,6 +589,12 @@ surf wait.ready --accept login --json   # {"state":"login","evidence":[...]} ins
 
 ### Other
 
+`js` and `frame.js` accept `--options '{"limit": 20}'` with inline code or
+`--file`. This prepends `const SURF_OPTIONS = Object.freeze({...});` to the
+script; use an explicit `return` for its result. The freeze is shallow.
+Invalid JSON and non-object values are rejected before sending a request;
+`--options ''` defines an empty object. Without `--options`, code is unchanged.
+
 ```bash
 surf js "return document.title"     # Execute JavaScript
 surf js "piHelpers.setValue(document.querySelector('#q'), 'hello')"  # Native value setter + input/change events

--- a/README.md
+++ b/README.md
@@ -590,8 +590,8 @@ surf wait.ready --accept login --json   # {"state":"login","evidence":[...]} ins
 ### Other
 
 `js` and `frame.js` accept `--options '{"limit": 20}'` with inline code or
-`--file`. This prepends `const SURF_OPTIONS = Object.freeze({...});` to the
-script; use an explicit `return` for its result. The freeze is shallow.
+`--file`. This defines `SURF_OPTIONS` by parsing the JSON and freezing the
+result; use an explicit `return` for the script's result. The freeze is shallow.
 Invalid JSON and non-object values are rejected before sending a request;
 `--options ''` defines an empty object. Without `--options`, code is unchanged.
 

--- a/README.md
+++ b/README.md
@@ -592,6 +592,7 @@ surf wait.ready --accept login --json   # {"state":"login","evidence":[...]} ins
 ```bash
 surf js "return document.title"     # Execute JavaScript
 surf js "piHelpers.setValue(document.querySelector('#q'), 'hello')"  # Native value setter + input/change events
+surf js --file script.js --options '{"limit": 20}'   # Script reads SURF_OPTIONS.limit
 surf record --duration 2000 --fps 10 --output /tmp/anim.gif      # Animated GIF capture
 surf animate-audit --selector ".thing" --duration 2000 --fps 10  # JSON animation timeline
 surf perf-audit --duration 3000 --output /tmp/perf.json           # PerformanceObserver snapshot

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -17,6 +17,7 @@ const {
   validateWorkflowFile,
 } = require("./workflow-definition.cjs");
 const { executeDoSteps } = require("./do-executor.cjs");
+const { applyOptionsPrelude } = require("./script-options.cjs");
 const { openClientTransport } = require("./client-transport.cjs");
 const { version: VERSION } = require("../package.json");
 const {
@@ -913,11 +914,12 @@ const TOOLS = {
       "js": {
         desc: "Execute JavaScript (use 'return' for values)",
         args: ["code"],
-        opts: { file: "Run JS from file" },
+        opts: { file: "Run JS from file", options: "JSON object exposed to the script as a frozen SURF_OPTIONS constant" },
         examples: [
           { cmd: 'js "return document.title"', desc: "Get title" },
           { cmd: 'js "document.body.style.background = \'red\'"', desc: "Run code" },
           { cmd: "js --file script.js", desc: "Run file" },
+          { cmd: 'js --file script.js --options \'{"limit": 20}\'', desc: "Run file with SURF_OPTIONS.limit" },
         ]
       },
     }
@@ -1185,7 +1187,7 @@ const TOOLS = {
       "frame.js": {
         desc: "Execute JS in specific frame",
         args: ["code"],
-        opts: { id: "Frame ID from frame.list", file: "Run JS from file" },
+        opts: { id: "Frame ID from frame.list", file: "Run JS from file", options: "JSON object exposed as SURF_OPTIONS" },
         examples: [
           { cmd: 'frame.js "return document.title" --id frame1', desc: "JS in specific frame" },
         ]
@@ -3011,6 +3013,17 @@ if ((tool === "js" || tool === "frame.js") && toolArgs.file) {
     delete toolArgs.file;
   } catch (e) {
     console.error(`Error: Failed to read file: ${e.message}`);
+    process.exit(1);
+  }
+}
+
+if ((tool === "js" || tool === "frame.js") && toolArgs.options !== undefined) {
+  try {
+    if (typeof toolArgs.code !== "string") throw new Error("--options needs code (inline or --file)");
+    toolArgs.code = applyOptionsPrelude(toolArgs.code, toolArgs.options);
+    delete toolArgs.options;
+  } catch (e) {
+    console.error(`Error: ${e.message}`);
     process.exit(1);
   }
 }

--- a/native/script-options.cjs
+++ b/native/script-options.cjs
@@ -1,0 +1,40 @@
+/** Options prelude for page-side scripts run through js or frame.js. */
+const PRELUDE_NAME = "SURF_OPTIONS";
+
+function isPlainObject(value) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/** Accept an object or JSON string; missing input defaults to an empty object. */
+function parseScriptOptions(input) {
+  if (input === undefined || input === null || input === "") return {};
+  if (input === true) throw new Error("--options needs a JSON object value");
+  let value = input;
+  if (typeof input === "string") {
+    try {
+      value = JSON.parse(input);
+    } catch (error) {
+      throw new Error(`--options is not valid JSON: ${error.message}`);
+    }
+  }
+  if (!isPlainObject(value)) {
+    throw new Error("--options must be a JSON object, e.g. '{\"limit\": 20}'");
+  }
+  // Round-trip so functions, undefined and prototypes cannot leak into the page.
+  return JSON.parse(JSON.stringify(value));
+}
+
+/** `const SURF_OPTIONS = Object.freeze({...});` followed by a newline. */
+function buildOptionsPrelude(options) {
+  const normalized = parseScriptOptions(options);
+  return `const ${PRELUDE_NAME} = Object.freeze(${JSON.stringify(normalized)});\n`;
+}
+
+/** Prefix code with the prelude; empty options still defines the constant. */
+function applyOptionsPrelude(code, options) {
+  return `${buildOptionsPrelude(options)}${code}`;
+}
+
+module.exports = { PRELUDE_NAME, applyOptionsPrelude, buildOptionsPrelude, parseScriptOptions };

--- a/native/script-options.cjs
+++ b/native/script-options.cjs
@@ -26,10 +26,10 @@ function parseScriptOptions(input) {
   return JSON.parse(JSON.stringify(value));
 }
 
-/** `const SURF_OPTIONS = Object.freeze({...});` followed by a newline. */
+/** Parse serialized JSON before freezing to preserve own __proto__ keys. */
 function buildOptionsPrelude(options) {
   const normalized = parseScriptOptions(options);
-  return `const ${PRELUDE_NAME} = Object.freeze(${JSON.stringify(normalized)});\n`;
+  return `const ${PRELUDE_NAME} = Object.freeze(JSON.parse(${JSON.stringify(JSON.stringify(normalized))}));\n`;
 }
 
 /** Prefix code with the prelude; empty options still defines the constant. */

--- a/test/e2e/fixtures/list-items.js
+++ b/test/e2e/fixtures/list-items.js
@@ -1,0 +1,11 @@
+// Page-side script used by the real-Chrome E2E for js --file --options.
+// Reads SURF_OPTIONS.limit (injected by --options) and returns rows.
+const limit = Number.isFinite(SURF_OPTIONS.limit) ? SURF_OPTIONS.limit : 50;
+const rows = Array.from(document.querySelectorAll(".item"))
+  .slice(0, limit)
+  .map((item) => ({
+    id: item.dataset.id,
+    title: item.querySelector("h2")?.textContent?.trim() ?? "",
+    href: item.querySelector("a")?.getAttribute("href") ?? "",
+  }));
+return { query: new URL(location.href).searchParams.get("q") ?? "", total: rows.length, rows };

--- a/test/e2e/real-chrome.mjs
+++ b/test/e2e/real-chrome.mjs
@@ -523,7 +523,37 @@ try {
   if (jsOutput?.query !== "js" || jsOutput?.total !== 1 || jsOutput?.rows?.[0]?.title !== "Item 1") {
     throw new Error(`js --file with statements and --options did not return the script result: ${JSON.stringify(jsOutput)}`);
   }
-  await runSurf("tab.close", "--id", String(listTabForJs.tabId), "--json");
+  const optionsTabId = String(listTabForJs.tabId);
+  const inlineOptions = unwrapJson(await runSurf(
+    "js", "return {limit: SURF_OPTIONS.limit, frozen: Object.isFrozen(SURF_OPTIONS)};",
+    "--options", '{"limit":2}', "--tab-id", optionsTabId, "--json",
+  ));
+  if (inlineOptions.limit !== 2 || inlineOptions.frozen !== true) {
+    throw new Error(`js inline options failed: ${JSON.stringify(inlineOptions)}`);
+  }
+  await runSurf("js", `const frame = document.createElement('iframe'); frame.src = '${baseUrl}/list?q=frame'; document.body.append(frame);`, "--tab-id", optionsTabId);
+  let childFrame;
+  await waitFor(async () => {
+    const result = unwrapJson(await runSurf("frame.list", "--tab-id", optionsTabId, "--json"));
+    childFrame = result.find((frame) => frame.url === `${baseUrl}/list?q=frame`);
+    return Boolean(childFrame);
+  }, "options child frame");
+  const frameOutput = unwrapJson(await runSurf(
+    "frame.js", "--id", childFrame.frameId, "--file", optionsScript,
+    "--options", '{"limit":2}', "--tab-id", optionsTabId, "--json",
+  ));
+  if (frameOutput.query !== "frame" || frameOutput.total !== 2 || frameOutput.rows[1].title !== "Item 2") {
+    throw new Error(`frame.js file options failed: ${JSON.stringify(frameOutput)}`);
+  }
+  const frameInline = unwrapJson(await runSurf(
+    "frame.js", "--id", childFrame.frameId,
+    "return {query: new URL(location.href).searchParams.get('q'), frozen: Object.isFrozen(SURF_OPTIONS), limit: SURF_OPTIONS.limit};",
+    "--options", '{"limit":3}', "--tab-id", optionsTabId, "--json",
+  ));
+  if (frameInline.query !== "frame" || frameInline.frozen !== true || frameInline.limit !== 3) {
+    throw new Error(`frame.js inline options failed: ${JSON.stringify(frameInline)}`);
+  }
+  await runSurf("tab.close", "--id", optionsTabId, "--json");
 
   await runSurf("screenshot", "--output", screenshotPath);
   const png = readFileSync(screenshotPath);
@@ -569,6 +599,7 @@ try {
         result: "pass",
         readiness: { fixture: readiness.state, loginAccepted: acceptedLogin.state },
         frameDiagnoseWarnings: diagnosis.warnings.length,
+        scriptOptions: { js: jsOutput.total, frameJs: frameOutput.total, frozen: frameInline.frozen },
         screenshotBytes: png.length,
         serviceWorker: workerTarget.url(),
       },

--- a/test/e2e/real-chrome.mjs
+++ b/test/e2e/real-chrome.mjs
@@ -513,6 +513,18 @@ try {
   }
   await runSurf("tab.close", "--id", String(listTab.tabId), "--json");
 
+  // --- js --file with statements and --options -------------------------------
+  const optionsScript = join(repo, "test/e2e/fixtures/list-items.js");
+  const listTabForJs = { tabId: tabIdFromOutput(await runSurf("tab.new", `${baseUrl}/list?q=js`)) };
+  await runSurf("wait.ready", "--json", "--tab-id", String(listTabForJs.tabId), "--selector", ".item");
+  const jsOutput = unwrapJson(
+    await runSurf("js", "--file", optionsScript, "--options", '{"limit": 1}', "--tab-id", String(listTabForJs.tabId), "--json"),
+  );
+  if (jsOutput?.query !== "js" || jsOutput?.total !== 1 || jsOutput?.rows?.[0]?.title !== "Item 1") {
+    throw new Error(`js --file with statements and --options did not return the script result: ${JSON.stringify(jsOutput)}`);
+  }
+  await runSurf("tab.close", "--id", String(listTabForJs.tabId), "--json");
+
   await runSurf("screenshot", "--output", screenshotPath);
   const png = readFileSync(screenshotPath);
   if (png.length < 100 || png.subarray(0, 8).toString("hex") !== "89504e470d0a1a0a") {

--- a/test/unit/cli-script-options.test.ts
+++ b/test/unit/cli-script-options.test.ts
@@ -49,12 +49,28 @@ describe.each(["js", "frame.js"])("%s script options", (tool) => {
       const request = JSON.parse(result.stdout);
       expect(request.params.tool).toBe(tool);
       expect(request.params.args).toEqual({
-        code: `const SURF_OPTIONS = Object.freeze({"limit":2});\n${code}`,
+        code: `const SURF_OPTIONS = Object.freeze(JSON.parse("{\\"limit\\":2}"));\n${code}`,
         ...(tool === "frame.js" ? { id: "child-frame" } : { autoScreenshot: true }),
       });
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  it("preserves own __proto__ keys without inheriting option values", () => {
+    const options =
+      '{"__proto__":{"limit":99},"nested":{"__proto__":{"limit":42}},"text":"quotes: \\"; newline: \\n; slash: \\\\"}';
+    const result = capture([tool, "return SURF_OPTIONS;", ...target, "--options", options]);
+    expect(result.status).toBe(0);
+    const value = new Function(JSON.parse(result.stdout).params.args.code)();
+    expect(value).toEqual(JSON.parse(options));
+    for (const object of [value, value.nested]) {
+      expect(Object.hasOwn(object, "__proto__")).toBe(true);
+      expect(Object.getPrototypeOf(object)).toBe(Object.prototype);
+      expect(object.limit).toBeUndefined();
+    }
+    expect(Object.isFrozen(value)).toBe(true);
+    expect(Object.isFrozen(value.nested)).toBe(false);
   });
 
   it("leaves code unchanged without options", () => {

--- a/test/unit/cli-script-options.test.ts
+++ b/test/unit/cli-script-options.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+declare const require: (moduleName: string) => any;
+const { spawnSync } = require("node:child_process");
+const { mkdtempSync, rmSync, writeFileSync } = require("node:fs");
+const { tmpdir } = require("node:os");
+const { join, resolve } = require("node:path");
+
+const cliPath = resolve("native/cli.cjs");
+
+function capture(args: string[]) {
+  const script = `
+    const { EventEmitter } = require("node:events");
+    require("node:net").createConnection = (_path, onConnect) => {
+      const socket = new EventEmitter();
+      socket.write = (data) => { console.log(String(data).trim()); process.exit(0); };
+      socket.end = socket.destroy = () => {};
+      process.nextTick(onConnect);
+      return socket;
+    };
+    process.argv = [process.execPath, ${JSON.stringify(cliPath)}, ...${JSON.stringify(args)}];
+    require(${JSON.stringify(cliPath)});
+  `;
+  return spawnSync(process.execPath, ["-e", script], {
+    encoding: "utf8",
+    env: { ...process.env, SURF_REMOTE: "", SURF_SESSION: "", SURF_NO_LOCK: "1" },
+    timeout: 5000,
+  });
+}
+
+describe.each(["js", "frame.js"])("%s script options", (tool) => {
+  const target = tool === "frame.js" ? ["--id", "child-frame"] : [];
+
+  it.each([false, true])("prefixes code (file=%s) and removes CLI-only flags", (file) => {
+    const dir = mkdtempSync(join(tmpdir(), "surf-options-"));
+    const code = "return SURF_OPTIONS.limit;";
+    const path = join(dir, "script.js");
+    writeFileSync(path, code);
+    try {
+      const result = capture([
+        tool,
+        ...(file ? ["--file", path] : [code]),
+        ...target,
+        "--options",
+        '{"limit":2}',
+      ]);
+      expect(result.stderr).toBe("");
+      expect(result.status).toBe(0);
+      const request = JSON.parse(result.stdout);
+      expect(request.params.tool).toBe(tool);
+      expect(request.params.args).toEqual({
+        code: `const SURF_OPTIONS = Object.freeze({"limit":2});\n${code}`,
+        ...(tool === "frame.js" ? { id: "child-frame" } : { autoScreenshot: true }),
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves code unchanged without options", () => {
+    const result = capture([tool, "return 42;", ...target]);
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout).params.args.code).toBe("return 42;");
+  });
+
+  it.each(["[]", "null", "false", "42", '"text"', "{oops", undefined])(
+    "rejects invalid options %s before sending",
+    (value) => {
+      const result = capture([
+        tool,
+        "return 1;",
+        ...target,
+        "--options",
+        ...(value === undefined ? [] : [value]),
+      ]);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("--options");
+      expect(result.stdout).toBe("");
+    },
+  );
+
+  it("requires code", () => {
+    const result = capture([tool, ...target, "--options", "{}"]);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("--options needs code");
+    expect(result.stdout).toBe("");
+  });
+});

--- a/test/unit/script-options.test.ts
+++ b/test/unit/script-options.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+// @ts-expect-error - CommonJS module without type definitions
+import * as scriptOptions from "../../native/script-options.cjs";
+
+describe("parseScriptOptions", () => {
+  it("returns an empty object for missing input", () => {
+    expect(scriptOptions.parseScriptOptions(undefined)).toEqual({});
+    expect(scriptOptions.parseScriptOptions(null)).toEqual({});
+    expect(scriptOptions.parseScriptOptions("")).toEqual({});
+  });
+
+  it("accepts JSON strings and plain objects", () => {
+    expect(scriptOptions.parseScriptOptions('{"limit": 20, "query": "x"}')).toEqual({
+      limit: 20,
+      query: "x",
+    });
+    expect(scriptOptions.parseScriptOptions({ mode: "list" })).toEqual({ mode: "list" });
+  });
+
+  it("rejects non-object values and invalid JSON", () => {
+    expect(() => scriptOptions.parseScriptOptions("[1]")).toThrow(/must be a JSON object/);
+    expect(() => scriptOptions.parseScriptOptions("42")).toThrow(/must be a JSON object/);
+    expect(() => scriptOptions.parseScriptOptions("{oops")).toThrow(/not valid JSON/);
+    expect(() => scriptOptions.parseScriptOptions(true)).toThrow(/needs a JSON object/);
+  });
+
+  it("strips functions and undefined values by JSON round-trip", () => {
+    const parsed = scriptOptions.parseScriptOptions({ keep: 1, fn: () => 1, gone: undefined });
+    expect(parsed).toEqual({ keep: 1 });
+  });
+});
+
+describe("buildOptionsPrelude", () => {
+  it("defines a frozen SURF_OPTIONS constant that is valid JavaScript on its own", () => {
+    const prelude = scriptOptions.buildOptionsPrelude({ limit: 3 });
+    expect(prelude).toBe('const SURF_OPTIONS = Object.freeze({"limit":3});\n');
+    const evaluate = new Function(`${prelude}return SURF_OPTIONS;`);
+    expect(evaluate()).toEqual({ limit: 3 });
+    expect(Object.isFrozen(evaluate())).toBe(true);
+  });
+
+  it("still defines the constant for empty options and prefixes the code", () => {
+    expect(scriptOptions.applyOptionsPrelude("return 1;", undefined)).toBe(
+      "const SURF_OPTIONS = Object.freeze({});\nreturn 1;",
+    );
+  });
+});

--- a/test/unit/script-options.test.ts
+++ b/test/unit/script-options.test.ts
@@ -34,7 +34,7 @@ describe("parseScriptOptions", () => {
 describe("buildOptionsPrelude", () => {
   it("defines a frozen SURF_OPTIONS constant that is valid JavaScript on its own", () => {
     const prelude = scriptOptions.buildOptionsPrelude({ limit: 3 });
-    expect(prelude).toBe('const SURF_OPTIONS = Object.freeze({"limit":3});\n');
+    expect(prelude).toBe('const SURF_OPTIONS = Object.freeze(JSON.parse("{\\"limit\\":3}"));\n');
     const evaluate = new Function(`${prelude}return SURF_OPTIONS;`);
     expect(evaluate()).toEqual({ limit: 3 });
     expect(Object.isFrozen(evaluate())).toBe(true);
@@ -42,7 +42,7 @@ describe("buildOptionsPrelude", () => {
 
   it("still defines the constant for empty options and prefixes the code", () => {
     expect(scriptOptions.applyOptionsPrelude("return 1;", undefined)).toBe(
-      "const SURF_OPTIONS = Object.freeze({});\nreturn 1;",
+      'const SURF_OPTIONS = Object.freeze(JSON.parse("{}"));\nreturn 1;',
     );
   });
 });


### PR DESCRIPTION
## Summary

- add `--options <json>` to `js` and `frame.js` for inline and file scripts
- expose shallow-frozen `SURF_OPTIONS` without leaking CLI-only flags
- preserve arbitrary JSON keys through safely quoted `JSON.parse`, including `__proto__`
- retain frame target isolation and focused real-Chrome coverage

This is the first split replacement for aggregate #257. It excludes readiness/#253 duplication and all extract lifecycle/retry/output code. The contributed implementation commit preserves @tryingET authorship and attribution trailers; profile-linked changelog credit is included.

## Validation

- 30 focused options/CLI tests
- 140 frame/readiness/CDP integration tests
- 892-test full suite on Node 24/Vitest 5
- TypeScript checks, lint, build, and real Chrome
- contributor-author, scope, conflict-marker, lockfile, and diff checks

Fresh review found and the retained writer fixed the object-literal `__proto__` semantic bug; targeted re-review accepted the correction. Mechanical promotion retained all landed E2E behavior.