### PR TITLE
feat(cli): add compound extract command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,14 @@
 ## [Unreleased]
 
 ### Added
+- **`surf extract`** - Composes `tab.new`, bounded `wait.ready`, page JavaScript and owned-tab cleanup, with bounded fresh-tab retries for documented transient extraction failures, JSON or concise Markdown output, explicit empty-result handling, and existing-tab mode. Intended for read-only/idempotent scripts; retries can replay caller code.
 - **`surf js --options`** - Exposes a JSON object to `js`/`frame.js` scripts as a frozen `SURF_OPTIONS` constant.
 - **Typed page readiness** - `surf wait.ready` polls with a bounded budget and reports `ready`, `empty`, `login`, `challenge`, `not-found` or `error` instead of timing out silently; negative states exit with `page_login`, `page_challenge`, `page_not_found`, `page_error` or `page_timeout`, and `--accept` returns them to the caller. `surf page.readiness` classifies the page once. Detection uses visible UI state and the caller's expectations (`--selector`, `--text`, `--url-prefix`, `--empty-text`), not site-specific selectors.
 - **`surf frame.diagnose`** - DOM `<iframe>` elements (including those inside open shadow roots, reported with their `shadowHost`), extension frames with a content-script reachability check, and the CDP frame tree side by side, correlated by URL and by `name`/`id` for `srcdoc`/`about:blank` frames, with warnings for blank frames, sandboxes without `allow-scripts`, cross-origin frames, out-of-process frames that `frame.js` cannot reach (and which commands still work there), still-loading frames and count mismatches. The text report abbreviates long frame URLs; `--json` keeps them whole.
 
 Thanks to [@tryingET](https://github.com/tryingET) for #255.
 Thanks to [@tryingET](https://github.com/tryingET) for the `js`/`frame.js --options` split from #257.
+Thanks to [@tryingET](https://github.com/tryingET) for the extract work in #257 and extract cleanup in #258.
 
 ### Fixed
 - **Readable CDP errors** - `chrome.debugger` failures surfaced as a JSON blob (`{"code":-32000,"message":"Inspected target navigated or closed"}`); the message is now unwrapped and the CDP code and method are kept on the error as `cdpCode`/`cdpMethod`.

--- a/README.md
+++ b/README.md
@@ -587,6 +587,32 @@ surf wait.ready --url-prefix "https://app.example.com/" --empty-text "No results
 surf wait.ready --accept login --json   # {"state":"login","evidence":[...]} instead of an error
 ```
 
+### Extracting structured data
+
+`surf extract` composes existing client-side tools: it opens an owned tab,
+waits for explicit readiness, runs a page script, validates its JSON result,
+and closes the tab. It prints concise Markdown by default or structured JSON
+with `--json`. Return an array, or an object containing a conventional row key
+such as `rows`, `items`, or `results`; use `--rows <key>` for another key.
+
+```bash
+surf extract "https://example.com/list" --file rows.js --ready-selector ".item"
+surf extract "https://example.com/search" --file rows.js --options '{"limit":20}' --empty-text "No results" --json
+surf extract --tab-id 42 --code 'return [...document.querySelectorAll("h2")].map(h => ({title: h.textContent}))'
+```
+
+Owned-tab failures always attempt cleanup. Zero rows retry unless
+`--allow-empty` is set or `--empty-text` identifies the page's accepted empty
+state. Fresh-tab retries are bounded (`--retry`, default 1, maximum 5) and are
+limited to readiness timeouts, zero rows, and lost tab/execution-context
+failures. Login, challenge, not-found, page-error, script/output, and cleanup
+failures do not retry. `--tab-id` and `--session` target an existing page and
+never retry or close it; `--keep-tab` preserves a successfully owned tab.
+
+Extract is intended for read-only or otherwise idempotent caller scripts.
+JavaScript is not inherently read-only: a retry can replay the script, so avoid
+mutations or make them idempotent.
+
 ### Other
 
 `js` and `frame.js` accept `--options '{"limit": 20}'` with inline code or

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -16,8 +16,9 @@ const {
   validateWorkflowArgs,
   validateWorkflowFile,
 } = require("./workflow-definition.cjs");
-const { executeDoSteps } = require("./do-executor.cjs");
-const { applyOptionsPrelude } = require("./script-options.cjs");
+const { executeDoSteps, sendDoRequest } = require("./do-executor.cjs");
+const { runExtraction, renderExtractionMarkdown } = require("./extract.cjs");
+const { applyOptionsPrelude, parseScriptOptions } = require("./script-options.cjs");
 const { openClientTransport } = require("./client-transport.cjs");
 const { version: VERSION } = require("../package.json");
 const {
@@ -906,6 +907,39 @@ const TOOLS = {
       },
       "hover": { desc: "Hover over element", args: [], opts: { ref: "Element ref", x: "X coordinate", y: "Y coordinate" } },
       "drag": { desc: "Drag between points", args: [], opts: { from: "Start x,y", to: "End x,y" } },
+    }
+  },
+  extract: {
+    desc: "Read-only extraction in an owned tab",
+    commands: {
+      "extract": {
+        desc: "Open a URL in a fresh tab, wait until it is ready, run a page-side script that returns JSON, print rows",
+        args: ["url"],
+        opts: {
+          file: "Script file; must `return` JSON (an array, or an object with a rows/items/results array)",
+          code: "Inline script instead of --file",
+          options: "JSON object exposed to the script as SURF_OPTIONS",
+          "options-file": "Read the options object from a JSON file",
+          "ready-selector": "wait.ready --selector before extracting",
+          "ready-text": "wait.ready --text before extracting",
+          "ready-url-prefix": "wait.ready --url-prefix; a different URL is a bounce",
+          "empty-text": "wait.ready --empty-text; lets an explicit no-results page pass the zero-rows check",
+          "ready-timeout": "Readiness timeout in ms (default: 20000)",
+          rows: "Key of the row array in the script result (default: auto)",
+          retry: "Fresh-tab retries on transient failures (default: 1, max: 5)",
+          "retry-delay-ms": "Delay between attempts (default: 500)",
+          "allow-empty": "Accept zero rows",
+          "keep-tab": "Leave the owned tab open on success and report its id",
+          "tab-id": "Extract from an existing tab instead (no fresh tab, no retry; navigates only if a URL is given)",
+          session: "Extract from a session's tab instead (same rules as --tab-id)",
+          json: "Print {data, rows, rowCount, attempts, readiness} as JSON",
+        },
+        examples: [
+          { cmd: 'extract "https://example.com/list" --file rows.js --ready-selector ".item"', desc: "Fresh tab, wait for items, print a Markdown table" },
+          { cmd: 'extract "https://example.com/search?q=x" --file rows.js --options \'{"limit": 20}\' --empty-text "No results" --json', desc: "Options prelude, explicit empty state, JSON output" },
+          { cmd: "extract --tab-id 42 --code 'return [...document.querySelectorAll(\"h2\")].map(h => ({ title: h.textContent }))'", desc: "Read an existing tab in place" },
+        ]
+      },
     }
   },
   js: {
@@ -2603,6 +2637,139 @@ if (args[0] === "do") {
       console.error(`Error: ${error.message}`);
       process.exit(1);
     });
+  return;
+}
+
+// Handle `surf extract`: a read-only page-side script in an owned tab with a
+// readiness gate, bounded fresh-tab retry and the zero-rows invariant.
+if (args[0] === "extract") {
+  const extractArgs = args.slice(1);
+  const valueFlags = new Set([
+    "file", "code", "options", "options-file", "ready-selector", "ready-text", "ready-url-prefix",
+    "ready-timeout", "ready-interval", "empty-text", "rows", "retry", "retry-delay-ms",
+    "tab-id", "window-id", "session",
+  ]);
+  const boolFlags = new Set(["allow-empty", "keep-tab", "json", "markdown", "no-wait", "no-lock", "help"]);
+  const opts = {};
+  let url = null;
+  for (let i = 0; i < extractArgs.length; i++) {
+    const arg = extractArgs[i];
+    if (arg === "-f") {
+      opts.file = extractArgs[++i];
+    } else if (arg.startsWith("--")) {
+      const key = arg.slice(2);
+      if (boolFlags.has(key)) opts[key] = true;
+      else if (valueFlags.has(key)) opts[key] = extractArgs[++i];
+      else {
+        console.error(`Error: unknown extract option --${key}`);
+        process.exit(1);
+      }
+    } else if (url === null) {
+      url = arg;
+    } else {
+      console.error(`Error: unexpected argument ${arg}`);
+      process.exit(1);
+    }
+  }
+  if (opts.help) {
+    showToolHelp("extract");
+    process.exit(0);
+  }
+  const wantJson = opts.json === true;
+  const fail = (code, message, details) => {
+    if (wantJson) {
+      console.log(JSON.stringify({ error: { code, message, ...(details ? { details } : {}) } }, null, 2));
+    } else {
+      console.error(`Error: ${message}${code ? ` [${code}]` : ""}`);
+    }
+    process.exit(1);
+  };
+
+  let code = null;
+  try {
+    if (opts.file && opts.code) fail("usage", "use either --file or --code, not both");
+    if (opts.file) code = fs.readFileSync(opts.file, "utf8");
+    else if (typeof opts.code === "string") code = opts.code;
+    else fail("usage", "an extraction script is required: --file script.js or --code 'return {...}'");
+  } catch (error) {
+    fail("usage", `Failed to read script: ${error.message}`);
+  }
+
+  let scriptOptions = {};
+  try {
+    if (opts.options && opts["options-file"]) fail("usage", "use either --options or --options-file, not both");
+    if (opts["options-file"]) scriptOptions = parseScriptOptions(fs.readFileSync(opts["options-file"], "utf8"));
+    else scriptOptions = parseScriptOptions(opts.options);
+  } catch (error) {
+    fail("usage", error.message);
+  }
+
+  const toInt = (key, fallback) => {
+    if (opts[key] === undefined) return fallback;
+    const parsed = parseInt(opts[key], 10);
+    if (Number.isNaN(parsed) || parsed < 0) fail("usage", `--${key} must be a non-negative integer`);
+    return parsed;
+  };
+
+  const targetOptions = resolveEarlyTargetOptions(extractArgs);
+  const hasTarget = Boolean(targetOptions.tabId || targetOptions.windowId || targetOptions.session);
+  if (!hasTarget && !url) fail("usage", "a URL is required unless --tab-id, --window-id or --session names the page to read");
+
+  const settings = {
+    code,
+    url: url ?? undefined,
+    options: scriptOptions,
+    ready: {
+      selector: opts["ready-selector"],
+      text: opts["ready-text"],
+      urlPrefix: opts["ready-url-prefix"],
+      emptyText: opts["empty-text"],
+      timeout: toInt("ready-timeout", undefined),
+      interval: toInt("ready-interval", undefined),
+    },
+    retry: { count: toInt("retry", undefined), delayMs: toInt("retry-delay-ms", undefined) },
+    keepTab: opts["keep-tab"] === true,
+    allowEmpty: opts["allow-empty"] === true,
+    rowsKey: opts.rows,
+    target: hasTarget,
+  };
+
+  const runExtract = async () => {
+    let transport;
+    try {
+      transport = await openClientTransport(endpoint);
+      const baseContext = { ...targetOptions, endpoint, transport };
+      const executeTool = (toolName, toolArgs, ownedTabId) => {
+        const context = ownedTabId
+          ? { tabId: ownedTabId, admission: targetOptions.admission, endpoint, transport }
+          : baseContext;
+        return sendDoRequest(toolName, toolArgs, context);
+      };
+      const result = await runExtraction({
+        ...settings,
+        executeTool,
+        onEvent: (event) => {
+          if (wantJson) return;
+          if (event.type === "attempt" && event.of > 1) console.error(`[surf] extract attempt ${event.attempt}/${event.of}`);
+          if (event.type === "attempt-failed" && event.retryable) console.error(`[surf] attempt ${event.attempt} failed (${event.error}); retrying with a fresh tab`);
+        },
+      });
+      if (wantJson) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        console.log(renderExtractionMarkdown(result.data, result.rows, { title: url ? `Extraction from ${url}` : "Extraction" }));
+        if (result.tabId) console.error(`[surf] tab ${result.tabId} left open (--keep-tab)`);
+      }
+      return 0;
+    } catch (error) {
+      fail(error.code || "extraction_failed", error.message, error.details);
+      return 1;
+    } finally {
+      await transport?.close();
+    }
+  };
+
+  runExtract().then((exitCode) => process.exit(exitCode));
   return;
 }
 

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -2689,6 +2689,9 @@ if (args[0] === "extract") {
     }
     process.exit(1);
   };
+  if (opts.options !== undefined && opts["options-file"] !== undefined) {
+    fail("usage", "use either --options or --options-file, not both");
+  }
 
   let code = null;
   try {
@@ -2702,9 +2705,6 @@ if (args[0] === "extract") {
 
   let scriptOptions = {};
   try {
-    if (opts.options !== undefined && opts["options-file"] !== undefined) {
-      fail("usage", "use either --options or --options-file, not both");
-    }
     if (opts["options-file"]) scriptOptions = parseScriptOptions(fs.readFileSync(opts["options-file"], "utf8"));
     else scriptOptions = parseScriptOptions(opts.options);
   } catch (error) {

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -910,7 +910,7 @@ const TOOLS = {
     }
   },
   extract: {
-    desc: "Read-only extraction in an owned tab",
+    desc: "Scripted extraction in an owned tab",
     commands: {
       "extract": {
         desc: "Open a URL in a fresh tab, wait until it is ready, run a page-side script that returns JSON, print rows",
@@ -2640,7 +2640,7 @@ if (args[0] === "do") {
   return;
 }
 
-// Handle `surf extract`: a read-only page-side script in an owned tab with a
+// Handle `surf extract`: a page-side script in an owned tab with a
 // readiness gate, bounded fresh-tab retry and the zero-rows invariant.
 if (args[0] === "extract") {
   const extractArgs = args.slice(1);

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -2771,7 +2771,6 @@ if (args[0] === "extract") {
       return 0;
     } catch (error) {
       fail(error.code || "extraction_failed", error.message, error.details);
-      return 1;
     } finally {
       await transport?.close();
     }

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -75,7 +75,7 @@ function positiveIdFlag(argv, flag) {
   return parsed;
 }
 
-function resolveEarlyTargetOptions(argv, { allowWindow = true } = {}) {
+function resolveEarlyTargetOptions(argv, { allowWindow = true, allowEnvironmentSession = true } = {}) {
   const explicitSession = flagValue(argv, "--session");
   const tabId = positiveIdFlag(argv, "--tab-id");
   const windowId = allowWindow ? positiveIdFlag(argv, "--window-id") : undefined;
@@ -84,7 +84,7 @@ function resolveEarlyTargetOptions(argv, { allowWindow = true } = {}) {
     process.exit(1);
   }
   const environmentSession = process.env.SURF_SESSION;
-  const session = explicitSession || (!tabId && !windowId ? environmentSession : undefined);
+  const session = explicitSession || (allowEnvironmentSession && !tabId && !windowId ? environmentSession : undefined);
   return {
     ...(session ? { session, sessionSource: explicitSession ? "explicit" : "environment" } : {}),
     ...(tabId ? { tabId } : {}),
@@ -2647,20 +2647,23 @@ if (args[0] === "extract") {
   const valueFlags = new Set([
     "file", "code", "options", "options-file", "ready-selector", "ready-text", "ready-url-prefix",
     "ready-timeout", "ready-interval", "empty-text", "rows", "retry", "retry-delay-ms",
-    "tab-id", "window-id", "session",
+    "tab-id", "session",
   ]);
-  const boolFlags = new Set(["allow-empty", "keep-tab", "json", "markdown", "no-wait", "no-lock", "help"]);
+  const boolFlags = new Set(["allow-empty", "keep-tab", "json", "no-wait", "help"]);
   const opts = {};
   let url = null;
   for (let i = 0; i < extractArgs.length; i++) {
     const arg = extractArgs[i];
     if (arg === "-f") {
-      opts.file = extractArgs[++i];
+      opts.file = flagValue(extractArgs, arg);
+      i++;
     } else if (arg.startsWith("--")) {
       const key = arg.slice(2);
       if (boolFlags.has(key)) opts[key] = true;
-      else if (valueFlags.has(key)) opts[key] = extractArgs[++i];
-      else {
+      else if (valueFlags.has(key)) {
+        opts[key] = flagValue(extractArgs, arg);
+        i++;
+      } else {
         console.error(`Error: unknown extract option --${key}`);
         process.exit(1);
       }
@@ -2706,14 +2709,19 @@ if (args[0] === "extract") {
 
   const toInt = (key, fallback) => {
     if (opts[key] === undefined) return fallback;
-    const parsed = parseInt(opts[key], 10);
-    if (Number.isNaN(parsed) || parsed < 0) fail("usage", `--${key} must be a non-negative integer`);
+    const parsed = Number(opts[key]);
+    if (!/^\d+$/.test(opts[key]) || !Number.isSafeInteger(parsed)) {
+      fail("usage", `--${key} must be a non-negative integer`);
+    }
     return parsed;
   };
 
-  const targetOptions = resolveEarlyTargetOptions(extractArgs);
-  const hasTarget = Boolean(targetOptions.tabId || targetOptions.windowId || targetOptions.session);
-  if (!hasTarget && !url) fail("usage", "a URL is required unless --tab-id, --window-id or --session names the page to read");
+  const targetOptions = resolveEarlyTargetOptions(extractArgs, {
+    allowWindow: false,
+    allowEnvironmentSession: false,
+  });
+  const hasTarget = Boolean(targetOptions.tabId || targetOptions.session);
+  if (!hasTarget && !url) fail("usage", "a URL is required unless --tab-id or --session names the page to read");
 
   const settings = {
     code,

--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -2661,7 +2661,9 @@ if (args[0] === "extract") {
       const key = arg.slice(2);
       if (boolFlags.has(key)) opts[key] = true;
       else if (valueFlags.has(key)) {
-        opts[key] = flagValue(extractArgs, arg);
+        opts[key] = key === "options" && extractArgs[i + 1] === ""
+          ? ""
+          : flagValue(extractArgs, arg);
         i++;
       } else {
         console.error(`Error: unknown extract option --${key}`);
@@ -2700,7 +2702,9 @@ if (args[0] === "extract") {
 
   let scriptOptions = {};
   try {
-    if (opts.options && opts["options-file"]) fail("usage", "use either --options or --options-file, not both");
+    if (opts.options !== undefined && opts["options-file"] !== undefined) {
+      fail("usage", "use either --options or --options-file, not both");
+    }
     if (opts["options-file"]) scriptOptions = parseScriptOptions(fs.readFileSync(opts["options-file"], "utf8"));
     else scriptOptions = parseScriptOptions(opts.options);
   } catch (error) {

--- a/native/extract.cjs
+++ b/native/extract.cjs
@@ -157,10 +157,6 @@ function cellText(value) {
   return text.replace(/\s+/g, " ").replace(/\|/g, "\\|").trim();
 }
 
-function isPlainRow(row) {
-  return row !== null && typeof row === "object" && !Array.isArray(row);
-}
-
 /** Markdown for humans and LLMs: metadata bullets, then a table of rows. */
 function renderExtractionMarkdown(data, rows, { title = "Extraction" } = {}) {
   const lines = [`# ${title}`, ""];
@@ -177,7 +173,7 @@ function renderExtractionMarkdown(data, rows, { title = "Extraction" } = {}) {
   }
   lines.push(`${rows.length} row${rows.length === 1 ? "" : "s"}`, "");
   if (rows.length === 0) return lines.join("\n").trimEnd();
-  if (!rows.every(isPlainRow)) {
+  if (!rows.every((row) => row !== null && typeof row === "object" && !Array.isArray(row))) {
     for (const row of rows) lines.push(`- ${cellText(row)}`);
     return lines.join("\n");
   }
@@ -376,16 +372,8 @@ async function runExtraction(settings) {
 }
 
 module.exports = {
-  DEFAULT_RETRY_COUNT,
-  DEFAULT_RETRY_DELAY_MS,
   ExtractError,
-  FATAL_READINESS_CODES,
-  MAX_RETRY_COUNT,
-  RETRYABLE_ERROR_CODES,
-  ROW_KEY_CANDIDATES,
-  TRANSIENT_TAB_ERROR_MARKERS,
   enforceRowsInvariant,
-  errorMessageOf,
   isRetryableExtractionError,
   isTransientTabError,
   parseExtractionOutput,

--- a/native/extract.cjs
+++ b/native/extract.cjs
@@ -1,5 +1,5 @@
 /**
- * Read-only page extraction in an owned tab.
+ * Page extraction intended for read-only/idempotent scripts in an owned tab.
  *
  * Lifecycle per attempt: tab.new -> wait.ready -> js -> parse -> rows
  * invariant -> tab.close. A retry always closes the failed tab and opens
@@ -212,25 +212,13 @@ function readinessArgs(ready = {}) {
   return args;
 }
 
-/**
- * Tab id from a tab.new response. The host prints "Created tab <id>: <url>"
- * for a single tab; socket clients may also see {tabId} or {id}.
- */
+/** Tab id from the stable structured field on a tab.new host response. */
 function tabIdFromResponse(response) {
   const failure = responseError(response, "tab.new");
   if (failure) throw failure;
-  const text = responseText(response);
-  let parsed = null;
-  try {
-    parsed = text === null ? null : JSON.parse(text);
-  } catch {
-    parsed = null;
-  }
-  const fromJson = Number(parsed?.tabId ?? parsed?.id);
-  if (Number.isInteger(fromJson) && fromJson > 0) return fromJson;
-  const match = typeof text === "string" ? text.match(/\btab\s+(\d+)\b/i) : null;
-  if (match) return Number(match[1]);
-  throw new ExtractError("no_tab", "tab.new did not return a tab id", { response: text ?? response });
+  const tabId = response?.result?.tabId;
+  if (Number.isInteger(tabId) && tabId > 0) return tabId;
+  throw new ExtractError("no_tab", "tab.new did not return a structured tab id");
 }
 
 function parseToolJson(response, stage) {
@@ -245,12 +233,21 @@ function parseToolJson(response, stage) {
   }
 }
 
+/** Drop transport-only fields from the readiness metadata returned to callers. */
+function cleanReadiness(readiness) {
+  if (!readiness || typeof readiness !== "object") return readiness;
+  const { id, _resolvedTabId, _resolvedWindowId, _hint, ...publicReadiness } = readiness;
+  return publicReadiness;
+}
+
 /**
  * Run one extraction attempt on `tabId` (already navigated). Shared by the
  * owned-tab and caller-supplied-target modes.
  */
 async function runAttemptOnTab(executeTool, tabId, settings) {
-  const readiness = parseToolJson(await executeTool("wait.ready", readinessArgs(settings.ready), tabId), "wait.ready");
+  const readiness = cleanReadiness(
+    parseToolJson(await executeTool("wait.ready", readinessArgs(settings.ready), tabId), "wait.ready"),
+  );
   const code = applyOptionsPrelude(settings.code, settings.options);
   const jsResponse = await executeTool("js", { code }, tabId);
   const failure = responseError(jsResponse, "js");
@@ -316,35 +313,60 @@ async function runExtraction(settings) {
     if (attempt > 1) await sleep(retry.delayMs);
     onEvent({ type: "attempt", attempt, of: attempts, mode: "owned-tab" });
     let tabId = null;
+    let result;
     try {
       tabId = tabIdFromResponse(await executeTool("tab.new", { url }));
-      const result = await runAttemptOnTab(executeTool, tabId, settings);
-      if (!keepTab) {
-        const closed = await executeTool("tab.close", { id: tabId }, tabId);
-        const closeFailure = responseError(closed, "tab.close");
-        if (closeFailure) throw closeFailure;
-      }
-      return {
-        ...result,
-        rowCount: Array.isArray(result.rows) ? result.rows.length : null,
-        attempts: attempt,
-        mode: "owned-tab",
-        url,
-        tabId: keepTab ? tabId : null,
-      };
+      result = await runAttemptOnTab(executeTool, tabId, settings);
     } catch (error) {
       lastError = error;
+      let cleanupError = null;
       if (tabId) {
         try {
-          await executeTool("tab.close", { id: tabId }, tabId);
+          const closed = await executeTool("tab.close", { id: tabId }, tabId);
+          const closeFailure = responseError(closed, "tab.close");
+          if (closeFailure) throw closeFailure;
         } catch (closeError) {
+          cleanupError = closeError;
           onEvent({ type: "close-failed", attempt, tabId, error: errorMessageOf(closeError) });
         }
+      }
+      if (cleanupError) {
+        throw new ExtractError("cleanup_failed", `Extraction failed and the owned tab could not be closed: ${errorMessageOf(cleanupError)}`, {
+          stage: "tab.close",
+          tabId,
+          attempts: attempt,
+          extractionError: { code: errorCodeOf(error), message: errorMessageOf(error) },
+        });
       }
       const retryable = attempt < attempts && isRetryable(error);
       onEvent({ type: "attempt-failed", attempt, of: attempts, error: errorMessageOf(error), code: errorCodeOf(error), retryable });
       if (!retryable) break;
+      continue;
     }
+
+    if (!keepTab) {
+      try {
+        const closed = await executeTool("tab.close", { id: tabId }, tabId);
+        const closeFailure = responseError(closed, "tab.close");
+        if (closeFailure) throw closeFailure;
+      } catch (error) {
+        throw new ExtractError("cleanup_failed", `Extraction succeeded but the owned tab could not be closed: ${errorMessageOf(error)}`, {
+          stage: "tab.close",
+          tabId,
+          attempts: attempt,
+          extractionSucceeded: true,
+          rowCount: Array.isArray(result.rows) ? result.rows.length : null,
+        });
+      }
+    }
+    return {
+      ...result,
+      rowCount: Array.isArray(result.rows) ? result.rows.length : null,
+      attempts: attempt,
+      mode: "owned-tab",
+      url,
+      tabId: keepTab ? tabId : null,
+    };
   }
   if (lastError instanceof ExtractError) {
     lastError.details = { ...lastError.details, attempts: attemptsMade };

--- a/native/extract.cjs
+++ b/native/extract.cjs
@@ -207,8 +207,8 @@ function readinessArgs(ready = {}) {
   if (ready.text) args.text = ready.text;
   if (ready.urlPrefix) args.urlPrefix = ready.urlPrefix;
   if (ready.emptyText) args.emptyText = ready.emptyText;
-  if (ready.timeout) args.timeout = ready.timeout;
-  if (ready.interval) args.interval = ready.interval;
+  if (ready.timeout !== undefined) args.timeout = ready.timeout;
+  if (ready.interval !== undefined) args.interval = ready.interval;
   return args;
 }
 

--- a/native/extract.cjs
+++ b/native/extract.cjs
@@ -1,0 +1,374 @@
+/**
+ * Read-only page extraction in an owned tab.
+ *
+ * Lifecycle per attempt: tab.new -> wait.ready -> js -> parse -> rows
+ * invariant -> tab.close. A retry always closes the failed tab and opens
+ * a fresh one, so a target whose execution context was invalidated by a
+ * navigation is never reused.
+ *
+ * This runner is for extraction only. It replays the whole sequence on
+ * transient failures, so a script that mutates state (submits a form,
+ * sends a message, changes a setting) could apply its side effect more
+ * than once. Run such scripts through `surf js` on an explicit target.
+ */
+
+const { applyOptionsPrelude } = require("./script-options.cjs");
+
+const DEFAULT_RETRY_COUNT = 1;
+const DEFAULT_RETRY_DELAY_MS = 500;
+const MAX_RETRY_COUNT = 5;
+const ROW_KEY_CANDIDATES = ["rows", "items", "results", "entries", "records", "data"];
+
+/** Error substrings that mean the tab or its execution context went away. */
+const TRANSIENT_TAB_ERROR_MARKERS = [
+  "navigated or closed",
+  "Detached while handling command",
+  "Cannot find default execution context",
+  "Execution context was destroyed",
+  "Receiving end does not exist",
+  "Content script not loaded",
+  "no longer exists",
+  "Target closed",
+];
+
+/** Error codes for which a fresh tab is meaningful. */
+const RETRYABLE_ERROR_CODES = new Set(["empty_result", "page_timeout", "tab_gone", "target_gone"]);
+
+/** Readiness codes where a retry cannot help. */
+const FATAL_READINESS_CODES = new Set(["page_login", "page_challenge", "page_not_found", "page_error"]);
+
+class ExtractError extends Error {
+  constructor(code, message, details = {}) {
+    super(message);
+    this.name = "ExtractError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+function errorMessageOf(error) {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  if (error && typeof error === "object") {
+    const text = error.content?.[0]?.text;
+    if (typeof text === "string") return text;
+    if (typeof error.message === "string") return error.message;
+    return JSON.stringify(error);
+  }
+  return String(error);
+}
+
+function errorCodeOf(error) {
+  if (error && typeof error === "object" && typeof error.code === "string") return error.code;
+  return null;
+}
+
+function isTransientTabError(error) {
+  const message = errorMessageOf(error);
+  return TRANSIENT_TAB_ERROR_MARKERS.some((marker) => message.includes(marker));
+}
+
+/**
+ * Whether a failed attempt is worth a fresh tab. Login bounces, challenges
+ * and not-found pages are not: the next tab lands on the same page.
+ */
+function isRetryableExtractionError(error) {
+  const code = errorCodeOf(error);
+  if (code && FATAL_READINESS_CODES.has(code)) return false;
+  if (code && RETRYABLE_ERROR_CODES.has(code)) return true;
+  return isTransientTabError(error);
+}
+
+/** Text of a successful tool response, or null. */
+function responseText(response) {
+  const text = response?.result?.content?.[0]?.text;
+  return typeof text === "string" ? text : null;
+}
+
+/** Turn a `{error}` tool response into an ExtractError, or return null. */
+function responseError(response, stage) {
+  if (!response || !response.error) return null;
+  const err = response.error;
+  const code = errorCodeOf(err) || "tool_error";
+  return new ExtractError(code, errorMessageOf(err), { stage, ...(err.details || {}) });
+}
+
+/** Parse what `surf js` printed for the script's return value. */
+function parseExtractionOutput(text) {
+  if (text === null || text === undefined || text.trim() === "" || text.trim() === "undefined") {
+    throw new ExtractError(
+      "no_output",
+      "The extraction script returned nothing. End it with `return { rows: [...] }` or `return [...]`.",
+    );
+  }
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new ExtractError("invalid_output", `The extraction script did not return JSON: ${error.message}`, {
+      preview: text.slice(0, 200),
+    });
+  }
+}
+
+/**
+ * Pick the row array out of the script result: the result itself when it
+ * is an array, `--rows <key>` when given, else the first conventional key
+ * holding an array. Returns null when the result has no row concept.
+ */
+function selectRows(data, rowsKey) {
+  if (rowsKey) {
+    const rows = data && typeof data === "object" && !Array.isArray(data) ? data[rowsKey] : undefined;
+    if (!Array.isArray(rows)) {
+      throw new ExtractError("rows_key_missing", `The script result has no array at "${rowsKey}"`, {
+        keys: data && typeof data === "object" ? Object.keys(data) : [],
+      });
+    }
+    return rows;
+  }
+  if (Array.isArray(data)) return data;
+  if (data && typeof data === "object") {
+    for (const key of ROW_KEY_CANDIDATES) {
+      if (Array.isArray(data[key])) return data[key];
+    }
+  }
+  return null;
+}
+
+/**
+ * Zero rows is a failure unless the caller opts in. A logged-out render,
+ * a selector miss or a half-loaded page all look like "no results"; only
+ * the caller knows whether an empty result is plausible.
+ */
+function enforceRowsInvariant(rows, { allowEmpty = false, readiness } = {}) {
+  if (!Array.isArray(rows) || rows.length > 0 || allowEmpty) return;
+  if (readiness?.state === "empty") return;
+  throw new ExtractError(
+    "empty_result",
+    "The extraction returned zero rows (the page may be logged out, blocked, or the selectors missed). Pass --allow-empty to accept an empty result, or --empty-text to recognise the page's own no-results message.",
+    { rows: 0 },
+  );
+}
+
+function cellText(value) {
+  let text;
+  if (value === null || value === undefined) text = "";
+  else if (typeof value === "string") text = value;
+  else text = JSON.stringify(value);
+  return text.replace(/\s+/g, " ").replace(/\|/g, "\\|").trim();
+}
+
+function isPlainRow(row) {
+  return row !== null && typeof row === "object" && !Array.isArray(row);
+}
+
+/** Markdown for humans and LLMs: metadata bullets, then a table of rows. */
+function renderExtractionMarkdown(data, rows, { title = "Extraction" } = {}) {
+  const lines = [`# ${title}`, ""];
+  if (data && typeof data === "object" && !Array.isArray(data)) {
+    for (const [key, value] of Object.entries(data)) {
+      if (Array.isArray(value) || (value && typeof value === "object")) continue;
+      lines.push(`- ${key}: ${cellText(value)}`);
+    }
+    if (lines.length > 2) lines.push("");
+  }
+  if (!Array.isArray(rows)) {
+    lines.push("```json", JSON.stringify(data, null, 2), "```");
+    return lines.join("\n");
+  }
+  lines.push(`${rows.length} row${rows.length === 1 ? "" : "s"}`, "");
+  if (rows.length === 0) return lines.join("\n").trimEnd();
+  if (!rows.every(isPlainRow)) {
+    for (const row of rows) lines.push(`- ${cellText(row)}`);
+    return lines.join("\n");
+  }
+  const columns = [];
+  for (const row of rows) {
+    for (const key of Object.keys(row)) {
+      if (!columns.includes(key)) columns.push(key);
+    }
+  }
+  lines.push(`| ${columns.join(" | ")} |`);
+  lines.push(`| ${columns.map(() => "---").join(" | ")} |`);
+  for (const row of rows) {
+    lines.push(`| ${columns.map((column) => cellText(row[column])).join(" | ")} |`);
+  }
+  return lines.join("\n");
+}
+
+function normalizeRetry(retry) {
+  const count = Number.isInteger(retry?.count) ? Math.max(0, Math.min(retry.count, MAX_RETRY_COUNT)) : DEFAULT_RETRY_COUNT;
+  const delayMs = Number.isFinite(retry?.delayMs) && retry.delayMs >= 0 ? retry.delayMs : DEFAULT_RETRY_DELAY_MS;
+  return { count, delayMs };
+}
+
+function readinessArgs(ready = {}) {
+  const args = {};
+  if (ready.selector) args.selector = ready.selector;
+  if (ready.text) args.text = ready.text;
+  if (ready.urlPrefix) args.urlPrefix = ready.urlPrefix;
+  if (ready.emptyText) args.emptyText = ready.emptyText;
+  if (ready.timeout) args.timeout = ready.timeout;
+  if (ready.interval) args.interval = ready.interval;
+  return args;
+}
+
+/**
+ * Tab id from a tab.new response. The host prints "Created tab <id>: <url>"
+ * for a single tab; socket clients may also see {tabId} or {id}.
+ */
+function tabIdFromResponse(response) {
+  const failure = responseError(response, "tab.new");
+  if (failure) throw failure;
+  const text = responseText(response);
+  let parsed = null;
+  try {
+    parsed = text === null ? null : JSON.parse(text);
+  } catch {
+    parsed = null;
+  }
+  const fromJson = Number(parsed?.tabId ?? parsed?.id);
+  if (Number.isInteger(fromJson) && fromJson > 0) return fromJson;
+  const match = typeof text === "string" ? text.match(/\btab\s+(\d+)\b/i) : null;
+  if (match) return Number(match[1]);
+  throw new ExtractError("no_tab", "tab.new did not return a tab id", { response: text ?? response });
+}
+
+function parseToolJson(response, stage) {
+  const failure = responseError(response, stage);
+  if (failure) throw failure;
+  const text = responseText(response);
+  if (text === null) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+/**
+ * Run one extraction attempt on `tabId` (already navigated). Shared by the
+ * owned-tab and caller-supplied-target modes.
+ */
+async function runAttemptOnTab(executeTool, tabId, settings) {
+  const readiness = parseToolJson(await executeTool("wait.ready", readinessArgs(settings.ready), tabId), "wait.ready");
+  const code = applyOptionsPrelude(settings.code, settings.options);
+  const jsResponse = await executeTool("js", { code }, tabId);
+  const failure = responseError(jsResponse, "js");
+  if (failure) throw failure;
+  const data = parseExtractionOutput(responseText(jsResponse));
+  const rows = selectRows(data, settings.rowsKey);
+  enforceRowsInvariant(rows, { allowEmpty: settings.allowEmpty, readiness });
+  return { data, rows, readiness };
+}
+
+/**
+ * @param {object} settings
+ * @param {(tool: string, args: object, tabId?: number) => Promise<object>} settings.executeTool
+ *   Sends one tool request. `tabId` overrides the target for owned tabs; when
+ *   it is undefined the caller's default target (session/tab/window) applies.
+ * @param {string} settings.code Page-side script; must `return` JSON.
+ * @param {string} [settings.url] Page to open. Required unless `target` is set.
+ * @param {object} [settings.options] Exposed to the script as SURF_OPTIONS.
+ * @param {object} [settings.ready] wait.ready expectations (selector, text, urlPrefix, emptyText, timeout, interval).
+ * @param {{count?: number, delayMs?: number}} [settings.retry]
+ * @param {boolean} [settings.keepTab] Leave the owned tab open on success.
+ * @param {boolean} [settings.allowEmpty]
+ * @param {string} [settings.rowsKey]
+ * @param {boolean} [settings.target] Use the caller's target instead of an owned tab.
+ * @param {(error: unknown) => boolean} [settings.isRetryable]
+ * @param {(ms: number) => Promise<void>} [settings.sleep]
+ * @param {(event: object) => void} [settings.onEvent]
+ */
+async function runExtraction(settings) {
+  const {
+    executeTool,
+    code,
+    url,
+    target = false,
+    keepTab = false,
+    isRetryable = isRetryableExtractionError,
+    sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+    onEvent = () => {},
+  } = settings;
+  if (typeof executeTool !== "function") throw new Error("runExtraction requires executeTool");
+  if (typeof code !== "string" || code.trim() === "") throw new ExtractError("no_script", "An extraction script is required (--file or --code)");
+  if (!target && !url) throw new ExtractError("no_url", "A URL is required unless --tab-id or --session names the page to read");
+
+  if (target) {
+    // Caller-supplied target: navigate once if asked, never close, never retry.
+    if (url) {
+      const navigation = await executeTool("navigate", { url });
+      const failure = responseError(navigation, "navigate");
+      if (failure) throw failure;
+    }
+    onEvent({ type: "attempt", attempt: 1, of: 1, mode: "target" });
+    const attempt = await runAttemptOnTab(executeTool, undefined, settings);
+    return { ...attempt, rowCount: Array.isArray(attempt.rows) ? attempt.rows.length : null, attempts: 1, mode: "target", url: url ?? null };
+  }
+
+  const retry = normalizeRetry(settings.retry);
+  const attempts = retry.count + 1;
+  let lastError = null;
+  let attemptsMade = 0;
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    attemptsMade = attempt;
+    if (attempt > 1) await sleep(retry.delayMs);
+    onEvent({ type: "attempt", attempt, of: attempts, mode: "owned-tab" });
+    let tabId = null;
+    try {
+      tabId = tabIdFromResponse(await executeTool("tab.new", { url }));
+      const result = await runAttemptOnTab(executeTool, tabId, settings);
+      if (!keepTab) {
+        const closed = await executeTool("tab.close", { id: tabId }, tabId);
+        const closeFailure = responseError(closed, "tab.close");
+        if (closeFailure) throw closeFailure;
+      }
+      return {
+        ...result,
+        rowCount: Array.isArray(result.rows) ? result.rows.length : null,
+        attempts: attempt,
+        mode: "owned-tab",
+        url,
+        tabId: keepTab ? tabId : null,
+      };
+    } catch (error) {
+      lastError = error;
+      if (tabId) {
+        try {
+          await executeTool("tab.close", { id: tabId }, tabId);
+        } catch (closeError) {
+          onEvent({ type: "close-failed", attempt, tabId, error: errorMessageOf(closeError) });
+        }
+      }
+      const retryable = attempt < attempts && isRetryable(error);
+      onEvent({ type: "attempt-failed", attempt, of: attempts, error: errorMessageOf(error), code: errorCodeOf(error), retryable });
+      if (!retryable) break;
+    }
+  }
+  if (lastError instanceof ExtractError) {
+    lastError.details = { ...lastError.details, attempts: attemptsMade };
+    throw lastError;
+  }
+  throw new ExtractError(errorCodeOf(lastError) || "extraction_failed", errorMessageOf(lastError), { attempts: attemptsMade });
+}
+
+module.exports = {
+  DEFAULT_RETRY_COUNT,
+  DEFAULT_RETRY_DELAY_MS,
+  ExtractError,
+  FATAL_READINESS_CODES,
+  MAX_RETRY_COUNT,
+  RETRYABLE_ERROR_CODES,
+  ROW_KEY_CANDIDATES,
+  TRANSIENT_TAB_ERROR_MARKERS,
+  enforceRowsInvariant,
+  errorMessageOf,
+  isRetryableExtractionError,
+  isTransientTabError,
+  parseExtractionOutput,
+  renderExtractionMarkdown,
+  runExtraction,
+  selectRows,
+  tabIdFromResponse,
+};

--- a/native/host.cjs
+++ b/native/host.cjs
@@ -1766,7 +1766,12 @@ function sendToolResponse(socket, id, result, error) {
     }
     if (request?.notice) response.notice = request.notice;
     if (formattedError) response.error = formattedError;
-    else response.result = { content: formatToolContent(output, log, { suppressImages: Boolean(context?.isRemote) }) };
+    else {
+      response.result = { content: formatToolContent(output, log, { suppressImages: Boolean(context?.isRemote) }) };
+      if (request?.tool === "tab.new" && Number.isInteger(output?.tabId) && output.tabId > 0) {
+        response.result.tabId = output.tabId;
+      }
+    }
     if (!context?.closed) await sendSocket(socket, response);
   })().catch((sendError) => log(`Error sending tool_response: ${sendError.message}`));
 }

--- a/test/e2e/real-chrome.mjs
+++ b/test/e2e/real-chrome.mjs
@@ -555,6 +555,34 @@ try {
   }
   await runSurf("tab.close", "--id", optionsTabId, "--json");
 
+  // --- extract owned lifecycle, options, empty states and bounded cleanup ---
+  const pagesBeforeExtract = (await browser.pages()).length;
+  const extracted = JSON.parse(await runSurf(
+    "extract", `${baseUrl}/list?q=extract`, "--file", optionsScript,
+    "--options", '{"limit":2}', "--ready-selector", ".item", "--json",
+  ));
+  if (extracted.rowCount !== 2 || extracted.data?.query !== "extract" || extracted.rows?.[1]?.title !== "Item 2") {
+    throw new Error(`extract success contract failed: ${JSON.stringify(extracted)}`);
+  }
+  const acceptedEmpty = JSON.parse(await runSurf(
+    "extract", `${baseUrl}/list?empty=1`, "--file", optionsScript,
+    "--empty-text", "No results for this search.", "--json",
+  ));
+  if (acceptedEmpty.rowCount !== 0 || acceptedEmpty.readiness?.state !== "empty") {
+    throw new Error(`extract accepted-empty contract failed: ${JSON.stringify(acceptedEmpty)}`);
+  }
+  const rejectedEmpty = await runSurfExpectingFailure(
+    "extract", `${baseUrl}/list?empty=1`, "--file", optionsScript,
+    "--retry", "1", "--retry-delay-ms", "0", "--json",
+  );
+  const emptyError = JSON.parse(rejectedEmpty.stdout).error;
+  if (emptyError?.code !== "empty_result" || emptyError?.details?.attempts !== 2) {
+    throw new Error(`extract rejected-empty contract failed: ${JSON.stringify(emptyError)}`);
+  }
+  if ((await browser.pages()).length !== pagesBeforeExtract) {
+    throw new Error("extract leaked an owned tab");
+  }
+
   await runSurf("screenshot", "--output", screenshotPath);
   const png = readFileSync(screenshotPath);
   if (png.length < 100 || png.subarray(0, 8).toString("hex") !== "89504e470d0a1a0a") {

--- a/test/unit/cli-args.test.ts
+++ b/test/unit/cli-args.test.ts
@@ -210,6 +210,83 @@ function runCli(
   });
 }
 
+function extractFixtureResponse(request: any) {
+  const tool = request.params.tool;
+  if (tool === "js" && request.session === "chosen") {
+    return {
+      id: request.id,
+      error: { content: [{ type: "text", text: "Inspected target navigated or closed" }] },
+    };
+  }
+  const texts: Record<string, string> = {
+    "tab.new": "Created tab 41: https://example.com/list",
+    "wait.ready": JSON.stringify({ state: "ready" }),
+    js: JSON.stringify({ rows: [{ title: "A" }] }),
+  };
+  return {
+    id: request.id,
+    result: {
+      ...(tool === "tab.new" ? { tabId: 41 } : {}),
+      content: [{ type: "text", text: texts[tool] || "OK" }],
+    },
+  };
+}
+
+function runExtractCli(
+  args: string[],
+  extraEnv: Record<string, string | undefined> = {},
+): Promise<{ code: number | null; requests: any[]; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const socketPath = createSocketPath();
+    cleanupSocket(socketPath);
+    const requests: any[] = [];
+    let stdout = "";
+    let stderr = "";
+
+    const server = net.createServer((socket: any) => {
+      let buffer = "";
+      socket.on("data", (chunk: { toString(): string }) => {
+        buffer += chunk.toString();
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
+        for (const line of lines) {
+          if (!line) {
+            continue;
+          }
+          const request = JSON.parse(line);
+          requests.push(request);
+          socket.write(`${JSON.stringify(extractFixtureResponse(request))}\n`);
+        }
+      });
+    });
+
+    server.on("error", reject);
+    server.listen(socketPath, () => {
+      const child = spawn(process.execPath, ["native/cli.cjs", ...args], {
+        cwd: process.cwd(),
+        env: { ...createCliEnv(socketPath), ...extraEnv },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      child.stdout.on("data", (chunk: { toString(): string }) => {
+        stdout += chunk.toString();
+      });
+      child.stderr.on("data", (chunk: { toString(): string }) => {
+        stderr += chunk.toString();
+      });
+      child.on("error", (error: Error) => {
+        server.close();
+        reject(error);
+      });
+      child.on("close", (code: number | null) => {
+        server.close(() => {
+          cleanupSocket(socketPath);
+          resolve({ code, requests, stdout, stderr });
+        });
+      });
+    });
+  });
+}
+
 function spawnCliWithSocket(
   args: string[],
   socketPath: string,
@@ -250,6 +327,62 @@ function waitFor<T>(promise: Promise<T>, ms: number, label: string): Promise<T> 
 }
 
 describe("CLI argument parsing", () => {
+  it("keeps URL extraction owned despite ambient SURF_SESSION and targets explicit sessions in place", async () => {
+    const ambient = await runExtractCli(
+      ["extract", "https://example.com/list", "--code", "return [{title: 'A'}]", "--json"],
+      { SURF_SESSION: "ambient" },
+    );
+    expect(ambient.code).toBe(0);
+    expect(ambient.requests.map((request) => request.params.tool)).toEqual([
+      "tab.new",
+      "wait.ready",
+      "js",
+      "tab.close",
+    ]);
+    expect(ambient.requests.every((request) => request.session === undefined)).toBe(true);
+
+    const explicit = await runExtractCli([
+      "extract",
+      "--session",
+      "chosen",
+      "--code",
+      "return [{title: 'A'}]",
+      "--json",
+    ]);
+    expect(explicit.code).toBe(1);
+    expect(explicit.requests.map((request) => request.params.tool)).toEqual(["wait.ready", "js"]);
+    expect(explicit.requests.every((request) => request.session === "chosen")).toBe(true);
+  });
+
+  it.each([
+    {
+      args: ["extract", "https://example.com", "--code", "--json"],
+      error: "--code requires a value",
+    },
+    {
+      args: ["extract", "https://example.com", "--code", "return []", "--retry", "1junk"],
+      error: "--retry must be a non-negative integer",
+    },
+    {
+      args: ["extract", "https://example.com", "--code", "return []", "--window-id", "3"],
+      error: "unknown extract option --window-id",
+    },
+    {
+      args: ["extract", "https://example.com", "--code", "return []", "--markdown"],
+      error: "unknown extract option --markdown",
+    },
+    {
+      args: ["extract", "https://example.com", "--code", "return []", "--no-lock"],
+      error: "unknown extract option --no-lock",
+    },
+  ])("rejects invalid extract parser input: $error", async ({ args, error }) => {
+    const result = await runCliWithoutSocket(args);
+    expect(result.code).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain(error);
+    expect(result.stderr).not.toContain("Socket");
+  });
+
   it("prints LLM context without requiring a socket", async () => {
     const { code, stdout, stderr } = await runCliWithoutSocket(["--llm-context"]);
 

--- a/test/unit/cli-args.test.ts
+++ b/test/unit/cli-args.test.ts
@@ -350,20 +350,22 @@ describe("CLI argument parsing", () => {
     );
   });
 
-  it("rejects empty extract options combined with an options file before connecting", async () => {
+  it("rejects conflicting option sources before script-file IO or connection", async () => {
+    const missingRoot = path.join(os.tmpdir(), `surf-extract-missing-${process.pid}`);
     const result = await runCliWithoutSocket([
       "extract",
       "https://example.com/list",
-      "--code",
-      "return []",
+      "--file",
+      path.join(missingRoot, "script.js"),
       "--options",
       "",
       "--options-file",
-      "unused.json",
+      path.join(missingRoot, "options.json"),
     ]);
     expect(result.code).toBe(1);
     expect(result.stdout).toBe("");
     expect(result.stderr).toContain("use either --options or --options-file, not both");
+    expect(result.stderr).not.toContain("ENOENT");
     expect(result.stderr).not.toContain("Socket");
   });
 

--- a/test/unit/cli-args.test.ts
+++ b/test/unit/cli-args.test.ts
@@ -210,7 +210,13 @@ function runCli(
   });
 }
 
-function extractFixtureResponse(request: any) {
+type ExtractCliRequest = {
+  id: string;
+  params: { tool: string };
+  session?: string;
+};
+
+function extractFixtureResponse(request: ExtractCliRequest) {
   const tool = request.params.tool;
   if (tool === "js" && request.session === "chosen") {
     return {
@@ -235,11 +241,11 @@ function extractFixtureResponse(request: any) {
 function runExtractCli(
   args: string[],
   extraEnv: Record<string, string | undefined> = {},
-): Promise<{ code: number | null; requests: any[]; stdout: string; stderr: string }> {
+): Promise<{ code: number | null; requests: ExtractCliRequest[]; stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
     const socketPath = createSocketPath();
     cleanupSocket(socketPath);
-    const requests: any[] = [];
+    const requests: ExtractCliRequest[] = [];
     let stdout = "";
     let stderr = "";
 
@@ -253,7 +259,7 @@ function runExtractCli(
           if (!line) {
             continue;
           }
-          const request = JSON.parse(line);
+          const request: ExtractCliRequest = JSON.parse(line);
           requests.push(request);
           socket.write(`${JSON.stringify(extractFixtureResponse(request))}\n`);
         }

--- a/test/unit/cli-args.test.ts
+++ b/test/unit/cli-args.test.ts
@@ -212,7 +212,7 @@ function runCli(
 
 type ExtractCliRequest = {
   id: string;
-  params: { tool: string };
+  params: { tool: string; args: Record<string, unknown> };
   session?: string;
 };
 
@@ -333,6 +333,40 @@ function waitFor<T>(promise: Promise<T>, ms: number, label: string): Promise<T> 
 }
 
 describe("CLI argument parsing", () => {
+  it("passes empty extract options to js as an empty SURF_OPTIONS object", async () => {
+    const result = await runExtractCli([
+      "extract",
+      "https://example.com/list",
+      "--code",
+      "return []",
+      "--options",
+      "",
+      "--json",
+    ]);
+    expect(result.code).toBe(0);
+    const jsRequest = result.requests.find((request) => request.params.tool === "js");
+    expect(jsRequest?.params.args.code).toBe(
+      'const SURF_OPTIONS = Object.freeze(JSON.parse("{}"));\nreturn []',
+    );
+  });
+
+  it("rejects empty extract options combined with an options file before connecting", async () => {
+    const result = await runCliWithoutSocket([
+      "extract",
+      "https://example.com/list",
+      "--code",
+      "return []",
+      "--options",
+      "",
+      "--options-file",
+      "unused.json",
+    ]);
+    expect(result.code).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("use either --options or --options-file, not both");
+    expect(result.stderr).not.toContain("Socket");
+  });
+
   it("keeps URL extraction owned despite ambient SURF_SESSION and targets explicit sessions in place", async () => {
     const ambient = await runExtractCli(
       ["extract", "https://example.com/list", "--code", "return [{title: 'A'}]", "--json"],

--- a/test/unit/extract.test.ts
+++ b/test/unit/extract.test.ts
@@ -1,0 +1,448 @@
+import { describe, expect, it, vi } from "vitest";
+
+// @ts-expect-error - CommonJS module without type definitions
+import * as extract from "../../native/extract.cjs";
+
+type Call = { tool: string; args: Record<string, unknown>; tabId?: number };
+
+function ok(payload: unknown) {
+  return {
+    result: {
+      content: [
+        { type: "text", text: typeof payload === "string" ? payload : JSON.stringify(payload) },
+      ],
+    },
+  };
+}
+
+function toolError(text: string, code?: string) {
+  return { error: { content: [{ type: "text", text }], ...(code ? { code } : {}) } };
+}
+
+/**
+ * Scripted fake host: each entry answers the next call to `tool`. The
+ * recorded call list doubles as the protocol assertion, the same way the
+ * Go fork's socket-level retry test worked.
+ */
+function scriptedHost(script: Array<{ tool: string; reply: unknown | (() => unknown) }>) {
+  const calls: Call[] = [];
+  let index = 0;
+  const executeTool = vi.fn(async (tool: string, args: Record<string, unknown>, tabId?: number) => {
+    calls.push({ tool, args, tabId });
+    const entry = script[index++];
+    if (!entry) {
+      throw new Error(`unexpected call ${tool} (#${calls.length})`);
+    }
+    if (entry.tool !== tool) {
+      throw new Error(`expected ${entry.tool} but got ${tool} at call #${calls.length}`);
+    }
+    return typeof entry.reply === "function" ? (entry.reply as () => unknown)() : entry.reply;
+  });
+  return { calls, executeTool, remaining: () => script.length - index };
+}
+
+const ready = ok({
+  state: "ready",
+  evidence: ["document.readyState is complete"],
+  polls: 1,
+  waited: 12,
+});
+const rowsResult = ok({
+  rows: [
+    { title: "A", href: "/a" },
+    { title: "B", href: "/b" },
+  ],
+  total: 2,
+});
+
+describe("runExtraction (owned tab)", () => {
+  it("opens, waits, extracts and closes a fresh tab", async () => {
+    const host = scriptedHost([
+      { tool: "tab.new", reply: ok({ success: true, tabId: 41, url: "https://x/" }) },
+      { tool: "wait.ready", reply: ready },
+      { tool: "js", reply: rowsResult },
+      { tool: "tab.close", reply: ok({ success: true }) },
+    ]);
+
+    const result = await extract.runExtraction({
+      executeTool: host.executeTool,
+      url: "https://x/",
+      code: "return SURF_OPTIONS.limit;",
+      options: { limit: 5 },
+      ready: { selector: ".row", timeout: 3000 },
+    });
+
+    expect(result).toMatchObject({
+      rowCount: 2,
+      attempts: 1,
+      mode: "owned-tab",
+      tabId: null,
+      url: "https://x/",
+    });
+    expect(result.rows).toHaveLength(2);
+    expect(result.readiness.state).toBe("ready");
+    expect(host.calls.map((call) => [call.tool, call.tabId])).toEqual([
+      ["tab.new", undefined],
+      ["wait.ready", 41],
+      ["js", 41],
+      ["tab.close", 41],
+    ]);
+    expect(host.calls[0].args).toEqual({ url: "https://x/" });
+    expect(host.calls[1].args).toEqual({ selector: ".row", timeout: 3000 });
+    expect(host.calls[2].args.code).toBe(
+      'const SURF_OPTIONS = Object.freeze({"limit":5});\nreturn SURF_OPTIONS.limit;',
+    );
+    expect(host.calls[3].args).toEqual({ id: 41 });
+    expect(host.remaining()).toBe(0);
+  });
+
+  it("retries with a fresh tab after a transient execution-context failure", async () => {
+    const host = scriptedHost([
+      { tool: "tab.new", reply: ok({ tabId: 1 }) },
+      { tool: "wait.ready", reply: ready },
+      { tool: "js", reply: toolError("Inspected target navigated or closed") },
+      { tool: "tab.close", reply: ok({ success: true }) },
+      { tool: "tab.new", reply: ok({ tabId: 2 }) },
+      { tool: "wait.ready", reply: ready },
+      { tool: "js", reply: rowsResult },
+      { tool: "tab.close", reply: ok({ success: true }) },
+    ]);
+    const sleep = vi.fn(async () => undefined);
+    const events: Array<Record<string, unknown>> = [];
+
+    const result = await extract.runExtraction({
+      executeTool: host.executeTool,
+      url: "https://x/",
+      code: "return 1",
+      retry: { count: 1, delayMs: 250 },
+      sleep,
+      onEvent: (event: Record<string, unknown>) => events.push(event),
+    });
+
+    expect(result.attempts).toBe(2);
+    expect(result.rowCount).toBe(2);
+    expect(sleep).toHaveBeenCalledWith(250);
+    expect(host.calls.map((call) => call.tool)).toEqual([
+      "tab.new",
+      "wait.ready",
+      "js",
+      "tab.close",
+      "tab.new",
+      "wait.ready",
+      "js",
+      "tab.close",
+    ]);
+    expect(host.calls[3].args).toEqual({ id: 1 });
+    expect(events.find((event) => event.type === "attempt-failed")).toMatchObject({
+      attempt: 1,
+      retryable: true,
+    });
+  });
+
+  it("treats zero rows as a failure, retries once, then reports empty_result", async () => {
+    const empty = ok({ rows: [] });
+    const host = scriptedHost([
+      { tool: "tab.new", reply: ok({ tabId: 1 }) },
+      { tool: "wait.ready", reply: ready },
+      { tool: "js", reply: empty },
+      { tool: "tab.close", reply: ok({}) },
+      { tool: "tab.new", reply: ok({ tabId: 2 }) },
+      { tool: "wait.ready", reply: ready },
+      { tool: "js", reply: empty },
+      { tool: "tab.close", reply: ok({}) },
+    ]);
+
+    await expect(
+      extract.runExtraction({
+        executeTool: host.executeTool,
+        url: "https://x/",
+        code: "return []",
+        sleep: async () => undefined,
+      }),
+    ).rejects.toMatchObject({ code: "empty_result", details: { attempts: 2 } });
+    expect(host.remaining()).toBe(0);
+  });
+
+  it("accepts zero rows with allowEmpty and when the page reports its own empty state", async () => {
+    const allow = scriptedHost([
+      { tool: "tab.new", reply: ok({ tabId: 1 }) },
+      { tool: "wait.ready", reply: ready },
+      { tool: "js", reply: ok([]) },
+      { tool: "tab.close", reply: ok({}) },
+    ]);
+    const allowed = await extract.runExtraction({
+      executeTool: allow.executeTool,
+      url: "https://x/",
+      code: "return []",
+      allowEmpty: true,
+    });
+    expect(allowed.rowCount).toBe(0);
+
+    const emptyState = scriptedHost([
+      { tool: "tab.new", reply: ok({ tabId: 1 }) },
+      {
+        tool: "wait.ready",
+        reply: ok({ state: "empty", evidence: ['empty-state text "No results" found'] }),
+      },
+      { tool: "js", reply: ok({ rows: [] }) },
+      { tool: "tab.close", reply: ok({}) },
+    ]);
+    const explicit = await extract.runExtraction({
+      executeTool: emptyState.executeTool,
+      url: "https://x/",
+      code: "return {rows: []}",
+      ready: { emptyText: "No results" },
+    });
+    expect(explicit.rowCount).toBe(0);
+    expect(explicit.readiness.state).toBe("empty");
+  });
+
+  it("does not retry a login bounce and still closes the tab", async () => {
+    const host = scriptedHost([
+      { tool: "tab.new", reply: ok({ tabId: 1 }) },
+      {
+        tool: "wait.ready",
+        reply: toolError("Page is not ready: login at https://x/login", "page_login"),
+      },
+      { tool: "tab.close", reply: ok({}) },
+    ]);
+
+    await expect(
+      extract.runExtraction({
+        executeTool: host.executeTool,
+        url: "https://x/",
+        code: "return 1",
+        retry: { count: 3 },
+      }),
+    ).rejects.toMatchObject({
+      code: "page_login",
+      message: expect.stringContaining("login at https://x/login"),
+    });
+    expect(host.calls.map((call) => call.tool)).toEqual(["tab.new", "wait.ready", "tab.close"]);
+  });
+
+  it("does not retry a script error and reports a single attempt", async () => {
+    const host = scriptedHost([
+      { tool: "tab.new", reply: ok({ tabId: 1 }) },
+      { tool: "wait.ready", reply: ready },
+      { tool: "js", reply: toolError("SyntaxError: Unexpected token ')'") },
+      { tool: "tab.close", reply: ok({}) },
+    ]);
+    await expect(
+      extract.runExtraction({
+        executeTool: host.executeTool,
+        url: "https://x/",
+        code: "return )",
+        retry: { count: 2 },
+      }),
+    ).rejects.toMatchObject({ code: "tool_error", details: { stage: "js", attempts: 1 } });
+    expect(host.remaining()).toBe(0);
+  });
+
+  it("retries a readiness timeout but gives up after the retry budget", async () => {
+    const host = scriptedHost([
+      { tool: "tab.new", reply: ok({ tabId: 1 }) },
+      {
+        tool: "wait.ready",
+        reply: toolError("Page did not become ready within 20000ms", "page_timeout"),
+      },
+      { tool: "tab.close", reply: ok({}) },
+      { tool: "tab.new", reply: ok({ tabId: 2 }) },
+      {
+        tool: "wait.ready",
+        reply: toolError("Page did not become ready within 20000ms", "page_timeout"),
+      },
+      { tool: "tab.close", reply: ok({}) },
+    ]);
+    await expect(
+      extract.runExtraction({
+        executeTool: host.executeTool,
+        url: "https://x/",
+        code: "return 1",
+        sleep: async () => undefined,
+      }),
+    ).rejects.toMatchObject({ code: "page_timeout" });
+    expect(host.remaining()).toBe(0);
+  });
+
+  it("keeps the tab open on success when asked and reports its id", async () => {
+    const host = scriptedHost([
+      { tool: "tab.new", reply: ok({ tabId: 9 }) },
+      { tool: "wait.ready", reply: ready },
+      { tool: "js", reply: rowsResult },
+    ]);
+    const result = await extract.runExtraction({
+      executeTool: host.executeTool,
+      url: "https://x/",
+      code: "return 1",
+      keepTab: true,
+    });
+    expect(result.tabId).toBe(9);
+    expect(host.calls.map((call) => call.tool)).toEqual(["tab.new", "wait.ready", "js"]);
+  });
+
+  it("surfaces a script that returns nothing or non-JSON", async () => {
+    const host = scriptedHost([
+      { tool: "tab.new", reply: ok({ tabId: 1 }) },
+      { tool: "wait.ready", reply: ready },
+      { tool: "js", reply: ok("undefined") },
+      { tool: "tab.close", reply: ok({}) },
+    ]);
+    await expect(
+      extract.runExtraction({
+        executeTool: host.executeTool,
+        url: "https://x/",
+        code: "document.title",
+      }),
+    ).rejects.toMatchObject({ code: "no_output" });
+    expect(host.remaining()).toBe(0);
+  });
+
+  it("rejects missing script or URL before touching the browser", async () => {
+    const executeTool = vi.fn();
+    await expect(
+      extract.runExtraction({ executeTool, url: "https://x/", code: "" }),
+    ).rejects.toMatchObject({ code: "no_script" });
+    await expect(extract.runExtraction({ executeTool, code: "return 1" })).rejects.toMatchObject({
+      code: "no_url",
+    });
+    expect(executeTool).not.toHaveBeenCalled();
+  });
+});
+
+describe("runExtraction (caller-supplied target)", () => {
+  it("navigates once, never opens or closes tabs, never retries", async () => {
+    const host = scriptedHost([
+      { tool: "navigate", reply: ok({ success: true }) },
+      { tool: "wait.ready", reply: ready },
+      { tool: "js", reply: toolError("Inspected target navigated or closed") },
+    ]);
+    await expect(
+      extract.runExtraction({
+        executeTool: host.executeTool,
+        target: true,
+        url: "https://x/",
+        code: "return 1",
+        retry: { count: 3 },
+      }),
+    ).rejects.toMatchObject({ code: "tool_error" });
+    expect(host.calls.map((call) => [call.tool, call.tabId])).toEqual([
+      ["navigate", undefined],
+      ["wait.ready", undefined],
+      ["js", undefined],
+    ]);
+  });
+
+  it("reads the current page in place when no URL is given", async () => {
+    const host = scriptedHost([
+      { tool: "wait.ready", reply: ready },
+      { tool: "js", reply: ok([{ a: 1 }]) },
+    ]);
+    const result = await extract.runExtraction({
+      executeTool: host.executeTool,
+      target: true,
+      code: "return [{a: 1}]",
+    });
+    expect(result).toMatchObject({ mode: "target", attempts: 1, rowCount: 1, url: null });
+  });
+});
+
+describe("tabIdFromResponse", () => {
+  it("reads JSON and the host's text form", () => {
+    expect(extract.tabIdFromResponse(ok({ success: true, tabId: 12 }))).toBe(12);
+    expect(extract.tabIdFromResponse(ok({ id: 13 }))).toBe(13);
+    expect(extract.tabIdFromResponse(ok("Created tab 1076931763: http://127.0.0.1/list"))).toBe(
+      1076931763,
+    );
+    expect(() => extract.tabIdFromResponse(ok("OK"))).toThrow(/did not return a tab id/);
+    expect(() => extract.tabIdFromResponse(toolError("tab_busy", "tab_busy"))).toThrow(/tab_busy/);
+  });
+});
+
+describe("helpers", () => {
+  it("classifies transient tab errors and retryable codes", () => {
+    expect(extract.isTransientTabError(new Error("Inspected target navigated or closed"))).toBe(
+      true,
+    );
+    expect(extract.isTransientTabError("Cannot find default execution context")).toBe(true);
+    expect(
+      extract.isTransientTabError({ content: [{ text: "Receiving end does not exist" }] }),
+    ).toBe(true);
+    expect(extract.isTransientTabError(new Error("selector not found"))).toBe(false);
+
+    expect(extract.isRetryableExtractionError(new extract.ExtractError("empty_result", "x"))).toBe(
+      true,
+    );
+    expect(extract.isRetryableExtractionError({ code: "page_timeout", message: "slow" })).toBe(
+      true,
+    );
+    expect(
+      extract.isRetryableExtractionError({
+        code: "page_login",
+        message: "Detached while handling command",
+      }),
+    ).toBe(false);
+    expect(extract.isRetryableExtractionError(new Error("syntax error"))).toBe(false);
+  });
+
+  it("selects rows from arrays, conventional keys or an explicit key", () => {
+    expect(extract.selectRows([1, 2])).toEqual([1, 2]);
+    expect(extract.selectRows({ total: 2, items: [{ a: 1 }] })).toEqual([{ a: 1 }]);
+    expect(extract.selectRows({ jobs: [{ a: 1 }] }, "jobs")).toEqual([{ a: 1 }]);
+    expect(extract.selectRows({ title: "x" })).toBeNull();
+    expect(() => extract.selectRows({ title: "x" }, "jobs")).toThrow(/no array at "jobs"/);
+  });
+
+  it("enforces the zero-rows invariant only for row arrays", () => {
+    expect(() => extract.enforceRowsInvariant([])).toThrow(/zero rows/);
+    expect(() => extract.enforceRowsInvariant([], { allowEmpty: true })).not.toThrow();
+    expect(() => extract.enforceRowsInvariant([], { readiness: { state: "empty" } })).not.toThrow();
+    expect(() => extract.enforceRowsInvariant(null)).not.toThrow();
+    expect(() => extract.enforceRowsInvariant([{ a: 1 }])).not.toThrow();
+  });
+
+  it("parses script output and rejects undefined or non-JSON", () => {
+    expect(extract.parseExtractionOutput('{"a":1}')).toEqual({ a: 1 });
+    expect(() => extract.parseExtractionOutput("undefined")).toThrow(/returned nothing/);
+    expect(() => extract.parseExtractionOutput("hello")).toThrow(/did not return JSON/);
+  });
+
+  it("renders metadata bullets and a table with escaped cells", () => {
+    const markdown = extract.renderExtractionMarkdown(
+      {
+        query: "a|b",
+        total: 2,
+        rows: [
+          { title: "First", href: "/1" },
+          { title: "Second\nline", extra: true },
+        ],
+      },
+      [
+        { title: "First", href: "/1" },
+        { title: "Second\nline", extra: true },
+      ],
+      { title: "Search" },
+    );
+    expect(markdown).toBe(
+      [
+        "# Search",
+        "",
+        "- query: a\\|b",
+        "- total: 2",
+        "",
+        "2 rows",
+        "",
+        "| title | href | extra |",
+        "| --- | --- | --- |",
+        "| First | /1 |  |",
+        "| Second line |  | true |",
+      ].join("\n"),
+    );
+  });
+
+  it("renders scalar rows as bullets and row-less results as JSON", () => {
+    expect(extract.renderExtractionMarkdown(["x", "y"], ["x", "y"])).toContain("- x\n- y");
+    expect(extract.renderExtractionMarkdown({ title: "T" }, null)).toContain('"title": "T"');
+    expect(extract.renderExtractionMarkdown([], [])).toBe("# Extraction\n\n0 rows");
+  });
+});

--- a/test/unit/extract.test.ts
+++ b/test/unit/extract.test.ts
@@ -76,7 +76,7 @@ describe("runExtraction (owned tab)", () => {
       url: "https://x/",
       code: "return SURF_OPTIONS.limit;",
       options: { limit: 5 },
-      ready: { selector: ".row", timeout: 3000 },
+      ready: { selector: ".row", timeout: 0, interval: 0 },
     });
 
     expect(result).toMatchObject({
@@ -100,7 +100,7 @@ describe("runExtraction (owned tab)", () => {
       ["tab.close", 41],
     ]);
     expect(host.calls[0].args).toEqual({ url: "https://x/" });
-    expect(host.calls[1].args).toEqual({ selector: ".row", timeout: 3000 });
+    expect(host.calls[1].args).toEqual({ selector: ".row", timeout: 0, interval: 0 });
     expect(host.calls[2].args.code).toBe(
       'const SURF_OPTIONS = Object.freeze(JSON.parse("{\\"limit\\":5}"));\nreturn SURF_OPTIONS.limit;',
     );

--- a/test/unit/extract.test.ts
+++ b/test/unit/extract.test.ts
@@ -8,6 +8,9 @@ type Call = { tool: string; args: Record<string, unknown>; tabId?: number };
 function ok(payload: unknown) {
   return {
     result: {
+      ...(payload && typeof payload === "object" && "tabId" in payload
+        ? { tabId: payload.tabId }
+        : {}),
       content: [
         { type: "text", text: typeof payload === "string" ? payload : JSON.stringify(payload) },
       ],
@@ -42,6 +45,10 @@ function scriptedHost(script: Array<{ tool: string; reply: unknown | (() => unkn
 }
 
 const ready = ok({
+  id: 27,
+  _resolvedTabId: 41,
+  _resolvedWindowId: 9,
+  _hint: "internal",
   state: "ready",
   evidence: ["document.readyState is complete"],
   polls: 1,
@@ -80,7 +87,12 @@ describe("runExtraction (owned tab)", () => {
       url: "https://x/",
     });
     expect(result.rows).toHaveLength(2);
-    expect(result.readiness.state).toBe("ready");
+    expect(result.readiness).toEqual({
+      state: "ready",
+      evidence: ["document.readyState is complete"],
+      polls: 1,
+      waited: 12,
+    });
     expect(host.calls.map((call) => [call.tool, call.tabId])).toEqual([
       ["tab.new", undefined],
       ["wait.ready", 41],
@@ -90,7 +102,7 @@ describe("runExtraction (owned tab)", () => {
     expect(host.calls[0].args).toEqual({ url: "https://x/" });
     expect(host.calls[1].args).toEqual({ selector: ".row", timeout: 3000 });
     expect(host.calls[2].args.code).toBe(
-      'const SURF_OPTIONS = Object.freeze({"limit":5});\nreturn SURF_OPTIONS.limit;',
+      'const SURF_OPTIONS = Object.freeze(JSON.parse("{\\"limit\\":5}"));\nreturn SURF_OPTIONS.limit;',
     );
     expect(host.calls[3].args).toEqual({ id: 41 });
     expect(host.remaining()).toBe(0);
@@ -281,6 +293,54 @@ describe("runExtraction (owned tab)", () => {
     expect(host.calls.map((call) => call.tool)).toEqual(["tab.new", "wait.ready", "js"]);
   });
 
+  it("does not replay a successful script when tab cleanup fails", async () => {
+    const host = scriptedHost([
+      { tool: "tab.new", reply: ok({ tabId: 9 }) },
+      { tool: "wait.ready", reply: ready },
+      { tool: "js", reply: rowsResult },
+      { tool: "tab.close", reply: toolError("Target closed") },
+    ]);
+
+    await expect(
+      extract.runExtraction({
+        executeTool: host.executeTool,
+        url: "https://x/",
+        code: "return []",
+        retry: { count: 5 },
+      }),
+    ).rejects.toMatchObject({
+      code: "cleanup_failed",
+      details: { extractionSucceeded: true, attempts: 1, tabId: 9 },
+    });
+    expect(host.calls.map((call) => call.tool)).toEqual([
+      "tab.new",
+      "wait.ready",
+      "js",
+      "tab.close",
+    ]);
+  });
+
+  it("does not open another tab when failed-attempt cleanup fails", async () => {
+    const host = scriptedHost([
+      { tool: "tab.new", reply: ok({ tabId: 9 }) },
+      { tool: "wait.ready", reply: toolError("Page timed out", "page_timeout") },
+      { tool: "tab.close", reply: toolError("close rejected") },
+    ]);
+
+    await expect(
+      extract.runExtraction({
+        executeTool: host.executeTool,
+        url: "https://x/",
+        code: "return []",
+        retry: { count: 5 },
+      }),
+    ).rejects.toMatchObject({
+      code: "cleanup_failed",
+      details: { attempts: 1, tabId: 9, extractionError: { code: "page_timeout" } },
+    });
+    expect(host.calls.map((call) => call.tool)).toEqual(["tab.new", "wait.ready", "tab.close"]);
+  });
+
   it("surfaces a script that returns nothing or non-JSON", async () => {
     const host = scriptedHost([
       { tool: "tab.new", reply: ok({ tabId: 1 }) },
@@ -348,13 +408,13 @@ describe("runExtraction (caller-supplied target)", () => {
 });
 
 describe("tabIdFromResponse", () => {
-  it("reads JSON and the host's text form", () => {
+  it("uses only the stable structured host field, never human prose", () => {
     expect(extract.tabIdFromResponse(ok({ success: true, tabId: 12 }))).toBe(12);
-    expect(extract.tabIdFromResponse(ok({ id: 13 }))).toBe(13);
-    expect(extract.tabIdFromResponse(ok("Created tab 1076931763: http://127.0.0.1/list"))).toBe(
-      1076931763,
-    );
-    expect(() => extract.tabIdFromResponse(ok("OK"))).toThrow(/did not return a tab id/);
+    expect(() => extract.tabIdFromResponse(ok({ id: 13 }))).toThrow(/structured tab id/);
+    expect(() =>
+      extract.tabIdFromResponse(ok("Created tab 1076931763: http://127.0.0.1/list")),
+    ).toThrow(/structured tab id/);
+    expect(() => extract.tabIdFromResponse(ok("OK"))).toThrow(/structured tab id/);
     expect(() => extract.tabIdFromResponse(toolError("tab_busy", "tab_busy"))).toThrow(/tab_busy/);
   });
 });

--- a/test/unit/extract.test.ts
+++ b/test/unit/extract.test.ts
@@ -414,7 +414,6 @@ describe("tabIdFromResponse", () => {
     expect(() =>
       extract.tabIdFromResponse(ok("Created tab 1076931763: http://127.0.0.1/list")),
     ).toThrow(/structured tab id/);
-    expect(() => extract.tabIdFromResponse(ok("OK"))).toThrow(/structured tab id/);
     expect(() => extract.tabIdFromResponse(toolError("tab_busy", "tab_busy"))).toThrow(/tab_busy/);
   });
 });


### PR DESCRIPTION
## Summary

- add `surf extract` as a client-side `tab.new -> wait.ready -> js -> tab.close` composition
- use structured tab ownership and separate successful evaluation from cleanup so close failures never replay caller code
- support bounded safe retries, explicit target mode, empty/rows/output contracts, JSON and concise Markdown output, and landed script options
- reject malformed options before file or socket effects and keep ambient `SURF_SESSION` from changing owned extraction
- document that retries may replay caller scripts, so mutation must be avoided or idempotent

This completes the extract and extract-specific cleanup portions split from #257 and #258. It excludes the already-landed options, readiness, MV3, and generic-error work. The contributor implementation commit preserves tryingET authorship, co-author/session trailers, and source provenance; profile-linked changelog credit is included.

The owned-tab lifecycle, zero-rows invariant, retry rules, and page-side script contract were studied in the surf-cli Go fork by Manuel Odendahl (MIT) and re-implemented from scratch in TypeScript/CommonJS for this codebase; no code was copied.

## Validation

- 105 focused extract/options/CLI tests
- 937-test full suite on Node 24 / Vitest 5
- TypeScript checks, lint, build, syntax, conflict, dependency, and diff checks
- real Chrome success, accepted empty state, bounded rejected-empty retry, options, and no leaked tab

The candidate completed two challenges, retained-writer deslop and simplification, fresh independent review, two focused blocker fixes, and targeted acceptance review.