### PR TITLE
fix: tighten unreleased runtime contracts

### DIFF
--- a/native/cli.cjs
+++ b/native/cli.cjs
@@ -925,6 +925,7 @@ const TOOLS = {
           "ready-url-prefix": "wait.ready --url-prefix; a different URL is a bounce",
           "empty-text": "wait.ready --empty-text; lets an explicit no-results page pass the zero-rows check",
           "ready-timeout": "Readiness timeout in ms (default: 20000)",
+          "ready-interval": "Readiness polling interval in ms (default: 400)",
           rows: "Key of the row array in the script result (default: auto)",
           retry: "Fresh-tab retries on transient failures (default: 1, max: 5)",
           "retry-delay-ms": "Delay between attempts (default: 500)",

--- a/native/script-options.cjs
+++ b/native/script-options.cjs
@@ -34,7 +34,7 @@ function buildOptionsPrelude(options) {
 
 /** Add the prelude while preserving a leading strict-mode directive. */
 function applyOptionsPrelude(code, options) {
-  const strict = code.match(/^\s*(["'])use strict\1\s*;?/);
+  const strict = code.match(/^\s*(["'])use strict\1\s*;/);
   if (!strict) return `${buildOptionsPrelude(options)}${code}`;
   return `${strict[0]}\n${buildOptionsPrelude(options)}${code.slice(strict[0].length)}`;
 }

--- a/native/script-options.cjs
+++ b/native/script-options.cjs
@@ -32,9 +32,11 @@ function buildOptionsPrelude(options) {
   return `const ${PRELUDE_NAME} = Object.freeze(JSON.parse(${JSON.stringify(JSON.stringify(normalized))}));\n`;
 }
 
-/** Prefix code with the prelude; empty options still defines the constant. */
+/** Add the prelude while preserving a leading strict-mode directive. */
 function applyOptionsPrelude(code, options) {
-  return `${buildOptionsPrelude(options)}${code}`;
+  const strict = code.match(/^\s*(["'])use strict\1\s*;?/);
+  if (!strict) return `${buildOptionsPrelude(options)}${code}`;
+  return `${strict[0]}\n${buildOptionsPrelude(options)}${code.slice(strict[0].length)}`;
 }
 
 module.exports = { PRELUDE_NAME, applyOptionsPrelude, buildOptionsPrelude, parseScriptOptions };

--- a/src/cdp/controller.ts
+++ b/src/cdp/controller.ts
@@ -34,7 +34,7 @@ export function describeDebuggerError(err: unknown, method?: string): Error {
     try {
       const parsed = JSON.parse(trimmed) as { code?: unknown; message?: unknown };
       if (parsed && typeof parsed.message === "string" && parsed.message.length > 0) {
-        const error = new Error(parsed.message) as DebuggerCommandError;
+        const error = new Error(parsed.message, { cause: err }) as DebuggerCommandError;
         if (typeof parsed.code === "number") error.cdpCode = parsed.code;
         if (method) error.cdpMethod = method;
         return error;
@@ -1413,12 +1413,30 @@ export class CDPController {
     width: number;
     height: number;
   }> {
-    const result = await this.captureScreenshotData(tabId, {
-      format: "png",
-      captureBeyondViewport: false,
+    return this.withScreenshotDeadline(tabId, (async () => {
+      const result = await this.captureScreenshotData(tabId, {
+        format: "png",
+        captureBeyondViewport: false,
+      });
+      const { width, height } = await this.getViewportSize(tabId);
+      return { base64: result.data, width, height };
+    })());
+  }
+
+  private async withScreenshotDeadline<T>(tabId: number, work: Promise<T>): Promise<T> {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => reject(new CDPControllerError(
+        "screenshot_timeout",
+        `Screenshot capture timed out after ${CDPController.SCREENSHOT_TIMEOUT_MS}ms`,
+        { tabId, timeoutMs: CDPController.SCREENSHOT_TIMEOUT_MS },
+      )), CDPController.SCREENSHOT_TIMEOUT_MS);
     });
-    const { width, height } = await this.getViewportSize(tabId);
-    return { base64: result.data, width, height };
+    try {
+      return await Promise.race([work, timeout]);
+    } finally {
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+    }
   }
 
   async captureRegion(tabId: number, x: number, y: number, width: number, height: number): Promise<{
@@ -1436,23 +1454,8 @@ export class CDPController {
   private async captureScreenshotData(
     tabId: number,
     params: { [key: string]: unknown },
-  ): Promise<any> {
-    let timeoutId: ReturnType<typeof setTimeout> | undefined;
-    const timeout = new Promise<never>((_, reject) => {
-      timeoutId = setTimeout(() => reject(new CDPControllerError(
-        "screenshot_timeout",
-        `Screenshot capture timed out after ${CDPController.SCREENSHOT_TIMEOUT_MS}ms`,
-        { tabId, timeoutMs: CDPController.SCREENSHOT_TIMEOUT_MS },
-      )), CDPController.SCREENSHOT_TIMEOUT_MS);
-    });
-    try {
-      return await Promise.race([
-        this.send(tabId, "Page.captureScreenshot", params),
-        timeout,
-      ]);
-    } finally {
-      if (timeoutId !== undefined) clearTimeout(timeoutId);
-    }
+  ): Promise<{ data: string }> {
+    return this.withScreenshotDeadline(tabId, this.send(tabId, "Page.captureScreenshot", params));
   }
 
   private async dispatchMouseEvent(

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -188,10 +188,12 @@ function readinessExpectationsFrom(input: unknown): ReadinessExpectations {
 async function probeTabReadiness(tabId: number, expect: ReadinessExpectations): Promise<ReadinessProbeResult> {
   let tabStatus: string | undefined;
   let tabUrl: string | undefined;
+  let pendingUrl: string | undefined;
   try {
     const tab = await chrome.tabs.get(tabId);
     tabStatus = tab.status;
-    tabUrl = tab.pendingUrl || tab.url;
+    pendingUrl = tab.pendingUrl;
+    tabUrl = pendingUrl || tab.url;
   } catch {}
   if (!tabUrl || tabUrl === "about:blank") {
     return { state: "loading", evidence: [`tab URL is ${tabUrl || "empty"}`], href: tabUrl, tabStatus };
@@ -207,6 +209,14 @@ async function probeTabReadiness(tabId: number, expect: ReadinessExpectations): 
     return { state: "loading", evidence: [`content script unreachable: ${reason}`], href: tabUrl, tabStatus };
   }
   if (report?.state) {
+    if (pendingUrl && report.href !== pendingUrl) {
+      return {
+        state: "loading",
+        evidence: [`navigation to ${pendingUrl} pending; report is from ${report.href}`],
+        href: report.href,
+        tabStatus,
+      };
+    }
     return { ...report, tabStatus };
   }
   if (report?.code === "invalid_selector") {
@@ -604,12 +614,8 @@ async function statementBodyParses(tabId: number, body: string): Promise<boolean
   } catch (err) {
     if (err instanceof SyntaxError) return false;
   }
-  try {
-    const compiled = await cdp.compileScript(tabId, `(async () => { 'use strict'; ${body} })()`);
-    return compiled.parses;
-  } catch {
-    return true;
-  }
+  const compiled = await cdp.compileScript(tabId, `(async () => { 'use strict'; ${body} })()`);
+  return compiled.parses;
 }
 
 async function captureFullPage(tabId: number, maxHeight: number): Promise<{ base64: string; width: number; height: number }> {

--- a/test/e2e/real-chrome.mjs
+++ b/test/e2e/real-chrome.mjs
@@ -431,7 +431,7 @@ try {
     "visual indicator",
   );
 
-  // --- js --file with a statement script (MV3 CSP) -----------------------
+  // js --file with a statement script (MV3 CSP)
   const statementScript = join(scratch, "statement-script.js");
   writeFileSync(
     statementScript,
@@ -444,7 +444,7 @@ try {
     throw new Error(`js --file with a leading declaration did not run: ${JSON.stringify(statementResult)}`);
   }
 
-  // --- page readiness ---------------------------------------------------
+  // Page readiness
   const readiness = unwrapJson(await runSurf("page.readiness", "--json", "--tab-id", String(fixtureTab.id)));
   if (readiness.state !== "ready" || readiness.readyState !== "complete") {
     throw new Error(`page.readiness did not report ready: ${JSON.stringify(readiness)}`);
@@ -471,7 +471,7 @@ try {
   }
   await runSurf("tab.close", "--id", String(loginTab.tabId), "--json");
 
-  // --- frame.diagnose ----------------------------------------------------
+  // frame.diagnose
   const framesTab = { tabId: tabIdFromOutput(await runSurf("tab.new", `${baseUrl}/frames`)) };
   await runSurf("wait.element", "#sandboxed", "--tab-id", String(framesTab.tabId), "--json");
   await runSurf("wait.dom", "--tab-id", String(framesTab.tabId), "--json");
@@ -501,7 +501,7 @@ try {
   }
   await runSurf("tab.close", "--id", String(framesTab.tabId), "--json");
 
-  // --- native value setter -------------------------------------------------
+  // Native value setter
   const listTab = { tabId: tabIdFromOutput(await runSurf("tab.new", `${baseUrl}/list`)) };
   await runSurf("wait.element", "#tracked", "--tab-id", String(listTab.tabId), "--json");
   await runSurf("type", "hello tracker", "--into", "#tracked", "--tab-id", String(listTab.tabId), "--no-screenshot", "--json");
@@ -513,7 +513,7 @@ try {
   }
   await runSurf("tab.close", "--id", String(listTab.tabId), "--json");
 
-  // --- js --file with statements and --options -------------------------------
+  // js --file with statements and --options
   const optionsScript = join(repo, "test/e2e/fixtures/list-items.js");
   const listTabForJs = { tabId: tabIdFromOutput(await runSurf("tab.new", `${baseUrl}/list?q=js`)) };
   await runSurf("wait.ready", "--json", "--tab-id", String(listTabForJs.tabId), "--selector", ".item");
@@ -555,7 +555,7 @@ try {
   }
   await runSurf("tab.close", "--id", optionsTabId, "--json");
 
-  // --- extract owned lifecycle, options, empty states and bounded cleanup ---
+  // extract owned lifecycle
   const pagesBeforeExtract = (await browser.pages()).length;
   const extracted = JSON.parse(await runSurf(
     "extract", `${baseUrl}/list?q=extract`, "--file", optionsScript,

--- a/test/unit/cdp/controller.test.ts
+++ b/test/unit/cdp/controller.test.ts
@@ -17,12 +17,11 @@ vi.stubGlobal("chrome", mockChrome);
 
 describe("describeDebuggerError", () => {
   it("unwraps the JSON-encoded CDP error chrome.debugger rejects with", () => {
-    const error = describeDebuggerError(
-      new Error('{"code":-32000,"message":"Inspected target navigated or closed"}'),
-      "Runtime.evaluate",
-    );
+    const original = new Error('{"code":-32000,"message":"Inspected target navigated or closed"}');
+    const error = describeDebuggerError(original, "Runtime.evaluate");
     expect(error.message).toBe("Inspected target navigated or closed");
     expect(error).toMatchObject({ cdpCode: -32000, cdpMethod: "Runtime.evaluate" });
+    expect(error.cause).toBe(original);
   });
 
   it("passes plain errors and non-JSON messages through unchanged", () => {
@@ -537,6 +536,19 @@ describe("CDPController", () => {
       });
       await vi.advanceTimersByTimeAsync(5000);
 
+      await rejection;
+    });
+
+    it("rejects when viewport lookup never settles", async () => {
+      vi.useFakeTimers();
+      mockChrome.debugger.sendCommand
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({ data: "base64" })
+        .mockReturnValueOnce(new Promise(() => undefined));
+
+      const capture = controller.captureScreenshot(tabId);
+      const rejection = expect(capture).rejects.toMatchObject({ code: "screenshot_timeout" });
+      await vi.advanceTimersByTimeAsync(5000);
       await rejection;
     });
   });

--- a/test/unit/extract.test.ts
+++ b/test/unit/extract.test.ts
@@ -24,8 +24,7 @@ function toolError(text: string, code?: string) {
 
 /**
  * Scripted fake host: each entry answers the next call to `tool`. The
- * recorded call list doubles as the protocol assertion, the same way the
- * Go fork's socket-level retry test worked.
+ * recorded call list doubles as the protocol assertion.
  */
 function scriptedHost(script: Array<{ tool: string; reply: unknown | (() => unknown) }>) {
   const calls: Call[] = [];

--- a/test/unit/script-options.test.ts
+++ b/test/unit/script-options.test.ts
@@ -45,4 +45,12 @@ describe("buildOptionsPrelude", () => {
       'const SURF_OPTIONS = Object.freeze(JSON.parse("{}"));\nreturn 1;',
     );
   });
+
+  it("keeps a leading use strict directive before the options prelude", () => {
+    expect(
+      scriptOptions.applyOptionsPrelude('"use strict";\nreturn SURF_OPTIONS;', { ok: true }),
+    ).toBe(
+      '"use strict";\nconst SURF_OPTIONS = Object.freeze(JSON.parse("{\\"ok\\":true}"));\n\nreturn SURF_OPTIONS;',
+    );
+  });
 });

--- a/test/unit/script-options.test.ts
+++ b/test/unit/script-options.test.ts
@@ -53,4 +53,10 @@ describe("buildOptionsPrelude", () => {
       '"use strict";\nconst SURF_OPTIONS = Object.freeze(JSON.parse("{\\"ok\\":true}"));\n\nreturn SURF_OPTIONS;',
     );
   });
+
+  it("does not hoist a string literal continued as a call", () => {
+    const code = '"use strict"\n(function(){ return this })()';
+    expect(() => new Function(code)()).toThrow(TypeError);
+    expect(() => new Function(scriptOptions.applyOptionsPrelude(code, {}))()).toThrow(TypeError);
+  });
 });

--- a/test/unit/service-worker/readiness-handlers.test.ts
+++ b/test/unit/service-worker/readiness-handlers.test.ts
@@ -83,6 +83,28 @@ describe("readiness handlers", () => {
     expect(result.tabStatus).toBe("loading");
   });
 
+  it("PAGE_READINESS does not accept a stale report during pending navigation", async () => {
+    const handleMessage = await loadHandleMessage();
+    const chrome = (globalThis as any).chrome;
+    chrome.tabs.get.mockResolvedValue({
+      id: 5,
+      url: "https://example.com/old",
+      pendingUrl: "https://example.com/new",
+      status: "loading",
+    });
+    chrome.tabs.sendMessage.mockResolvedValue(report("ready", { href: "https://example.com/old" }));
+
+    const result = await handleMessage({ type: "PAGE_READINESS", tabId: 5 }, {});
+    expect(result).toEqual({
+      state: "loading",
+      evidence: [
+        "navigation to https://example.com/new pending; report is from https://example.com/old",
+      ],
+      href: "https://example.com/old",
+      tabStatus: "loading",
+    });
+  });
+
   it("reports invalid CSS selectors as deterministic caller errors", async () => {
     const handleMessage = await loadHandleMessage();
     const chrome = (globalThis as any).chrome;


### PR DESCRIPTION
## Summary

This is the independent cleanup pass over changes made since v2.18.0. It is intentionally separate from #276 and contains no TLS changes.

- propagate CDP parser-probe failures instead of treating them as successful parsing
- preserve debugger error causes
- cover viewport lookup with the screenshot deadline and narrow its result type
- reject stale readiness reports during pending navigation
- preserve explicit strict-mode directives when injecting script options without changing call continuations
- complete extract help and remove low-value test commentary/formatting

The seven-category and per-change review rejected speculative guards, credit rewrites, helper churn, broad comment deletion, and the optional minified-helper rewrite.

## Validation

- full suite before mechanical promotion — 70 files, 950 tests passed
- `npm run check`
- `npm run lint`
- `npm run build`
- real-Chrome E2E
- post-review regression tests — 2 files, 32 tests passed
- promoted tree exactly matches the reviewed merge-tree result on current `main`
