### PR TITLE
refactor: trim unreleased implementation

### DIFF
--- a/native/extract.cjs
+++ b/native/extract.cjs
@@ -1,16 +1,4 @@
-/**
- * Page extraction intended for read-only/idempotent scripts in an owned tab.
- *
- * Lifecycle per attempt: tab.new -> wait.ready -> js -> parse -> rows
- * invariant -> tab.close. A retry always closes the failed tab and opens
- * a fresh one, so a target whose execution context was invalidated by a
- * navigation is never reused.
- *
- * This runner is for extraction only. It replays the whole sequence on
- * transient failures, so a script that mutates state (submits a form,
- * sends a message, changes a setting) could apply its side effect more
- * than once. Run such scripts through `surf js` on an explicit target.
- */
+/** Retries use fresh tabs, so caller scripts must be read-only or idempotent. */
 
 const { applyOptionsPrelude } = require("./script-options.cjs");
 
@@ -19,7 +7,6 @@ const DEFAULT_RETRY_DELAY_MS = 500;
 const MAX_RETRY_COUNT = 5;
 const ROW_KEY_CANDIDATES = ["rows", "items", "results", "entries", "records", "data"];
 
-/** Error substrings that mean the tab or its execution context went away. */
 const TRANSIENT_TAB_ERROR_MARKERS = [
   "navigated or closed",
   "Detached while handling command",
@@ -31,10 +18,8 @@ const TRANSIENT_TAB_ERROR_MARKERS = [
   "Target closed",
 ];
 
-/** Error codes for which a fresh tab is meaningful. */
 const RETRYABLE_ERROR_CODES = new Set(["empty_result", "page_timeout", "tab_gone", "target_gone"]);
 
-/** Readiness codes where a retry cannot help. */
 const FATAL_READINESS_CODES = new Set(["page_login", "page_challenge", "page_not_found", "page_error"]);
 
 class ExtractError extends Error {
@@ -79,13 +64,11 @@ function isRetryableExtractionError(error) {
   return isTransientTabError(error);
 }
 
-/** Text of a successful tool response, or null. */
 function responseText(response) {
   const text = response?.result?.content?.[0]?.text;
   return typeof text === "string" ? text : null;
 }
 
-/** Turn a `{error}` tool response into an ExtractError, or return null. */
 function responseError(response, stage) {
   if (!response || !response.error) return null;
   const err = response.error;
@@ -93,7 +76,6 @@ function responseError(response, stage) {
   return new ExtractError(code, errorMessageOf(err), { stage, ...(err.details || {}) });
 }
 
-/** Parse what `surf js` printed for the script's return value. */
 function parseExtractionOutput(text) {
   if (text === null || text === undefined || text.trim() === "" || text.trim() === "undefined") {
     throw new ExtractError(
@@ -236,10 +218,6 @@ function cleanReadiness(readiness) {
   return publicReadiness;
 }
 
-/**
- * Run one extraction attempt on `tabId` (already navigated). Shared by the
- * owned-tab and caller-supplied-target modes.
- */
 async function runAttemptOnTab(executeTool, tabId, settings) {
   const readiness = cleanReadiness(
     parseToolJson(await executeTool("wait.ready", readinessArgs(settings.ready), tabId), "wait.ready"),

--- a/native/script-options.cjs
+++ b/native/script-options.cjs
@@ -1,13 +1,9 @@
-/** Options prelude for page-side scripts run through js or frame.js. */
-const PRELUDE_NAME = "SURF_OPTIONS";
-
 function isPlainObject(value) {
   if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
   const proto = Object.getPrototypeOf(value);
   return proto === Object.prototype || proto === null;
 }
 
-/** Accept an object or JSON string; missing input defaults to an empty object. */
 function parseScriptOptions(input) {
   if (input === undefined || input === null || input === "") return {};
   if (input === true) throw new Error("--options needs a JSON object value");
@@ -26,17 +22,12 @@ function parseScriptOptions(input) {
   return JSON.parse(JSON.stringify(value));
 }
 
-/** Parse serialized JSON before freezing to preserve own __proto__ keys. */
-function buildOptionsPrelude(options) {
-  const normalized = parseScriptOptions(options);
-  return `const ${PRELUDE_NAME} = Object.freeze(JSON.parse(${JSON.stringify(JSON.stringify(normalized))}));\n`;
-}
-
-/** Add the prelude while preserving a leading strict-mode directive. */
 function applyOptionsPrelude(code, options) {
+  const normalized = parseScriptOptions(options);
+  const prelude = `const SURF_OPTIONS = Object.freeze(JSON.parse(${JSON.stringify(JSON.stringify(normalized))}));\n`;
   const strict = code.match(/^\s*(["'])use strict\1\s*;/);
-  if (!strict) return `${buildOptionsPrelude(options)}${code}`;
-  return `${strict[0]}\n${buildOptionsPrelude(options)}${code.slice(strict[0].length)}`;
+  if (!strict) return `${prelude}${code}`;
+  return `${strict[0]}\n${prelude}${code.slice(strict[0].length)}`;
 }
 
-module.exports = { PRELUDE_NAME, applyOptionsPrelude, buildOptionsPrelude, parseScriptOptions };
+module.exports = { applyOptionsPrelude, parseScriptOptions };

--- a/native/stdin-frames.cjs
+++ b/native/stdin-frames.cjs
@@ -30,13 +30,4 @@ function takeFrames(buffer) {
   return { frames, rest: offset === 0 ? buffer : buffer.subarray(offset) };
 }
 
-/** Encode one message the way the extension does, for tests and tools. */
-function encodeFrame(message) {
-  const json = Buffer.from(typeof message === "string" ? message : JSON.stringify(message), "utf8");
-  const frame = Buffer.alloc(HEADER_BYTES + json.length);
-  frame.writeUInt32LE(json.length, 0);
-  json.copy(frame, HEADER_BYTES);
-  return frame;
-}
-
-module.exports = { HEADER_BYTES, encodeFrame, takeFrames };
+module.exports = { takeFrames };

--- a/src/cdp/controller.ts
+++ b/src/cdp/controller.ts
@@ -1414,7 +1414,7 @@ export class CDPController {
     height: number;
   }> {
     return this.withScreenshotDeadline(tabId, (async () => {
-      const result = await this.captureScreenshotData(tabId, {
+      const result: { data: string } = await this.send(tabId, "Page.captureScreenshot", {
         format: "png",
         captureBeyondViewport: false,
       });
@@ -1444,18 +1444,14 @@ export class CDPController {
     width: number;
     height: number;
   }> {
-    const result = await this.captureScreenshotData(tabId, {
-      format: "png",
-      clip: { x, y, width, height, scale: 1 },
-    });
+    const result: { data: string } = await this.withScreenshotDeadline(
+      tabId,
+      this.send(tabId, "Page.captureScreenshot", {
+        format: "png",
+        clip: { x, y, width, height, scale: 1 },
+      }),
+    );
     return { base64: result.data, width, height };
-  }
-
-  private async captureScreenshotData(
-    tabId: number,
-    params: { [key: string]: unknown },
-  ): Promise<{ data: string }> {
-    return this.withScreenshotDeadline(tabId, this.send(tabId, "Page.captureScreenshot", params));
   }
 
   private async dispatchMouseEvent(

--- a/src/content/native-value.ts
+++ b/src/content/native-value.ts
@@ -41,11 +41,6 @@ export function findNativeValueSetter(element: object): ((value: string) => void
   return null;
 }
 
-function createValueEvent(name: ValueEventName): Event {
-  // `blur` does not bubble in the DOM; the other two do.
-  return new Event(name, { bubbles: name !== "blur" });
-}
-
 /**
  * Set `value` on a text-like input or textarea so both plain pages and
  * framework-controlled forms observe the change, then dispatch `events` in
@@ -63,7 +58,7 @@ export function setNativeValue(
     element.value = value;
   }
   for (const name of events) {
-    element.dispatchEvent(createValueEvent(name));
+    element.dispatchEvent(new Event(name, { bubbles: name !== "blur" }));
   }
   return { method: setter ? "native-setter" : "assignment", events: [...events] };
 }

--- a/src/content/page-readiness-probe.ts
+++ b/src/content/page-readiness-probe.ts
@@ -45,7 +45,7 @@ function safeCount(dom: ReadinessProbeDom, selector: string): number {
   }
 }
 
-/** Gather the facts the classifier needs. Caller-provided invalid CSS is rejected. */
+/** Rejects invalid caller-provided CSS. */
 export function collectReadinessSnapshot(
   dom: ReadinessProbeDom,
   expect: ReadinessExpectations = {},
@@ -97,7 +97,6 @@ export interface PageReadinessReport extends ReadinessVerdict {
   snapshot: Omit<ReadinessSnapshot, "bodyTextSample">;
 }
 
-/** Collect and classify in one step; this is what the content script returns. */
 export function probePageReadiness(
   dom: ReadinessProbeDom,
   expect: ReadinessExpectations = {},

--- a/src/utils/frame-diagnose.ts
+++ b/src/utils/frame-diagnose.ts
@@ -117,7 +117,6 @@ export function isBlankFrameUrl(url: string): boolean {
   return url === "" || url === "about:blank" || url.startsWith("about:blank?") || url === "about:srcdoc";
 }
 
-/** Sandboxed frames run no scripts unless `allow-scripts` is present. */
 export function sandboxBlocksScripts(sandbox: string | null): boolean {
   if (sandbox === null) return false;
   return !sandbox.split(/\s+/).includes("allow-scripts");
@@ -133,7 +132,6 @@ function short(url: string, max = 80): string {
   return `${url.slice(0, max - 3)}...`;
 }
 
-/** The name CDP reports for a frame is the iframe's `name`, else its `id`. */
 function frameName(iframe: DomIframeEntry): string {
   return iframe.name || iframe.id || "";
 }

--- a/src/utils/readiness-poll.ts
+++ b/src/utils/readiness-poll.ts
@@ -14,7 +14,6 @@ export type ReadinessState =
   | "not-found"
   | "error";
 
-/** States that mean "stop waiting, the page will not become ready". */
 export const NEGATIVE_READINESS_STATES: readonly ReadinessState[] = [
   "challenge",
   "login",
@@ -22,10 +21,8 @@ export const NEGATIVE_READINESS_STATES: readonly ReadinessState[] = [
   "error",
 ];
 
-/** States that mean "the page has settled and can be read". */
 export const SETTLED_READINESS_STATES: readonly ReadinessState[] = ["ready", "empty"];
 
-/** Error code for a negative state, or null for states that are not errors. */
 export function readinessErrorCode(state: ReadinessState): string | null {
   switch (state) {
     case "challenge":
@@ -50,7 +47,6 @@ export function isReadinessState(value: unknown): value is ReadinessState {
   );
 }
 
-/** Parse `--accept login,challenge` style input into a state list. */
 export function parseAcceptStates(input: unknown): ReadinessState[] {
   const raw: unknown[] = Array.isArray(input)
     ? input
@@ -70,7 +66,6 @@ export function parseAcceptStates(input: unknown): ReadinessState[] {
   return states;
 }
 
-/** What one probe of the page reports. */
 export interface ReadinessProbeResult {
   state: ReadinessState;
   evidence: string[];
@@ -90,7 +85,6 @@ export const MAX_READINESS_TIMEOUT_MS = 120_000;
 export const DEFAULT_READINESS_INTERVAL_MS = 400;
 export const MIN_READINESS_INTERVAL_MS = 50;
 
-/** Clamp caller-supplied numbers into a bounded polling budget. */
 export function clampReadinessBudget(input: { timeoutMs?: unknown; intervalMs?: unknown }): ReadinessBudget {
   const timeoutRaw = Number(input.timeoutMs);
   const intervalRaw = Number(input.intervalMs);

--- a/test/unit/script-options.test.ts
+++ b/test/unit/script-options.test.ts
@@ -31,11 +31,10 @@ describe("parseScriptOptions", () => {
   });
 });
 
-describe("buildOptionsPrelude", () => {
-  it("defines a frozen SURF_OPTIONS constant that is valid JavaScript on its own", () => {
-    const prelude = scriptOptions.buildOptionsPrelude({ limit: 3 });
-    expect(prelude).toBe('const SURF_OPTIONS = Object.freeze(JSON.parse("{\\"limit\\":3}"));\n');
-    const evaluate = new Function(`${prelude}return SURF_OPTIONS;`);
+describe("applyOptionsPrelude", () => {
+  it("defines a frozen SURF_OPTIONS constant", () => {
+    const code = scriptOptions.applyOptionsPrelude("return SURF_OPTIONS;", { limit: 3 });
+    const evaluate = new Function(code);
     expect(evaluate()).toEqual({ limit: 3 });
     expect(Object.isFrozen(evaluate())).toBe(true);
   });

--- a/test/unit/stdin-frames.test.ts
+++ b/test/unit/stdin-frames.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from "vitest";
 
 const Buffer: any = require("node:buffer").Buffer;
-const { encodeFrame, takeFrames } = require("../../native/stdin-frames.cjs") as {
-  encodeFrame(message: unknown): any;
+const { takeFrames } = require("../../native/stdin-frames.cjs") as {
   takeFrames(buffer: any): { frames: string[]; rest: any };
 };
+
+function encodeFrame(message: unknown) {
+  const body = Buffer.from(JSON.stringify(message));
+  const header = Buffer.alloc(4);
+  header.writeUInt32LE(body.length);
+  return Buffer.concat([header, body]);
+}
 
 describe("takeFrames", () => {
   it("returns nothing for an empty or header-only buffer", () => {


### PR DESCRIPTION
## Summary

Follow-up verbosity reduction over unreleased changes:

- inline pass-through screenshot and native-event helpers
- inline the single-use script-options prelude builder
- keep test-only native-frame encoding out of production code
- remove comments that only repeat names, types, or nearby implementation

This preserves the documented retry, timeout, strict-mode, frame parsing, native setter, readiness, and frame-diagnosis behavior while removing 53 net lines.

## Diff

- 10 files
- 29 additions
- 82 deletions
- net **-53 LOC**

## Validation

- Node 24 + Vitest 5 focused affected suite — 10 files, 233 tests passed
- full Vitest suite — 71 files, 963 tests passed
- `npm run check`
- `npm run lint`
- `npm run build`
- independent final review — merge verdict OK
